### PR TITLE
Json literal as param and hash

### DIFF
--- a/examples/render.rs
+++ b/examples/render.rs
@@ -16,13 +16,13 @@ use std::path::Path;
 
 use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context, JsonRender};
 
-fn format_helper(c: &Context,
+fn format_helper(_: &Context,
                  h: &Helper,
                  _: &Handlebars,
                  rc: &mut RenderContext)
                  -> Result<(), RenderError> {
-    let param = h.params().get(0).unwrap();
-    let rendered = format!("{} pts", c.navigate(rc.get_path(), param).render());
+    let param = h.param(0).unwrap();
+    let rendered = format!("{} pts", param.value().render());
     try!(rc.writer.write(rendered.into_bytes().as_ref()));
     Ok(())
 }

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -9,13 +9,13 @@ use std::fs::File;
 
 use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context, JsonRender};
 
-fn format_helper(c: &Context,
+fn format_helper(_: &Context,
                  h: &Helper,
                  _: &Handlebars,
                  rc: &mut RenderContext)
                  -> Result<(), RenderError> {
-    let param = h.params().get(0).unwrap();
-    let rendered = format!("{} pts", c.navigate(rc.get_path(), param).render());
+    let param = h.param(0).unwrap();
+    let rendered = format!("{} pts", param.value().render());
     try!(rc.writer.write(rendered.into_bytes().as_ref()));
     Ok(())
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -101,16 +101,16 @@ impl HelperDef for EachHelper {
 
                 rc.promote_local_vars();
 
-                debug!("each value {:?}", value.value);
-                let rendered = match value.value {
-                    Json::Array(ref list) => {
+                debug!("each value {:?}", value.value());
+                let rendered = match value.value() {
+                    &Json::Array(ref list) => {
                         let len = list.len();
                         for i in 0..len {
                             rc.set_local_var("@first".to_string(), value::to_value(&(i == 0usize)));
                             rc.set_local_var("@last".to_string(), value::to_value(&(i == len - 1)));
                             rc.set_local_var("@index".to_string(), value::to_value(&i));
 
-                            if let Some(ref inner_path) = value.path {
+                            if let Some(inner_path) = value.path() {
                                 let new_path = format!("{}/{}.[{}]", path, inner_path, i);
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);
@@ -119,7 +119,7 @@ impl HelperDef for EachHelper {
                         }
                         Ok(())
                     }
-                    Json::Object(ref obj) => {
+                    &Json::Object(ref obj) => {
                         let mut first: bool = true;
                         for k in obj.keys() {
                             rc.set_local_var("@first".to_string(), value::to_value(&first));
@@ -128,7 +128,7 @@ impl HelperDef for EachHelper {
                             }
 
                             rc.set_local_var("@key".to_string(), value::to_value(&k));
-                            if let Some(ref inner_path) = value.path {
+                            if let Some(inner_path) = value.path() {
                                 let new_path = format!("{}/{}.[{}]", path, inner_path, k);
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -20,7 +20,7 @@ impl HelperDef for EachHelper {
             r: &Registry,
             rc: &mut RenderContext)
             -> Result<(), RenderError> {
-        let param = try!(h.param(0)
+        let value = try!(h.param(0)
                           .ok_or_else(|| RenderError::new("Param not found for helper \"each\"")));
 
         let template = h.template();
@@ -28,27 +28,30 @@ impl HelperDef for EachHelper {
         match template {
             Some(t) => {
                 let path = rc.get_path().clone();
-                let value = c.navigate(&path, param);
 
                 rc.promote_local_vars();
 
-                debug!("each value {:?}", value);
-                let rendered = match *value {
-                    Json::Array(ref list) => {
+                debug!("each value {:?}", value.value());
+                let rendered = match value.value() {
+                    &Json::Array(ref list) => {
                         let len = list.len();
                         for i in 0..len {
                             rc.set_local_var("@first".to_string(), (i == 0usize).to_json());
                             rc.set_local_var("@last".to_string(), (i == len - 1).to_json());
                             rc.set_local_var("@index".to_string(), i.to_json());
 
-                            let new_path = format!("{}/{}.[{}]", path, param, i);
-                            debug!("each value {:?}", new_path);
-                            rc.set_path(new_path);
+                            if let Some(inner_path) = value.path() {
+                                let new_path = format!("{}/{}.[{}]", path, inner_path, i);
+                                debug!("each value {:?}", new_path);
+                                rc.set_path(new_path);
+                            }
+                            // FIXME: context for literal
+
                             try!(t.render(c, r, rc));
                         }
                         Ok(())
                     }
-                    Json::Object(ref obj) => {
+                    &Json::Object(ref obj) => {
                         let mut first: bool = true;
                         for k in obj.keys() {
                             rc.set_local_var("@first".to_string(), first.to_json());
@@ -57,8 +60,12 @@ impl HelperDef for EachHelper {
                             }
 
                             rc.set_local_var("@key".to_string(), k.to_json());
-                            let new_path = format!("{}/{}.[{}]", path, param, k);
-                            rc.set_path(new_path);
+
+                            if let Some(inner_path) = value.path() {
+                                let new_path = format!("{}/{}.[{}]", path, inner_path, k);
+                                rc.set_path(new_path);
+                            }
+
                             try!(t.render(c, r, rc));
                         }
 
@@ -83,7 +90,7 @@ impl HelperDef for EachHelper {
             r: &Registry,
             rc: &mut RenderContext)
             -> Result<(), RenderError> {
-        let param = try!(h.param(0)
+        let value = try!(h.param(0)
                           .ok_or_else(|| RenderError::new("Param not found for helper \"each\"")));
 
         let template = h.template();
@@ -91,12 +98,11 @@ impl HelperDef for EachHelper {
         match template {
             Some(t) => {
                 let path = rc.get_path().clone();
-                let value = c.navigate(&path, param);
 
                 rc.promote_local_vars();
 
-                debug!("each value {:?}", value);
-                let rendered = match *value {
+                debug!("each value {:?}", value.value);
+                let rendered = match value.value {
                     Json::Array(ref list) => {
                         let len = list.len();
                         for i in 0..len {
@@ -104,9 +110,11 @@ impl HelperDef for EachHelper {
                             rc.set_local_var("@last".to_string(), value::to_value(&(i == len - 1)));
                             rc.set_local_var("@index".to_string(), value::to_value(&i));
 
-                            let new_path = format!("{}/{}.[{}]", path, param, i);
-                            debug!("each value {:?}", new_path);
-                            rc.set_path(new_path);
+                            if let Some(ref inner_path) = value.path {
+                                let new_path = format!("{}/{}.[{}]", path, inner_path, i);
+                                debug!("each value {:?}", new_path);
+                                rc.set_path(new_path);
+                            }
                             try!(t.render(c, r, rc));
                         }
                         Ok(())
@@ -120,8 +128,12 @@ impl HelperDef for EachHelper {
                             }
 
                             rc.set_local_var("@key".to_string(), value::to_value(&k));
-                            let new_path = format!("{}/{}.[{}]", path, param, k);
-                            rc.set_path(new_path);
+                            if let Some(ref inner_path) = value.path {
+                                let new_path = format!("{}/{}.[{}]", path, inner_path, k);
+                                debug!("each value {:?}", new_path);
+                                rc.set_path(new_path);
+                            }
+
                             try!(t.render(c, r, rc));
                         }
 

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,5 +1,5 @@
-use helpers::{HelperDef};
-use registry::{Registry};
+use helpers::HelperDef;
+use registry::Registry;
 use context::{JsonRender, Context};
 use render::{RenderContext, RenderError, Helper};
 
@@ -7,22 +7,18 @@ use render::{RenderContext, RenderError, Helper};
 pub struct LogHelper;
 
 impl HelperDef for LogHelper {
-    fn call(&self, c: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
-        let param = h.param(0);
+    fn call(&self,
+            _: &Context,
+            h: &Helper,
+            _: &Registry,
+            _: &mut RenderContext)
+            -> Result<(), RenderError> {
+        let param = try!(h.param(0)
+                          .ok_or_else(|| RenderError::new("Param not found for helper \"log\"")));
 
-        if param.is_none() {
-            return Err(RenderError::new("Param not found for helper \"log\""));
-        }
-
-        let name = param.unwrap();
-
-        let value = if name.starts_with("@") {
-            rc.get_local_var(name)
-        } else {
-            c.navigate(rc.get_path(), name)
-        };
-
-        info!("{}: {}", name, value.render());
+        info!("{}: {}",
+              param.path().unwrap_or(&"".to_owned()),
+              param.value().render());
 
         Ok(())
     }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,14 +1,14 @@
 use render::{RenderContext, RenderError, Helper};
-use registry::{Registry};
-use context::{Context};
+use registry::Registry;
+use context::Context;
 
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
-pub use self::helper_each::{EACH_HELPER};
-pub use self::helper_with::{WITH_HELPER};
-pub use self::helper_lookup::{LOOKUP_HELPER};
-pub use self::helper_raw::{RAW_HELPER};
+pub use self::helper_each::EACH_HELPER;
+pub use self::helper_with::WITH_HELPER;
+pub use self::helper_lookup::LOOKUP_HELPER;
+pub use self::helper_raw::RAW_HELPER;
 pub use self::helper_partial::{INCLUDE_HELPER, BLOCK_HELPER, PARTIAL_HELPER};
-pub use self::helper_log::{LOG_HELPER};
+pub use self::helper_log::LOG_HELPER;
 
 /// Helper Definition
 ///
@@ -22,7 +22,12 @@ pub use self::helper_log::{LOG_HELPER};
 /// By default, you can use bare function as helper definition because we have supported unboxed_closure. If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
 ///
 pub trait HelperDef: Send + Sync {
-    fn call(&self, ctx: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError>;
+    fn call(&self,
+            ctx: &Context,
+            h: &Helper,
+            r: &Registry,
+            rc: &mut RenderContext)
+            -> Result<(), RenderError>;
 }
 
 /// implement HelperDef for bare function so we can use function as helper
@@ -40,36 +45,40 @@ mod helper_raw;
 mod helper_partial;
 mod helper_log;
 
-/*
-pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;
-
-pub fn helper_dummy (ctx: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
-    h.template().unwrap().render(ctx, r, rc).unwrap()
-}
- */
+// pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;
+//
+// pub fn helper_dummy (ctx: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<String, RenderError> {
+// h.template().unwrap().render(ctx, r, rc).unwrap()
+// }
+//
 
 #[cfg(test)]
 mod test {
     use std::collections::BTreeMap;
 
     use context::{JsonRender, Context};
-    use helpers::{HelperDef};
+    use helpers::HelperDef;
     use template::Template;
-    use registry::{Registry};
+    use registry::Registry;
     use render::{RenderContext, RenderError, Renderable, Helper};
 
     #[derive(Clone, Copy)]
     struct MetaHelper;
 
     impl HelperDef for MetaHelper {
-        fn call(&self, c: &Context, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
-            let v = c.navigate(rc.get_path(), h.params().get(0).unwrap());
+        fn call(&self,
+                c: &Context,
+                h: &Helper,
+                r: &Registry,
+                rc: &mut RenderContext)
+                -> Result<(), RenderError> {
+            let v = h.param(0).unwrap();
 
             if !h.is_block() {
-                let output = format!("{}:{}", h.name(), v.render());
+                let output = format!("{}:{}", h.name(), v.value().render());
                 try!(rc.writer.write(output.into_bytes().as_ref()));
             } else {
-                let output = format!("{}:{}", h.name(), v.render());
+                let output = format!("{}:{}", h.name(), v.value().render());
                 try!(rc.writer.write(output.into_bytes().as_ref()));
                 try!(rc.writer.write("->".as_bytes()));
                 try!(h.template().unwrap().render(c, r, rc));
@@ -100,8 +109,12 @@ mod test {
 
     #[test]
     fn test_helper_for_subexpression() {
-        let t0 = Template::compile("{{#if (bar 0)}}hello{{^}}world{{/if}}".to_string()).ok().unwrap();
-        let t1 = Template::compile("{{#if (bar 1)}}hello{{^}}world{{/if}}".to_string()).ok().unwrap();
+        let t0 = Template::compile("{{#if (bar 0)}}hello{{^}}world{{/if}}".to_string())
+                     .ok()
+                     .unwrap();
+        let t1 = Template::compile("{{#if (bar 1)}}hello{{^}}world{{/if}}".to_string())
+                     .ok()
+                     .unwrap();
         let t2 = Template::compile("{{foo value=(bar 0)}}".to_string()).ok().unwrap();
 
         let mut handlebars = Registry::new();
@@ -109,16 +122,31 @@ mod test {
         handlebars.register_template("t1", t1);
         handlebars.register_template("t2", t2);
 
-        handlebars.register_helper("helperMissing", Box::new(|_: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError>{
-            let output = format!("{}{}", h.name(), h.param(0).unwrap());
-            try!(rc.writer.write(output.into_bytes().as_ref()));
-            Ok(())
-        }));
-        handlebars.register_helper("foo", Box::new(|_: &Context, h: &Helper, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError>{
-            let output = format!("{}", h.hash_get("value").unwrap().as_string().unwrap());
-            try!(rc.writer.write(output.into_bytes().as_ref()));
-            Ok(())
-        }));
+        handlebars.register_helper("helperMissing",
+                                   Box::new(|_: &Context,
+                                             h: &Helper,
+                                             _: &Registry,
+                                             rc: &mut RenderContext|
+                                             -> Result<(), RenderError> {
+                                       let output = format!("{}{}",
+                                                            h.name(),
+                                                            h.param(0).unwrap().value());
+                                       try!(rc.writer.write(output.into_bytes().as_ref()));
+                                       Ok(())
+                                   }));
+        handlebars.register_helper("foo",
+                                   Box::new(|_: &Context,
+                                             h: &Helper,
+                                             _: &Registry,
+                                             rc: &mut RenderContext|
+                                             -> Result<(), RenderError> {
+                                       let output = format!("{}",
+                                                            h.hash_get("value")
+                                                             .unwrap()
+                                                             .value());
+                                       try!(rc.writer.write(output.into_bytes().as_ref()));
+                                       Ok(())
+                                   }));
 
         let mut data = BTreeMap::new();
         data.insert("bar0".to_string(), true);
@@ -129,6 +157,6 @@ mod test {
 
         assert_eq!(r0.ok().unwrap(), "hello".to_string());
         assert_eq!(r1.ok().unwrap(), "world".to_string());
-        assert_eq!(r2.ok().unwrap(), "bar0".to_string());
+        assert_eq!(r2.ok().unwrap(), "true".to_string());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 //!
 //! ```ignore
 //! fn hex_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-//!     let param = h.params().get(0).unwrap();
-//!     let rendered = format!("{:x}", c.navigate(rc.get_path(), param).render());
+//!     let param = h.param(0).unwrap();
+//!     let rendered = format!("{:x}", param.value().render());
 //!     try!(rc.writer.write(rendered.into_bytes().as_ref()));
 //!     Ok(())
 //! }
@@ -185,28 +185,20 @@
 //!
 //! impl HelperDef for SimpleHelper {
 //!   fn call(&self, c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-//!     let param = h.params().get(0).unwrap();
+//!     let param = h.param(0).unwrap();
 //!
-//!     // get value from context data
-//!     // rc.get_path() is current json parent path, you should always use it like this
-//!     // param is the key of value you want to display
-//!     let value = c.navigate(rc.get_path(), param);
 //!     try!(rc.writer.write("Ny helper dumps: ".as_bytes()));
-//!     try!(rc.writer.write(value.render().into_bytes().as_ref()));
+//!     try!(rc.writer.write(param.value().render().into_bytes().as_ref()));
 //!     Ok(())
 //!   }
 //! }
 //!
 //! // implement via bare function
 //! fn another_simple_helper (c: &Context, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-//!     let param = h.params().get(0).unwrap();
+//!     let param = h.param(0).unwrap();
 //!
-//!     // get value from context data
-//!     // rc.get_path() is current json parent path, you should always use it like this
-//!     // param is the key of value you want to display
-//!     let value = c.navigate(rc.get_path(), param);
 //!     try!(rc.writer.write("My second helper dumps: ".as_bytes()));
-//!     try!(rc.writer.write(value.render().into_bytes().as_ref()));
+//!     try!(rc.writer.write(param.value().render().into_bytes().as_ref()));
 //!     Ok(())
 //! }
 //!
@@ -274,8 +266,8 @@ extern crate serde_json;
 
 pub use self::template::Template;
 pub use self::error::{TemplateError, TemplateFileError, TemplateRenderError};
-pub use self::registry::{EscapeFn, Registry as Handlebars};
-pub use self::render::{Renderable, RenderError, RenderContext, Helper};
+pub use self::registry::{EscapeFn, no_escape, html_escape, Registry as Handlebars};
+pub use self::render::{Renderable, RenderError, RenderContext, Helper, ContextJson};
 pub use self::helpers::HelperDef;
 pub use self::context::{Context, JsonRender, JsonTruthy};
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -19,13 +19,12 @@ use error::{TemplateError, TemplateFileError, TemplateRenderError};
 /// This type represents an *escape fn*, that is a function who's purpose it is
 /// to escape potentially problematic characters in a string.
 ///
-/// The default *escape fn* replaces the characters `&"<>`
-/// with the equivalent html / xml entities.
-///
 /// An *escape fn* is represented as a `Box` to avoid unnecessary type
 /// parameters (and because traits cannot be aliased using `type`).
 pub type EscapeFn = Box<Fn(&str) -> String + Send + Sync>;
 
+/// The default *escape fn* replaces the characters `&"<>`
+/// with the equivalent html / xml entities.
 pub fn html_escape(data: &str) -> String {
     data.replace("&", "&amp;")
         .replace("\"", "&quot;")
@@ -33,6 +32,8 @@ pub fn html_escape(data: &str) -> String {
         .replace(">", "&gt;")
 }
 
+/// `EscapeFn` that donot change any thing. Useful when using in a non-html
+/// environment.
 pub fn no_escape(data: &str) -> String {
     data.to_owned()
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -174,6 +174,8 @@ impl<'a> fmt::Debug for RenderContext<'a> {
     }
 }
 
+/// Json wrapper that holds the Json value and reference path information
+///
 #[derive(Debug)]
 pub struct ContextJson {
     path: Option<String>,
@@ -181,15 +183,19 @@ pub struct ContextJson {
 }
 
 impl ContextJson {
+    /// Returns relative path when the value is referenced
+    /// If the value is from a literal, the path is `None`
     pub fn path(&self) -> Option<&String> {
         self.path.as_ref()
     }
 
+    /// Returns the value
     pub fn value(&self) -> &Json {
         &self.value
     }
 }
 
+/// Render-time Helper data when using in a helper definition
 pub struct Helper<'a> {
     name: &'a str,
     params: Vec<ContextJson>,
@@ -214,8 +220,6 @@ impl<'a, 'b> Helper<'a> {
         let mut evaluated_hash = BTreeMap::new();
         for (k, p) in ht.hash.iter() {
             let r = try!(p.expand(ctx, registry, rc));
-            // subexpression in hash values are all treated as json string for now
-            // FIXME: allow different types evaluated as hash value
             evaluated_hash.insert(k.clone(), r);
         }
 
@@ -229,26 +233,32 @@ impl<'a, 'b> Helper<'a> {
         })
     }
 
+    /// Returns helper name
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Returns all helper params, resolved within the context
     pub fn params(&self) -> &Vec<ContextJson> {
         &self.params
     }
 
+    /// Returns nth helper param, resolved within the context
     pub fn param(&self, idx: usize) -> Option<&ContextJson> {
         self.params.get(idx)
     }
 
+    /// Returns hash, resolved within the context
     pub fn hash(&self) -> &BTreeMap<String, ContextJson> {
         &self.hash
     }
 
+    /// Return hash value of a given key, resolved within the context
     pub fn hash_get(&self, key: &str) -> Option<&ContextJson> {
         self.hash.get(key)
     }
 
+    /// Returns the default inner template if any
     pub fn template(&self) -> Option<&Template> {
         match *self.template {
             Some(ref t) => Some(t),
@@ -256,6 +266,7 @@ impl<'a, 'b> Helper<'a> {
         }
     }
 
+    /// Returns the template of `else` branch if any
     pub fn inverse(&self) -> Option<&Template> {
         match *self.inverse {
             Some(ref t) => Some(t),
@@ -263,6 +274,7 @@ impl<'a, 'b> Helper<'a> {
         }
     }
 
+    /// Returns if the helper is a block one `{{#helper}}{{/helper}}` or not `{{helper 123}}`
     pub fn is_block(&self) -> bool {
         self.block
     }
@@ -277,7 +289,6 @@ pub trait Renderable {
 }
 
 
-// FIXME: return borrowed Json here to avoid clone
 impl Parameter {
     fn expand(&self,
               ctx: &Context,

--- a/src/render.rs
+++ b/src/render.rs
@@ -61,6 +61,7 @@ pub struct RenderContext<'a> {
     pub current_template: Option<String>,
     /// root template name
     pub root_template: Option<String>,
+    pub disable_escape: bool,
 }
 
 impl<'a> RenderContext<'a> {
@@ -74,6 +75,7 @@ impl<'a> RenderContext<'a> {
             writer: w,
             current_template: None,
             root_template: None,
+            disable_escape: false,
         }
     }
 
@@ -87,6 +89,7 @@ impl<'a> RenderContext<'a> {
             writer: w,
             current_template: self.current_template.clone(),
             root_template: self.root_template.clone(),
+            disable_escape: self.disable_escape,
         }
     }
 
@@ -161,20 +164,36 @@ impl<'a> fmt::Debug for RenderContext<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f,
                "partials: {:?}, path: {:?}, local_variables: {:?}, current_template: {:?}, \
-                root_template: {:?}",
+                root_template: {:?}, disable_escape: {:?}",
                self.partials,
                self.path,
                self.local_variables,
                self.current_template,
-               self.root_template)
+               self.root_template,
+               self.disable_escape)
     }
 }
 
+#[derive(Debug)]
+pub struct ContextJson {
+    path: Option<String>,
+    value: Json,
+}
+
+impl ContextJson {
+    pub fn path(&self) -> Option<&String> {
+        self.path.as_ref()
+    }
+
+    pub fn value(&self) -> &Json {
+        &self.value
+    }
+}
 
 pub struct Helper<'a> {
-    name: &'a String,
-    params: Vec<String>,
-    hash: BTreeMap<String, Json>,
+    name: &'a str,
+    params: Vec<ContextJson>,
+    hash: BTreeMap<String, ContextJson>,
     template: &'a Option<Template>,
     inverse: &'a Option<Template>,
     block: bool,
@@ -188,16 +207,16 @@ impl<'a, 'b> Helper<'a> {
                      -> Result<Helper<'a>, RenderError> {
         let mut evaluated_params = Vec::new();
         for p in ht.params.iter() {
-            let r = try!(p.renders(ctx, registry, rc));
+            let r = try!(p.expand(ctx, registry, rc));
             evaluated_params.push(r);
         }
 
         let mut evaluated_hash = BTreeMap::new();
         for (k, p) in ht.hash.iter() {
-            let r = try!(p.renders(ctx, registry, rc));
+            let r = try!(p.expand(ctx, registry, rc));
             // subexpression in hash values are all treated as json string for now
             // FIXME: allow different types evaluated as hash value
-            evaluated_hash.insert(k.clone(), Json::String(r));
+            evaluated_hash.insert(k.clone(), r);
         }
 
         Ok(Helper {
@@ -210,23 +229,23 @@ impl<'a, 'b> Helper<'a> {
         })
     }
 
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
-    pub fn params(&self) -> &Vec<String> {
+    pub fn params(&self) -> &Vec<ContextJson> {
         &self.params
     }
 
-    pub fn param(&self, idx: usize) -> Option<&String> {
+    pub fn param(&self, idx: usize) -> Option<&ContextJson> {
         self.params.get(idx)
     }
 
-    pub fn hash(&self) -> &BTreeMap<String, Json> {
+    pub fn hash(&self) -> &BTreeMap<String, ContextJson> {
         &self.hash
     }
 
-    pub fn hash_get(&self, key: &str) -> Option<&Json> {
+    pub fn hash_get(&self, key: &str) -> Option<&ContextJson> {
         self.hash.get(key)
     }
 
@@ -258,23 +277,52 @@ pub trait Renderable {
 }
 
 
+// FIXME: return borrowed Json here to avoid clone
 impl Parameter {
-    fn renders(&self,
-               ctx: &Context,
-               registry: &Registry,
-               rc: &mut RenderContext)
-               -> Result<String, RenderError> {
+    fn expand(&self,
+              ctx: &Context,
+              registry: &Registry,
+              rc: &mut RenderContext)
+              -> Result<ContextJson, RenderError> {
         match self {
-            &Parameter::Name(ref n) => Ok(n.clone()),
+            &Parameter::Name(ref name) => {
+                if name.starts_with("@") {
+                    Ok(ContextJson {
+                        path: None,
+                        value: rc.get_local_var(&name).clone(),
+                    })
+                } else {
+                    Ok(ContextJson {
+                        path: Some(name.to_owned()),
+                        value: ctx.navigate(rc.get_path(), name).clone(),
+                    })
+                }
+            }
+            &Parameter::Literal(ref j) => {
+                Ok(ContextJson {
+                    path: None,
+                    value: j.clone(),
+                })
+            }
             &Parameter::Subexpression(ref t) => {
                 let mut local_writer = StringWriter::new();
                 let result = {
                     let mut local_rc = rc.with_writer(&mut local_writer);
+                    // disable html escape for subexpression
+                    local_rc.disable_escape = true;
+
                     t.render(ctx, registry, &mut local_rc)
                 };
 
                 match result {
-                    Ok(_) => Ok(local_writer.to_string()),
+                    Ok(_) => {
+                        let n = local_writer.to_string();
+
+                        try!(Parameter::parse(&n).map_err(|_| {
+                            RenderError::new("subexpression generates invalid value")
+                        }))
+                            .expand(ctx, registry, rc)
+                    }
                     Err(e) => Err(e),
                 }
             }
@@ -310,29 +358,20 @@ impl Renderable for TemplateElement {
                 Ok(())
             }
             Expression(ref v) => {
-                let name = try!(v.renders(ctx, registry, rc));
-                let rendered = {
-                    let value = if name.starts_with("@") {
-                        rc.get_local_var(&name)
-                    } else {
-                        ctx.navigate(rc.get_path(), &name)
-                    };
-                    value.render()
+                let context_json = try!(v.expand(ctx, registry, rc));
+                let rendered = context_json.value.render();
+
+                let output = if !rc.disable_escape {
+                    registry.get_escape_fn()(&rendered)
+                } else {
+                    rendered
                 };
-                let output = registry.get_escape_fn()(&rendered);
                 try!(rc.writer.write(output.into_bytes().as_ref()));
                 Ok(())
             }
             HTMLExpression(ref v) => {
-                let name = try!(v.renders(ctx, registry, rc));
-                let rendered = {
-                    let value = if name.starts_with("@") {
-                        rc.get_local_var(&name)
-                    } else {
-                        ctx.navigate(rc.get_path(), &name)
-                    };
-                    value.render()
-                };
+                let context_json = try!(v.expand(ctx, registry, rc));
+                let rendered = context_json.value.render();
                 try!(rc.writer.write(rendered.into_bytes().as_ref()));
                 Ok(())
             }
@@ -477,25 +516,12 @@ fn test_render_subexpression() {
     let mut sw = StringWriter::new();
     {
         let mut rc = RenderContext::new(&mut sw);
-        let mut elements: Vec<TemplateElement> = Vec::new();
-
-        let e1 = RawString("<h1>".to_string());
-        elements.push(e1);
-
-        let e2 = Expression(Parameter::parse("(hello)").ok().unwrap());
-        elements.push(e2);
-
-        let e3 = RawString("</h1>".to_string());
-        elements.push(e3);
-
-        let template = Template {
-            elements: elements,
-            name: None,
-        };
+        let template = Template::compile("<h1>{{#if (const)}}{{(hello)}}{{/if}}</h1>").unwrap();
 
         let mut m: HashMap<String, String> = HashMap::new();
         m.insert("hello".to_string(), "world".to_string());
         m.insert("world".to_string(), "nice".to_string());
+        m.insert("const".to_string(), "\"truthy\"".to_string());
 
         let ctx = Context::wraps(&m);
         template.render(&ctx, &r, &mut rc).ok().unwrap();


### PR DESCRIPTION
Fixes #75 

* Added support for JSON literal in helpers like `{{hello 1 a=true b=3.14 c=ref}}` where `ref` is a reference to your context value, while `1`, `true` and `3.14` are all literal values.
* Return value subexpression are no treated as reference by default, if you want JSON value use literal instead. For example, `foo` will be treated as reference which `"foo"` is string.
* Break change for helper developers, references hash and params are now solved by default, no more `ctx.navigate` is needed.
* Removed `to_string()` implementation from template types.
