### PR TITLE
use num::FromPrimitive instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex = "*"
 regex_macros = "*"
 log = "*"
 rustc-serialize = "*"
+num = "*"
 
 [dev-dependencies]
 env_logger = "*"

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -1,4 +1,4 @@
-use std::num::ToPrimitive;
+use num::ToPrimitive;
 
 use serialize::json::Json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, core, collections)]
+#![feature(plugin, collections)]
 
 #![plugin(regex_macros)]
 
@@ -166,6 +166,7 @@ extern crate log;
 
 extern crate rustc_serialize as serialize;
 extern crate regex;
+extern crate num;
 
 pub use self::template::{Template, TemplateError, Helper};
 pub use self::registry::Registry as Handlebars;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,11 +1,11 @@
 use std::cmp::min;
 use std::ops::BitOr;
-use std::num::FromPrimitive;
 use std::error;
 use std::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, VecDeque};
 use std::string::ToString;
 use serialize::json::Json;
+use num::FromPrimitive;
 
 use self::TemplateElement::{RawString, Expression, HelperExpression,
                             HTMLExpression, HelperBlock, Comment};
@@ -160,12 +160,34 @@ impl Helper {
     }
 }
 
-#[derive(PartialEq, FromPrimitive)]
+#[derive(PartialEq)]
 enum WhiteSpaceOmit {
     Left = 0x01,
     Right = 0x10,
     Both = 0x11,
     None = 0x00
+}
+
+impl FromPrimitive for WhiteSpaceOmit {
+    fn from_i64(n: i64) -> Option<WhiteSpaceOmit> {
+        match n {
+            0x01 => Some(WhiteSpaceOmit::Left),
+            0x10 => Some(WhiteSpaceOmit::Right),
+            0x11 => Some(WhiteSpaceOmit::Both),
+            0x00 => Some(WhiteSpaceOmit::None),
+            _ => None
+        }
+    }
+
+    fn from_u64(n: u64) -> Option<WhiteSpaceOmit> {
+        match n {
+            0x01 => Some(WhiteSpaceOmit::Left),
+            0x10 => Some(WhiteSpaceOmit::Right),
+            0x11 => Some(WhiteSpaceOmit::Both),
+            0x00 => Some(WhiteSpaceOmit::None),
+            _ => None
+        }
+    }
 }
 
 impl BitOr<WhiteSpaceOmit> for WhiteSpaceOmit {


### PR DESCRIPTION
FromPrimitive was removed from the nightly std (not sure about beta), so
we might as well migrate to the num crate which now houses it. This
means we have to manually implement FromPrimitive.

Also no longer need the `core` feature.