### PR TITLE
Tracing current_template and root_template in RenderContext

### DIFF
--- a/src/helpers/helper_partial.rs
+++ b/src/helpers/helper_partial.rs
@@ -16,11 +16,13 @@ impl HelperDef for IncludeHelper {
     fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let template = match h.params().get(0) {
             Some(ref t) => {
-                if rc.current_template == Some((*t).to_string()) {
-                    return Err(RenderError::new("Cannot include self in >"));
-                } else {
-                    r.get_template(t)
+                if let Some(ref template_name_rc) = rc.current_template {
+                    if **template_name_rc == (*t).to_string() {
+                        return Err(RenderError::new("Cannot include self in >"));
+                    }
                 }
+
+                r.get_template(t)
             }
             None => return Err(RenderError::new("Param not found for helper")),
         };

--- a/src/helpers/helper_partial.rs
+++ b/src/helpers/helper_partial.rs
@@ -15,7 +15,13 @@ pub struct PartialHelper;
 impl HelperDef for IncludeHelper {
     fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let template = match h.params().get(0) {
-            Some(ref t) => r.get_template(t),
+            Some(ref t) => {
+                if rc.current_template == Some((*t).to_string()) {
+                    return Err(RenderError::new("Cannot include self in >"));
+                } else {
+                    r.get_template(t)
+                }
+            }
             None => return Err(RenderError::new("Param not found for helper")),
         };
 
@@ -159,5 +165,17 @@ mod test {
 
         let r0 = handlebars.render("t0", &map);
         assert_eq!(r0.ok().unwrap(), "<h1>include partial: hello world</h1>".to_string());
+    }
+
+    #[test]
+    fn test_include_self() {
+        let t0 = Template::compile("<h1>{{> t0}}</h1>".to_string()).ok().unwrap();
+        let mut handlebars = Registry::new();
+        handlebars.register_template("t0", t0);
+
+        let map: BTreeMap<String, String> = BTreeMap::new();
+
+        let r0 = handlebars.render("t0", &map);
+        assert!(r0.is_err());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write;
+use std::rc::Rc;
 
 use serialize::json::ToJson;
 
@@ -38,7 +39,7 @@ impl Registry {
     }
 
     pub fn register_template(&mut self, name: &str, mut template: Template) {
-        template.name = Some(name.to_owned());
+        template.name = Some(Rc::new(name.to_owned()));
         self.templates.insert(name.to_string(), template);
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -37,12 +37,14 @@ impl Registry {
         r
     }
 
-    pub fn register_template(&mut self, name: &str, template: Template) {
+    pub fn register_template(&mut self, name: &str, mut template: Template) {
+        template.name = Some(name.to_owned());
         self.templates.insert(name.to_string(), template);
     }
 
     pub fn register_template_string(&mut self, name: &str, tpl_str: String) -> Result<(), TemplateError>{
-        try!(Template::compile(tpl_str).and_then(|t| Ok(self.templates.insert(name.to_string(), t))));
+        try!(Template::compile_with_name(tpl_str, name.to_owned())
+             .and_then(|t| Ok(self.templates.insert(name.to_string(), t))));
         Ok(())
     }
 
@@ -84,6 +86,7 @@ impl Registry {
 
         if let Some(t) = template {
             let mut render_context = RenderContext::new(writer);
+            render_context.root_template = t.name.clone();
             (*t).render(context, self, &mut render_context)
         } else {
             Err(RenderError::new(format!("Template not found: {}", name)))

--- a/src/render.rs
+++ b/src/render.rs
@@ -53,7 +53,11 @@ pub struct RenderContext<'a> {
     local_variables: HashMap<String, Json>,
     default_var: Json,
     /// the `Write` where page is generated
-    pub writer: &'a mut Write
+    pub writer: &'a mut Write,
+    /// current template name
+    pub current_template: Option<String>,
+    /// root template name
+    pub root_template: Option<String>
 }
 
 impl<'a> RenderContext<'a> {
@@ -64,7 +68,9 @@ impl<'a> RenderContext<'a> {
             path: ".".to_string(),
             local_variables: HashMap::new(),
             default_var: Json::Null,
-            writer: w
+            writer: w,
+            current_template: None,
+            root_template: None
         }
     }
 
@@ -75,7 +81,9 @@ impl<'a> RenderContext<'a> {
             path: self.path.clone(),
             local_variables: self.local_variables.clone(),
             default_var: self.default_var.clone(),
-            writer: w
+            writer: w,
+            current_template: self.current_template.clone(),
+            root_template: self.root_template.clone()
         }
     }
 
@@ -145,6 +153,14 @@ impl<'a> RenderContext<'a> {
         self.writer
     }
 }
+
+impl<'a> fmt::Debug for RenderContext<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "partials: {:?}, path: {:?}, local_variables: {:?}, current_template: {:?}, root_template: {:?}",
+               self.partials, self.path, self.local_variables, self.current_template, self.root_template)
+    }
+}
+
 
 pub struct Helper<'a> {
     name: &'a String,
@@ -257,6 +273,7 @@ impl Parameter {
 
 impl Renderable for Template {
     fn render(&self, ctx: &Context, registry: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+        rc.current_template = self.name.clone();
         let iter = self.elements.iter();
         for t in iter {
             let c = ctx;
@@ -408,7 +425,8 @@ fn test_template() {
         elements.push(e4);
 
         let template = Template {
-            elements: elements
+            elements: elements,
+            name: None
         };
 
         let mut m: HashMap<String, String> = HashMap::new();
@@ -459,7 +477,8 @@ fn test_render_subexpression() {
         elements.push(e3);
 
         let template = Template {
-            elements: elements
+            elements: elements,
+            name: None
         };
 
         let mut m: HashMap<String, String> = HashMap::new();

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,6 +3,7 @@ use std::error;
 use std::fmt;
 use std::io::Write;
 use std::io::Error as IOError;
+use std::rc::Rc;
 use serialize::json::Json;
 
 use template::{Template, TemplateElement, Parameter, HelperTemplate};
@@ -55,9 +56,9 @@ pub struct RenderContext<'a> {
     /// the `Write` where page is generated
     pub writer: &'a mut Write,
     /// current template name
-    pub current_template: Option<String>,
+    pub current_template: Option<Rc<String>>,
     /// root template name
-    pub root_template: Option<String>
+    pub root_template: Option<Rc<String>>
 }
 
 impl<'a> RenderContext<'a> {

--- a/src/template.rs
+++ b/src/template.rs
@@ -8,12 +8,14 @@ use regex::Regex;
 
 use support::str::SliceChars;
 use TemplateError;
+use TemplateError::*;
 
 use self::TemplateElement::{RawString, Expression, HelperExpression,
                             HTMLExpression, HelperBlock, Comment};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Template {
+    pub name: Option<String>,
     pub elements: Vec<TemplateElement>
 }
 
@@ -240,13 +242,18 @@ fn process_whitespace(buf: &str, wso: &mut WhiteSpaceOmit) -> String {
 }
 
 impl Template {
-    pub fn compile<S: AsRef<str>>(source: S) -> Result<Template, TemplateError> {
-        use TemplateError::*;
+    pub fn new() -> Template {
+        Template {
+            elements: Vec::new(),
+            name: None
+        }
+    }
 
+    pub fn compile<S: AsRef<str>>(source: S) -> Result<Template, TemplateError> {
         let source = source.as_ref();
         let mut helper_stack: VecDeque<HelperTemplate> = VecDeque::new();
         let mut template_stack: VecDeque<Template> = VecDeque::new();
-        template_stack.push_front(Template{ elements: Vec::new() });
+        template_stack.push_front(Template::new());
 
         let mut buffer: String = String::new();
         let mut state = ParserState::Text;
@@ -334,7 +341,7 @@ impl Template {
                                             let t = template_stack.pop_front().unwrap();
                                             let h = helper_stack.front_mut().unwrap();
                                             h.template = Some(t);
-                                            template_stack.push_front(Template{ elements: Vec::new() });
+                                            template_stack.push_front(Template::new());
                                             ParserState::Text
                                         } else {
                                             if find_tokens(&buffer).len() > 1 {
@@ -365,7 +372,7 @@ impl Template {
                                 ParserState::HelperStart => {
                                     let helper = try!(HelperTemplate::parse(buffer.clone(), true, line_no, col_no));
                                     helper_stack.push_front(helper);
-                                    template_stack.push_front(Template{ elements: Vec::new() });
+                                    template_stack.push_front(Template::new());
 
                                     buffer.clear();
                                     ParserState::Text
@@ -409,6 +416,12 @@ impl Template {
         }
 
         return Ok(template_stack.pop_front().unwrap());
+    }
+
+    pub fn compile_with_name<S: AsRef<str>>(source: S, name: String) -> Result<Template, TemplateError> {
+        let mut t = try!(Template::compile(source));
+        t.name = Some(name);
+        Ok(t)
     }
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,6 +3,7 @@ use std::ops::BitOr;
 use std::fmt::{self, Display, Formatter};
 use std::collections::{BTreeMap, VecDeque};
 use std::string::ToString;
+use std::rc::Rc;
 use num::FromPrimitive;
 use regex::Regex;
 
@@ -15,7 +16,7 @@ use self::TemplateElement::{RawString, Expression, HelperExpression,
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Template {
-    pub name: Option<String>,
+    pub name: Option<Rc<String>>,
     pub elements: Vec<TemplateElement>
 }
 
@@ -420,7 +421,7 @@ impl Template {
 
     pub fn compile_with_name<S: AsRef<str>>(source: S, name: String) -> Result<Template, TemplateError> {
         let mut t = try!(Template::compile(source));
-        t.name = Some(name);
+        t.name = Some(Rc::new(name));
         Ok(t)
     }
 }


### PR DESCRIPTION
This feature is to add fix for #44 and enhance `RenderContext` for helper developers.

The current implementation uses too much clone which I think can be optimized to use borrowed string for `current_template` name and `root_template` name. But I'm lost in the borrow check... Help is wanted.