### PR TITLE
Fixed the breaking change in Collections library: RingBuf → VecDeque

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@ use std::num::Float;
 use serialize::json::{Json, ToJson};
 use regex::Regex;
 use std::iter::IteratorExt;
-use std::collections::RingBuf;
+use std::collections::VecDeque;
 
 pub struct Context {
     data: Json,
@@ -13,7 +13,7 @@ pub struct Context {
 static ARRAY_INDEX_MATCHER: Regex = regex!(r"\[\d+\]$");
 
 #[inline]
-fn parse_json_visitor<'a>(path_stack: &mut RingBuf<&'a str>, path: &'a String) {
+fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a String) {
     for p in (*path).split('/') {
         match p {
             "this" | "." | "" => {
@@ -49,7 +49,7 @@ impl Context {
     }
 
     pub fn navigate(&self, path: &String, relative_path: &String) -> &Json {
-        let mut path_stack :RingBuf<&str> = RingBuf::new();
+        let mut path_stack :VecDeque<&str> = VecDeque::new();
         parse_json_visitor(&mut path_stack, path);
         parse_json_visitor(&mut path_stack, relative_path);
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,7 +3,7 @@ use std::ops::BitOr;
 use std::num::FromPrimitive;
 use std::fmt::{self, Debug, Formatter};
 use std::iter::IteratorExt;
-use std::collections::{BTreeMap, RingBuf};
+use std::collections::{BTreeMap, VecDeque};
 use std::string::ToString;
 use serialize::json::Json;
 
@@ -186,8 +186,8 @@ fn process_whitespace(buf: &String, wso: &mut WhiteSpaceOmit) -> String {
 
 impl Template {
     pub fn compile(source: String) -> Result<Template, TemplateError> {
-        let mut helper_stack: RingBuf<Helper> = RingBuf::new();
-        let mut template_stack: RingBuf<Template> = RingBuf::new();
+        let mut helper_stack: VecDeque<Helper> = VecDeque::new();
+        let mut template_stack: VecDeque<Template> = VecDeque::new();
         template_stack.push_front(Template{ elements: Vec::new() });
 
         let mut buffer: String = String::new();


### PR DESCRIPTION
RingBuf seems to deleted in favor of VecDeque. This small change makes handlebars compile again.