### PR TITLE
Feature/writer

### DIFF
--- a/examples/render.rs
+++ b/examples/render.rs
@@ -25,9 +25,11 @@ impl ToJson for Team {
     }
 }
 
-fn format_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<String, RenderError> {
+fn format_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
     let param = h.params().get(0).unwrap();
-    Ok(format!("{} pts", c.navigate(rc.get_path(), param)))
+    let rendered = format!("{} pts", c.navigate(rc.get_path(), param));
+    try!(rc.writer.write(rendered.into_bytes().as_ref()));
+    Ok(())
 }
 
 fn load_template(name: &str) -> io::Result<String> {

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -1,7 +1,7 @@
 use helpers::{HelperDef};
 use registry::{Registry};
 use context::{Context, JsonTruthy};
-use render::{Renderable, RenderContext, RenderError, render_error, EMPTY, Helper};
+use render::{Renderable, RenderContext, RenderError, render_error, Helper};
 
 #[derive(Clone, Copy)]
 pub struct IfHelper {
@@ -9,7 +9,7 @@ pub struct IfHelper {
 }
 
 impl HelperDef for IfHelper{
-    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.param(0);
 
         if param.is_none() {
@@ -31,7 +31,7 @@ impl HelperDef for IfHelper{
         let tmpl = if value { h.template() } else { h.inverse() };
         match tmpl {
             Some(ref t) => t.render(c, r, rc),
-            None => Ok(EMPTY.to_string())
+            None => Ok(())
         }
     }
 }

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,13 +1,13 @@
 use helpers::{HelperDef};
 use registry::{Registry};
 use context::{Context};
-use render::{RenderContext, RenderError, render_error, EMPTY, Helper};
+use render::{RenderContext, RenderError, render_error, Helper};
 
 #[derive(Clone, Copy)]
 pub struct LogHelper;
 
 impl HelperDef for LogHelper {
-    fn call(&self, c: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, c: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.param(0);
 
         if param.is_none() {
@@ -24,7 +24,7 @@ impl HelperDef for LogHelper {
 
         info!("{}: {}", name, value);
 
-        Ok(EMPTY.to_string())
+        Ok(())
     }
 }
 

--- a/src/helpers/helper_partial.rs
+++ b/src/helpers/helper_partial.rs
@@ -1,7 +1,7 @@
 use helpers::{HelperDef};
 use registry::{Registry};
 use context::{Context};
-use render::{Renderable, RenderContext, RenderError, render_error, EMPTY, Helper};
+use render::{Renderable, RenderContext, RenderError, render_error, Helper};
 
 #[derive(Clone, Copy)]
 pub struct IncludeHelper;
@@ -13,7 +13,7 @@ pub struct BlockHelper;
 pub struct PartialHelper;
 
 impl HelperDef for IncludeHelper {
-    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.params().get(0);
 
         if param.is_none() {
@@ -34,7 +34,7 @@ impl HelperDef for IncludeHelper {
 }
 
 impl HelperDef for BlockHelper {
-    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.params().get(0);
 
         if param.is_none() {
@@ -55,7 +55,7 @@ impl HelperDef for BlockHelper {
 }
 
 impl HelperDef for PartialHelper {
-    fn call(&self, _: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, _: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.params().get(0);
 
         if param.is_none() {
@@ -63,7 +63,7 @@ impl HelperDef for PartialHelper {
         }
 
         rc.set_partial(param.unwrap().clone(), h.template().unwrap().clone());
-        Ok(EMPTY.to_string())
+        Ok(())
     }
 }
 

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -7,19 +7,18 @@ use render::{RenderContext, RenderError, Helper};
 pub struct RawHelper;
 
 impl HelperDef for RawHelper {
-    fn call(&self, _: &Context, h: &Helper, _: &Registry, _: &mut RenderContext) -> Result<String, RenderError> {
-        let mut buf = String::new();
+    fn call(&self, _: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let tpl = h.template();
         if tpl.is_some() {
-            buf.push_str(tpl.unwrap().to_string().as_ref());
+            try!(rc.writer.write(tpl.unwrap().to_string().into_bytes().as_ref()));
         }
         let ivs = h.inverse();
         if ivs.is_some() {
-            buf.push_str("{{else}}");
-            buf.push_str(ivs.unwrap().to_string().as_ref());
+            try!(rc.writer.write("{{else}}".to_owned().into_bytes().as_ref()));
+            try!(rc.writer.write(ivs.unwrap().to_string().into_bytes().as_ref()));
         }
 
-        Ok(buf)
+        Ok(())
     }
 }
 

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -1,13 +1,13 @@
 use helpers::{HelperDef};
 use registry::{Registry};
 use context::{Context, JsonTruthy};
-use render::{Renderable, RenderContext, RenderError, render_error, EMPTY, Helper};
+use render::{Renderable, RenderContext, RenderError, render_error, Helper};
 
 #[derive(Clone, Copy)]
 pub struct WithHelper;
 
 impl HelperDef for WithHelper {
-    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+    fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param = h.param(0);
 
         if param.is_none() {
@@ -33,7 +33,7 @@ impl HelperDef for WithHelper {
 
         let rendered = match template {
             Some(t) => t.render(c, r, rc),
-            None => Ok(EMPTY.to_string())
+            None => Ok(())
         };
 
         rc.set_path(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,33 +97,38 @@
 //!
 //! extern crate handlebars;
 //!
-//! use handlebars::{Handlebars, HelperDef, RenderError, RenderContext, Helper, Context};
+//! use std::io::Write;
+//! use handlebars::{Handlebars, HelperDef, RenderError, RenderContext, Helper, Context, JsonRender};
 //!
 //! // implement by a structure impls HelperDef
 //! #[derive(Clone, Copy)]
 //! struct SimpleHelper;
 //!
 //! impl HelperDef for SimpleHelper {
-//!   fn call(&self, c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<String, RenderError> {
+//!   fn call(&self, c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
 //!     let param = h.params().get(0).unwrap();
 //!
 //!     // get value from context data
 //!     // rc.get_path() is current json parent path, you should always use it like this
 //!     // param is the key of value you want to display
 //!     let value = c.navigate(rc.get_path(), param);
-//!     Ok(format!("My helper dumps: {} ", value))
+//!     try!(rc.writer.write("Ny helper dumps: ".as_bytes()));
+//!     try!(rc.writer.write(value.render().into_bytes().as_ref()));
+//!     Ok(())
 //!   }
 //! }
 //!
 //! // implement via bare function
-//! fn another_simple_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<String, RenderError> {
+//! fn another_simple_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
 //!     let param = h.params().get(0).unwrap();
 //!
 //!     // get value from context data
 //!     // rc.get_path() is current json parent path, you should always use it like this
 //!     // param is the key of value you want to display
 //!     let value = c.navigate(rc.get_path(), param);
-//!     Ok(format!("My second helper dumps: {} ", value))
+//!     try!(rc.writer.write("My second helper dumps: ".as_bytes()));
+//!     try!(rc.writer.write(value.render().into_bytes().as_ref()));
+//!     Ok(())
 //! }
 //!
 //!
@@ -133,8 +138,9 @@
 //!   handlebars.register_helper("another-simple-helper", Box::new(another_simple_helper));
 //!   // via closure
 //!   handlebars.register_helper("closure-helper",
-//!       Box::new(|c: &Context, h: &Helper, r: &Handlebars, rc: &mut RenderContext| -> Result<String, RenderError>{
-//!         Ok(format!("..."))
+//!       Box::new(|c: &Context, h: &Helper, r: &Handlebars, rc: &mut RenderContext| -> Result<(), RenderError>{
+//!         try!(rc.writer.write("...".as_bytes()));
+//!         Ok(())
 //!       }));
 //!
 //!   //...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,11 @@
 //!
 //! ### Rendering Something
 //!
-//! I should say that rendering is a little tricky. Since handlebars is originally a JavaScript templating framework. It supports dynamic features like duck-typing, truthy/falsy values. But for a static language like Rust, this is a little difficult. As a solution, I'm using the `serialize::json::Json` internally for data rendering, which seems good by far.
+//! I should say that rendering is a little tricky. Since handlebars is originally a JavaScript templating framework. It supports dynamic features like duck-typing, truthy/falsey values. But for a static language like Rust, this is a little difficult. As a solution, I'm using the `serialize::json::Json` internally for data rendering, which seems good by far.
 //!
-//! That means, if you want to render something, you have to ensure that it implements the `serialize::json::ToJson` trait. Luckily, most built-in types already have trait. However, if you want to render your custom struct, you need to implement this trait manually. (Rust has a deriving facility, but it's just for selected types. Maybe I will add some syntax extensions or macros to simplify this process.)
+//! That means, if you want to render something, you have to ensure that it implements the `serialize::json::ToJson` trait. Luckily, most built-in types already have trait. However, if you want to render your custom struct, you need to implement this trait manually, or use [tojson_macros](https://github.com/sunng87/tojson_macros) to generate default `ToJson` implementation.
+//!
+//! You can use default `render` function to render a template into `String`. From 0.9, there's `renderw` to render text into anything of `std::io::Write`.
 //!
 //! ```
 //! extern crate rustc_serialize;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -99,11 +99,14 @@ impl Registry {
 
 #[cfg(test)]
 mod test {
+    use serialize::json::Json;
+
     use template::{Template};
     use registry::{Registry};
     use render::{RenderContext, Renderable, RenderError, Helper};
     use helpers::{HelperDef};
     use context::{Context};
+    use support::str::StringWriter;
 
     #[derive(Clone, Copy)]
     struct DummyHelper;
@@ -141,5 +144,23 @@ mod test {
 
         // built-in helpers plus 1
         assert_eq!(r.helpers.len(), 10+1);
+    }
+
+    #[test]
+    fn test_renderw() {
+        let mut r = Registry::new();
+
+        let t = Template::compile("<h1></h1>".to_string()).ok().unwrap();
+        r.register_template("index", t.clone());
+
+        let mut sw = StringWriter::new();
+        let data = Json::Null;
+
+        {
+            r.renderw("index", &data, &mut sw).ok().unwrap();
+        }
+
+        assert_eq!("<h1></h1>".to_string(), sw.to_string());
+
     }
 }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,4 +1,6 @@
 pub mod str {
+    use std::io::{Write, Result};
+
     pub trait SliceChars {
         fn slice_chars_alt(&self, begin: usize, end: usize) -> &str;
     }
@@ -25,6 +27,56 @@ pub mod str {
                 (_, None) => panic!("slice_chars: `end` is beyond end of string"),
                 (Some(a), Some(b)) => unsafe { self.slice_unchecked(a, b) }
             }
+        }
+    }
+
+    pub struct StringWriter {
+        buf: Vec<u8>
+    }
+
+    impl StringWriter {
+        pub fn new() -> StringWriter {
+            StringWriter {
+                buf: Vec::new()
+            }
+        }
+
+        pub fn to_string(self) -> String {
+            if let Ok(s) = String::from_utf8(self.buf) {
+                s
+            } else {
+                String::new()
+            }
+        }
+    }
+
+    impl Write for StringWriter {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            for b in buf {
+                self.buf.push(*b);
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use support::str::StringWriter;
+        use std::io::Write;
+
+        #[test]
+        fn test_string_writer() {
+            let mut sw = StringWriter::new();
+
+            let _ = sw.write("hello".to_owned().into_bytes().as_ref());
+            let _ = sw.write("world".to_owned().into_bytes().as_ref());
+
+            let s = sw.to_string();
+            assert_eq!(s, "helloworld".to_string());
         }
     }
 }


### PR DESCRIPTION
Rewrite internal API to use a `std::io::Write` based API, which is more flexible for writing to different destination, and also efficient for large files.

Most APIs except Helper API kept unchanged. You will need to update your Helper:

* Return type changed from `Result<String, RenderError>` to `Result<(), RenderError>`
* Instead of returning a `String`, you will need to write your string data into the `Write`r by calling `rc.writer.write(s.into_bytes().as_ref())` where `rc` is your `RenderContext`.