### PR TITLE
compile on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/lib.rs"
 [dependencies]
 
 regex = "*"
-regex_macros = "*"
 log = "*"
 rustc-serialize = "*"
 num = "*"

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,11 +4,9 @@ use std::collections::VecDeque;
 
 pub struct Context {
     data: Json,
-    default: Json
+    default: Json,
+    array_index_matcher: Regex,
 }
-
-//pub static NULL_VALUE: &'static Json = &Json::Null;
-static ARRAY_INDEX_MATCHER: Regex = regex!(r"\[\d+\]$");
 
 #[inline]
 fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a String) {
@@ -35,14 +33,16 @@ impl Context {
     pub fn null() -> Context {
         Context {
             data: Json::Null,
-            default: Json::Null
+            default: Json::Null,
+            array_index_matcher: Regex::new(r"\[\d+\]$").unwrap(),
         }
     }
 
     pub fn wraps<T: ToJson>(e: &T) -> Context {
         Context {
             data: e.to_json(),
-            default: Json::Null
+            default: Json::Null,
+            array_index_matcher: Regex::new(r"\[\d+\]$").unwrap(),
         }
     }
 
@@ -54,7 +54,7 @@ impl Context {
         let paths :Vec<&str> = path_stack.iter().map(|x| *x).collect();
         let mut data: &Json = &self.data;
         for p in paths.iter() {
-            match ARRAY_INDEX_MATCHER.find(*p) {
+            match self.array_index_matcher.find(*p) {
                 Some((s, _)) => {
                     let arr = &p[..s];
                     let idx = &p[s+1 .. p.len()-1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(plugin, collections)]
-
-#![plugin(regex_macros)]
-
 //! # Handlebars
 //! Handlebars is a modern and extensible templating solution originally created in the JavaScript world. It's used by many popular frameworks like [Ember.js](http://emberjs.com) and Chaplin. It's also ported to some other platforms such as [Java](https://github.com/jknack/handlebars.java).
 //!
@@ -184,3 +180,4 @@ mod registry;
 mod render;
 mod helpers;
 mod context;
+mod support;

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,0 +1,30 @@
+pub mod str {
+    pub trait SliceChars {
+        fn slice_chars_alt(&self, begin: usize, end: usize) -> &str;
+    }
+
+    impl SliceChars for str {
+        fn slice_chars_alt(&self, begin: usize, end: usize) -> &str {
+            assert!(begin <= end);
+            let mut count = 0;
+            let mut begin_byte = None;
+            let mut end_byte = None;
+
+            // This could be even more efficient by not decoding,
+            // only finding the char boundaries
+            for (idx, _) in self.char_indices() {
+                if count == begin { begin_byte = Some(idx); }
+                if count == end { end_byte = Some(idx); break; }
+                count += 1;
+            }
+            if begin_byte.is_none() && count == begin { begin_byte = Some(self.len()) }
+            if end_byte.is_none() && count == end { end_byte = Some(self.len()) }
+
+            match (begin_byte, end_byte) {
+                (None, _) => panic!("slice_chars: `begin` is beyond end of string"),
+                (_, None) => panic!("slice_chars: `end` is beyond end of string"),
+                (Some(a), Some(b)) => unsafe { self.slice_unchecked(a, b) }
+            }
+        }
+    }
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,6 +7,8 @@ use std::string::ToString;
 use serialize::json::Json;
 use num::FromPrimitive;
 
+use support::str::SliceChars;
+
 use self::TemplateElement::{RawString, Expression, HelperExpression,
                             HTMLExpression, HelperBlock, Comment};
 
@@ -231,18 +233,18 @@ impl Template {
         let mut ws_omitter = WhiteSpaceOmit::None;
         let source_len = source.chars().count();
         while c < source_len {
-            let mut slice = source.slice_chars(c, min(c+3, source_len)).to_string();
+            let mut slice = source.slice_chars_alt(c, min(c+3, source_len)).to_string();
             if slice == "{{~" {
                 ws_omitter = ws_omitter | WhiteSpaceOmit::Right;
                 // read another char and remove ~
-                slice = source.slice_chars(c, min(c+4, source_len)).to_string();
+                slice = source.slice_chars_alt(c, min(c+4, source_len)).to_string();
                 slice.remove(2);
                 c += 1;
             }
             if slice == "~}}" {
                 ws_omitter = ws_omitter | WhiteSpaceOmit::Left;
                 c += 1;
-                slice = source.slice_chars(c, min(c+3, source_len)).to_string();
+                slice = source.slice_chars_alt(c, min(c+3, source_len)).to_string();
             }
             state = match slice.as_ref() {
                 "{{{" | "{{!" | "{{#" | "{{/" => {
@@ -279,7 +281,7 @@ impl Template {
                     ParserState::Text
                 },
                 _ => {
-                    match if slice.len() > 2 { slice.slice_chars(0, 2) } else { slice.as_ref() } {
+                    match if slice.len() > 2 { slice.slice_chars_alt(0, 2) } else { slice.as_ref() } {
                         "{{" => {
                             c += 1;
                             if !buffer.is_empty() {


### PR DESCRIPTION
This removes the use of the language features to enable its compilation
on rust stable.

the plugin feature was removed and so was the regex_macros dependency.
Instead of re-building the regular expression each time it needs to be
built, I build it once per `Context` instance, which I think is the next
best thing compared to a global, statically initialized regex.

the collections feature was needed for the str::slice_chars function. I
work around this for now by simply ripping out the slice_chars
implementation from the nightly std and embedding it in the code
directly, which we can use at least until the fate of std slice_chars
is determined.