### PR TITLE
Don't link to regex_macros at runtime.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@
 #[macro_use]
 extern crate log;
 #[plugin]
+#[no_link]
 extern crate regex_macros;
 
 extern crate "rustc-serialize" as serialize;


### PR DESCRIPTION
Fixes #2.

You may also want to consider moving to plain `regex` since `regex_macros` won't work in the stable channel of Rust 1.0. (We may come up with a fix before then using `build.rs` though.)