### PR TITLE
(feat) add support for custom escape functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@
 //! }
 //! ```
 //!
+//! #### Escaping
+//!
+//! As per the handlebars spec, output using `{{expression}}` is escaped by default (to be precise, the characters `&"<>` are replaced by their respective html / xml entities). However, since the use cases of a rust template engine are probably a bit more diverse than those of a JavaScript one, this implementation allows the user to supply a custom escape function to be used instead. For more information see the `EscapeFn` type and `Handlebars::register_escape_fn()` method.
+//!
 //! ### Custom Helper
 //!
 //! Handlebars is nothing without helpers. You can also create your own helpers with rust. Helpers in handlebars-rust are custom struct implements the `HelperDef` trait, concretely, the `call` function. For your convenience, most of stateless helpers can be implemented as bare functions.
@@ -186,7 +190,7 @@ extern crate num;
 
 pub use self::template::{Template};
 pub use self::error::TemplateError;
-pub use self::registry::Registry as Handlebars;
+pub use self::registry::{EscapeFn, Registry as Handlebars};
 pub use self::render::{Renderable, RenderError, RenderContext, Helper};
 pub use self::helpers::{HelperDef};
 pub use self::context::{Context, JsonRender, JsonTruthy};

--- a/src/render.rs
+++ b/src/render.rs
@@ -301,10 +301,7 @@ impl Renderable for TemplateElement {
                     };
                     value.render()
                 };
-                let output = rendered.replace("&", "&amp;")
-                    .replace("\"", "&quot;")
-                    .replace("<", "&lt;")
-                    .replace(">", "&gt;");
+                let output = registry.get_escape_fn()(&rendered);
                 try!(rc.writer.write(output.into_bytes().as_ref()));
                 Ok(())
             },


### PR DESCRIPTION
This pull request allows the user to override the way output of `{{expr}}` is escaped. 

While my own use case of disabling escaping completely could be achieved by using `{{{expr}}}` and different escape functions could probably be implemented using custom helpers I think this pull request provides a nicer solution.

I especially think that a rust template engine should be as output format agnostic as possible since the environments in which rust is used are more diverse than those in which JS is used.

Rendering performance seems to be unaffected:

```plain
before:
test parse_template  ... bench:     127,948 ns/iter (+/- 12,205)
test render_template ... bench:      18,471 ns/iter (+/- 7,158)

after:
test parse_template  ... bench:     127,924 ns/iter (+/- 18,775)
test render_template ... bench:      18,503 ns/iter (+/- 9,061)
```