### PR TITLE
added a markdown helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,28 @@
 [package]
-
-name = "handlebars"
-version = "0.11.2"
 authors = ["Ning Sun <sunng@about.me>"]
 description = "Handlebars templating implemented in Rust."
-license = "MIT"
-keywords = ["handlebars", "templating", "web"]
-homepage = "https://github.com/sunng87/handlebars-rust"
-repository = "https://github.com/sunng87/handlebars-rust"
 documentation = "http://sunng.info/handlebars-rust/"
-readme = "README.md"
-
-[lib]
-
+homepage = "https://github.com/sunng87/handlebars-rust"
+keywords = ["handlebars", "templating", "web"]
+license = "MIT"
 name = "handlebars"
-path = "src/lib.rs"
+readme = "README.md"
+repository = "https://github.com/sunng87/handlebars-rust"
+version = "0.11.2"
 
 [dependencies]
-
-regex = "^0.1.41"
-log = "^0.3.1"
-rustc-serialize = "^0.3.15"
-num = "^0.1.25"
 lazy_static = "^0.1.14"
+log = "^0.3.1"
+num = "^0.1.25"
+pulldown-cmark = { git = "https://github.com/google/pulldown-cmark.git"}
 quick-error = "^0.1.3"
+regex = "^0.1.41"
+rustc-serialize = "^0.3.15"
 
 [dev-dependencies]
 env_logger = "*"
 maplit = "*"
-#tojson_macros = "*"
+
+[lib]
+name = "handlebars"
+path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rustc-serialize = "^0.3.15"
 num = "^0.1.25"
 lazy_static = "^0.1.14"
 quick-error = "^0.1.3"
-pulldown-cmark={ git="https://github.com/google/pulldown-cmark.git", rev="e7c3918" }
+pulldown-cmark="^0.0.3"
 
 [dev-dependencies]
 env_logger = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rustc-serialize = "^0.3.15"
 num = "^0.1.25"
 lazy_static = "^0.1.14"
 quick-error = "^0.1.3"
-pulldown-cmark={ git="https://github.com/google/pulldown-cmark.git"}
+pulldown-cmark={ git="https://github.com/google/pulldown-cmark.git", rev="e7c3918" }
 
 [dev-dependencies]
 env_logger = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,32 @@
 [package]
+
+name = "handlebars"
+version = "0.11.2"
 authors = ["Ning Sun <sunng@about.me>"]
 description = "Handlebars templating implemented in Rust."
-documentation = "http://sunng.info/handlebars-rust/"
-homepage = "https://github.com/sunng87/handlebars-rust"
-keywords = ["handlebars", "templating", "web"]
 license = "MIT"
-name = "handlebars"
-readme = "README.md"
+keywords = ["handlebars", "templating", "web"]
+homepage = "https://github.com/sunng87/handlebars-rust"
 repository = "https://github.com/sunng87/handlebars-rust"
-version = "0.11.2"
+documentation = "http://sunng.info/handlebars-rust/"
+readme = "README.md"
+
+[lib]
+
+name = "handlebars"
+path = "src/lib.rs"
 
 [dependencies]
-lazy_static = "^0.1.14"
-log = "^0.3.1"
-num = "^0.1.25"
-pulldown-cmark = { git = "https://github.com/google/pulldown-cmark.git"}
-quick-error = "^0.1.3"
+
 regex = "^0.1.41"
+log = "^0.3.1"
 rustc-serialize = "^0.3.15"
+num = "^0.1.25"
+lazy_static = "^0.1.14"
+quick-error = "^0.1.3"
+pulldown-cmark={ git="https://github.com/google/pulldown-cmark.git"}
 
 [dev-dependencies]
 env_logger = "*"
 maplit = "*"
-
-[lib]
-name = "handlebars"
-path = "src/lib.rs"
+#tojson_macros = "*"

--- a/src/helpers/helper_markdown.rs
+++ b/src/helpers/helper_markdown.rs
@@ -1,0 +1,60 @@
+use helpers::{HelperDef};
+use registry::{Registry};
+use context::{Context, JsonRender};
+use render::{Renderable, RenderContext, RenderError, render_error, Helper};
+extern crate pulldown_cmark;
+
+use self::pulldown_cmark::Parser;
+use self::pulldown_cmark::{Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+use self::pulldown_cmark::html;
+
+
+#[derive(Clone, Copy)]
+pub struct MarkdownHelper;
+
+
+
+pub fn render_html(text: String) -> String {
+    let mut opts = Options::empty();
+    opts.insert(OPTION_ENABLE_TABLES);
+    opts.insert(OPTION_ENABLE_FOOTNOTES);
+    let mut s = String::with_capacity(text.len() * 3 / 2);
+    let p = Parser::new_ext(&*text, opts);
+    html::push_html(&mut s, p);
+    s
+}
+
+
+impl HelperDef for MarkdownHelper {
+    fn call(&self, c: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+        let markdown_text_var = try!(h.param(0).ok_or_else(|| render_error("Param not found for helper \"markdown\"")));
+        let markdown_text = c.navigate(rc.get_path(), &markdown_text_var).render(); 
+        let html_string = render_html(markdown_text);
+        try!(rc.writer.write(html_string.into_bytes().as_ref()));
+        Ok(())
+    }
+}
+
+pub static MARKDOWN_HELPER: MarkdownHelper = MarkdownHelper;
+
+#[cfg(test)]
+mod test {
+    use template::{Template};
+    use registry::{Registry};
+
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_markdown() {
+        let t0 = Template::compile("{{markdown x}}".to_string()).ok().unwrap();
+
+        let mut handlebars = Registry::new();
+        handlebars.register_template("t0", t0);
+
+        let mut m :BTreeMap<String, String> = BTreeMap::new();
+        m.insert("x".into(), "# wow\n\n## second wow".into());
+
+        let r0 = handlebars.render("t0", &m);
+        assert_eq!(r0.ok().unwrap(), "<h1>wow</h1>\n<h2>second wow</h2>\n".to_string());
+    }
+}

--- a/src/helpers/helper_markdown.rs
+++ b/src/helpers/helper_markdown.rs
@@ -5,7 +5,6 @@ use render::{Renderable, RenderContext, RenderError, render_error, Helper};
 extern crate pulldown_cmark;
 
 use self::pulldown_cmark::Parser;
-use self::pulldown_cmark::{Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
 use self::pulldown_cmark::html;
 
 
@@ -15,11 +14,8 @@ pub struct MarkdownHelper;
 
 
 pub fn render_html(text: String) -> String {
-    let mut opts = Options::empty();
-    opts.insert(OPTION_ENABLE_TABLES);
-    opts.insert(OPTION_ENABLE_FOOTNOTES);
     let mut s = String::with_capacity(text.len() * 3 / 2);
-    let p = Parser::new_ext(&*text, opts);
+    let p = Parser::new(&*text);
     html::push_html(&mut s, p);
     s
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -9,6 +9,7 @@ pub use self::helper_lookup::{LOOKUP_HELPER};
 pub use self::helper_raw::{RAW_HELPER};
 pub use self::helper_partial::{INCLUDE_HELPER, BLOCK_HELPER, PARTIAL_HELPER};
 pub use self::helper_log::{LOG_HELPER};
+pub use self::helper_markdown::{MARKDOWN_HELPER};
 
 /// Helper Definition
 ///
@@ -39,6 +40,7 @@ mod helper_lookup;
 mod helper_raw;
 mod helper_partial;
 mod helper_log;
+mod helper_markdown; 
 
 /*
 pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -33,7 +33,8 @@ impl Registry {
         r.register_helper("block", Box::new(helpers::BLOCK_HELPER));
         r.register_helper("partial", Box::new(helpers::PARTIAL_HELPER));
         r.register_helper("log", Box::new(helpers::LOG_HELPER));
-
+        r.register_helper("markdown", Box::new(helpers::MARKDOWN_HELPER));
+        
         r
     }
 
@@ -137,7 +138,7 @@ mod test {
         r.register_helper("dummy", Box::new(DUMMY_HELPER));
 
         // built-in helpers plus 1
-        assert_eq!(r.helpers.len(), 10+1);
+        assert_eq!(r.helpers.len(), 11+1);
     }
 
     #[test]


### PR DESCRIPTION
I know this is probably just the beginning but I think I added a working markdown helper so that if you have a variable `x` that is a string containing markdown, then you can parse it to html by passing 

```
{{markdown x}}
```

in the template..

I want to improve this by adding some kind of environment, but I couldn't quite figure it out right away (and the use case above is the one that i want to use anyway). As a second commit perhaps something like below could be implemented

```
{{#markdown}}
#wow
{{> sub_template}}
{{~markdown}}
```

edit: also sorry that this changed Cargo.toml so much. I used `cargo add pulldown-cmark` and it must have mangled the `Cargo.toml` I will go back and edit by hand