### PR TITLE
Implement some error reporting (#30)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log = "^0.3.1"
 rustc-serialize = "^0.3.15"
 num = "^0.1.25"
 lazy_static = "^0.1.14"
+quick-error = "^0.1.3"
 
 [dev-dependencies]
 env_logger = "*"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,21 @@
+quick_error! {
+    /// Template parsing error
+    #[derive(Debug, Clone)]
+    pub enum TemplateError {
+        UnclosedBraces {
+            description("closing braces `}}` expected but eof reached")
+        }
+        UnexpectedClosingBraces {
+            description("can't close braces `}}` at this location")
+        }
+        MismatchingClosedHelper(open: String, closed: String) {
+            display("helper {:?} was opened, but {:?} is closing",
+                open, closed)
+            description("wrong name of closing helper")
+        }
+        UnclosedHelper(name: String) {
+            display("helper {:?} was not closed on end of file", name)
+            description("some helper was not closed on end of file")
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ quick_error! {
     #[derive(Debug, Clone)]
     pub enum TemplateError {
         UnclosedBraces {
-            description("closing braces `}}` expected but eof reached")
+            description("closing braces `}}` expected but EOF reached")
         }
         UnexpectedClosingBraces {
             description("can't close braces `}}` at this location")
@@ -14,8 +14,8 @@ quick_error! {
             description("wrong name of closing helper")
         }
         UnclosedHelper(name: String) {
-            display("helper {:?} was not closed on end of file", name)
-            description("some helper was not closed on end of file")
+            display("helper {:?} was not closed on the end of file", name)
+            description("some helper was not closed on the end of file")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@
 //!
 
 #[macro_use] extern crate log;
+#[macro_use] extern crate quick_error;
 #[macro_use] extern crate lazy_static;
 #[cfg(test)] #[macro_use] extern crate maplit;
 
@@ -183,13 +184,15 @@ extern crate rustc_serialize as serialize;
 extern crate regex;
 extern crate num;
 
-pub use self::template::{Template, TemplateError};
+pub use self::template::{Template};
+pub use self::error::TemplateError;
 pub use self::registry::Registry as Handlebars;
 pub use self::render::{Renderable, RenderError, RenderContext, Helper};
 pub use self::helpers::{HelperDef};
 pub use self::context::{Context, JsonRender, JsonTruthy};
 
 mod template;
+mod error;
 mod registry;
 mod render;
 mod helpers;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,12 +3,13 @@ use std::io::Write;
 
 use serialize::json::ToJson;
 
-use template::{Template, TemplateError};
+use template::{Template};
 use render::{Renderable, RenderError, RenderContext};
 use helpers::{HelperDef};
 use context::{Context};
 use helpers;
 use support::str::StringWriter;
+use TemplateError;
 
 pub struct Registry {
     templates: HashMap<String, Template>,


### PR DESCRIPTION
The patch doesn't make error reporting perfect because there are no line numbers yet. But at least this makes error reporting on par with `rumblebars` that have multiple errors types but not error lines too (the `rumblebars` have somewhat complex dependencies, however).