### PR TITLE
Render string

### DIFF
--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -4,9 +4,8 @@ extern crate handlebars;
 #[cfg(not(feature = "serde_type"))]
 extern crate rustc_serialize;
 
-use std::io::Write;
+use std::io::{Write, Read};
 use std::fs::File;
-use std::path::Path;
 
 use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context, JsonRender};
 
@@ -56,15 +55,12 @@ mod render_example {
 }
 
 
-
 #[cfg(not(feature = "serde_type"))]
 fn main() {
     use render_example::*;
 
     env_logger::init().unwrap();
     let mut handlebars = Handlebars::new();
-
-    handlebars.register_template_file("table", &Path::new("./examples/template.hbs")).ok().unwrap();
 
     handlebars.register_helper("format", Box::new(format_helper));
     //    handlebars.register_helper("format", Box::new(FORMAT_HELPER));
@@ -74,15 +70,15 @@ fn main() {
         Context::wraps(&data)
     };
 
-    if let Ok(ref mut file) = File::create("target/table.html") {
-        if let Ok(_) = handlebars.renderw("table", &data, file) {
-            println!("target/table.html generated");
-        } else {
-            println!("Failed to geneate target/table.html");
-        }
+    // I'm using unwrap directly here to demostration.
+    // Never use this style in your real-world projects.
+    let mut source_template = File::open(&"./examples/template.hbs").unwrap();
+    let mut output_file = File::create("target/table.html").unwrap();
+    if let Ok(_) = handlebars.template_renderw2(&mut source_template, &data, &mut output_file) {
+        println!("target/table.html generated");
     } else {
-        println!("Failed to create target/table.html");
-    }
+        println!("Failed to geneate target/table.html");
+    };
 }
 
 #[cfg(feature = "serde_type")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::io::{Error as IOError};
 
+use render::RenderError;
+
 quick_error! {
     /// Template parsing error
     #[derive(Debug, Clone)]
@@ -39,6 +41,20 @@ quick_error! {
             cause(err)
         }
         IOError(err: IOError) {
+            from()
+            cause(err)
+        }
+    }
+}
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum TemplateRenderError {
+        TemplateError(err: TemplateError) {
+            from()
+            cause(err)
+        }
+        RenderError(err: RenderError) {
             from()
             cause(err)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,5 +58,9 @@ quick_error! {
             from()
             cause(err)
         }
+        IOError(err: IOError) {
+            from()
+            cause(err)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,24 @@
 //! }
 //! ```
 //!
+//! Or if you don't need the template to be cached or referenced by other ones, you can
+//! simply render it without registering.
+//!
+//! ```ignore
+//! fn main() {
+//!   let source = "Hello, {{name}}";
+//!
+//!   let mut handlebars = Handlebars::new();
+//!
+//!   let data = Person {
+//!       name: "Ning Sun".to_string(),
+//!       age: 27
+//!   };
+//!   let result = handlebars.template_render("Hello, {{name}}", &data);
+//! }
+//! ```
+//!
+//!
 //! #### Escaping
 //!
 //! As per the handlebars spec, output using `{{expression}}` is escaped by default (to be precise, the characters `&"<>` are replaced by their respective html / xml entities). However, since the use cases of a rust template engine are probably a bit more diverse than those of a JavaScript one, this implementation allows the user to supply a custom escape function to be used instead. For more information see the `EscapeFn` type and `Handlebars::register_escape_fn()` method.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -14,7 +14,7 @@ use helpers::{HelperDef};
 use context::{Context};
 use helpers;
 use support::str::StringWriter;
-use error::{TemplateError, TemplateFileError};
+use error::{TemplateError, TemplateFileError, TemplateRenderError};
 
 /// This type represents an *escape fn*, that is a function who's purpose it is
 /// to escape potentially problematic characters in a string.
@@ -139,6 +139,7 @@ impl Registry {
         self.templates.clear();
     }
 
+
     /// Render a registered template with some data into a string
     pub fn render<T>(&self, name: &str, ctx: &T) -> Result<String, RenderError> where T: ToJson {
         let mut writer = StringWriter::new();
@@ -148,6 +149,7 @@ impl Registry {
         }
         Ok(writer.to_string())
     }
+
 
     /// Render a registered template with some data to the `std::io::Write`
     pub fn renderw(&self, name: &str, context: &Context, writer: &mut Write) -> Result<(), RenderError> {
@@ -160,6 +162,23 @@ impl Registry {
         } else {
             Err(RenderError::new(format!("Template not found: {}", name)))
         }
+    }
+
+    /// render a template string using current registry without register it
+    pub fn template_render<T>(&self, template_string: &str, ctx: &T) -> Result<String, TemplateRenderError> where T: ToJson {
+        let mut writer = StringWriter::new();
+        let context = Context::wraps(ctx);
+        {
+            try!(self.template_renderw(template_string, &context, &mut writer));
+        }
+        Ok(writer.to_string())
+    }
+
+    /// render a template string using current registry without register it
+    pub fn template_renderw(&self, template_string: &str, context: &Context, writer: &mut Write) -> Result<(), TemplateRenderError> {
+        let tpl = try!(Template::compile(template_string).map_err(TemplateRenderError::from));
+        let mut render_context = RenderContext::new(writer);
+        tpl.render(context, self, &mut render_context).map_err(TemplateRenderError::from)
     }
 }
 
@@ -245,5 +264,28 @@ mod test {
         r.unregister_escape_fn();
 
         assert_eq!("&quot;&lt;&gt;&amp;", r.render("test", &input).unwrap());
+    }
+
+    #[test]
+    fn test_template_render() {
+        let mut r = Registry::new();
+
+        let t = Template::compile("<h1></h1>".to_string()).ok().unwrap();
+        r.register_template("index", t.clone());
+
+        assert_eq!("<h1></h1>".to_string(),
+                   r.template_render("{{> index}}", &{}).unwrap());
+
+        assert_eq!("hello world".to_string(),
+                   r.template_render("hello {{this}}", &"world".to_string()).unwrap());
+
+        let mut sw = StringWriter::new();
+        let context = Context::null();
+
+        {
+            r.template_renderw("{{> index}}", &context, &mut sw).unwrap();
+        }
+
+        assert_eq!("<h1></h1>".to_string(), sw.to_string());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -190,6 +190,7 @@ mod test {
     use helpers::{HelperDef};
     use context::{Context};
     use support::str::StringWriter;
+    use error::TemplateRenderError;
 
     #[derive(Clone, Copy)]
     struct DummyHelper;
@@ -287,5 +288,17 @@ mod test {
         }
 
         assert_eq!("<h1></h1>".to_string(), sw.to_string());
+
+        // fail for template error
+        match r.template_render("{{ hello", &{}).unwrap_err() {
+            TemplateRenderError::TemplateError(_) => {},
+            _ => { panic!(); }
+        }
+
+        // fail to render error
+        match r.template_render("{{> notfound}}", &{}).unwrap_err() {
+            TemplateRenderError::RenderError(_) => {},
+            _ => { panic!(); }
+        }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -180,6 +180,13 @@ impl Registry {
         let mut render_context = RenderContext::new(writer);
         tpl.render(context, self, &mut render_context).map_err(TemplateRenderError::from)
     }
+
+    /// render a template source using current registry without register it
+    pub fn template_renderw2(&self, template_source: &mut Read, context: &Context, writer: &mut Write) -> Result<(), TemplateRenderError> {
+        let mut tpl_str = String::new();
+        try!(template_source.read_to_string(&mut tpl_str));
+        self.template_renderw(&tpl_str, context, writer)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #69 

Added a few new APIs to render template without register it, and file a `std::io::Read` source