### PR TITLE
Pest parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "^0.7.0", optional = true }
 serde_json = { version = "^0.7.0", optional = true }
 serde_macros = { version = "^0.7.0", optional = true }
 itertools = "^0.4.7"
+pest = "^0.2.0"
 
 [features]
 default = ["rustc_ser_type"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ quick-error = "^1.0.0"
 serde = { version = "^0.7.0", optional = true }
 serde_json = { version = "^0.7.0", optional = true }
 serde_macros = { version = "^0.7.0", optional = true }
-pest = "^0.2.0"
+pest = "^0.3.0"
 
 [features]
 default = ["rustc_ser_type"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ quick-error = "^1.0.0"
 serde = { version = "^0.7.0", optional = true }
 serde_json = { version = "^0.7.0", optional = true }
 serde_macros = { version = "^0.7.0", optional = true }
-itertools = "^0.4.7"
 pest = "^0.2.0"
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,32 +6,18 @@ quick_error! {
 /// Template parsing error
     #[derive(PartialEq, Debug, Clone)]
     pub enum TemplateError {
-        UnclosedBraces(line_no: usize, col_no: usize) {
-            display("closing braces `}}` expected but EOF reached at line {:?}, column {:?}",
-                    line_no, col_no)
-            description("closing braces `}}` expected but EOF reached")
-        }
-        UnexpectedClosingBraces(line_no: usize, col_no: usize) {
-            display("can't close braces `}}` at line {:?}, column {:?}",
-                    line_no, col_no)
-            description("can't close braces `}}` at this location")
-        }
         MismatchingClosedHelper(line_no: usize, col_no: usize, open: String, closed: String) {
             display("helper {:?} was opened, but {:?} is closing at line {:?}, column {:?}",
                 open, closed, line_no, col_no)
             description("wrong name of closing helper")
         }
-        UnclosedHelper(line_no: usize, col_no: usize, name: String) {
-            display("helper {:?} was not closed on the end of file at line {:?}, column {:?}",
-                    name, line_no, col_no)
-            description("some helper was not closed on the end of file")
+        InvalidSyntax (line_no: usize, col_no: usize) {
+            display("invalid handlebars syntax at line {:?}, column {:?}", line_no, col_no)
+            description("invalid handlebars syntax")
         }
-        UnclosedExpression(line_no: usize, col_no: usize) {
-            display("expression or comment was not closed on the end of file at line {:?}, column {:?}", line_no, col_no)
-            description("some expression or comment was not closed on the end of file")
-        }
-        Unknown {
-
+        InvalidParam (param: String) {
+            display("invalid parameter {:?}", param)
+            description("invalid parameter")
         }
         NestedSubexpression(line_no: usize, col_no: usize) {
             display("nested subexpression at line {:?}, column {:?} is not supported.", line_no, col_no)

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,13 @@ quick_error! {
             display("expression or comment was not closed on the end of file at line {:?}, column {:?}", line_no, col_no)
             description("some expression or comment was not closed on the end of file")
         }
+        Unknown {
+
+        }
+        NestedSubexpression(line_no: usize, col_no: usize) {
+            display("nested subexpression at line {:?}, column {:?} is not supported.", line_no, col_no)
+            description("nested subexpression is not supported")
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use render::RenderError;
 
 quick_error! {
 /// Template parsing error
-    #[derive(Debug, Clone)]
+    #[derive(PartialEq, Debug, Clone)]
     pub enum TemplateError {
         UnclosedBraces(line_no: usize, col_no: usize) {
             display("closing braces `}}` expected but EOF reached at line {:?}, column {:?}",

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,0 +1,118 @@
+use pest::prelude::*;
+
+impl_rdp! {
+    grammar! {
+        whitespace = _{ [" "] }
+
+        raw_text = { ( !["{{"] ~ any )+ }
+        raw_block_text = { ( !["{{{{"] ~ any )+ }
+
+// Note: this is not full and strict json literal definition, just for tokenize string,
+// array and object types which may contains whitespace. We will use a real json parser
+// for real json processing
+        literal = _{ string_literal | array_literal | object_literal }
+        escape_literal = { (!["\""] ~ (["\\\""] | any))* }
+        string_literal = { ["\""] ~ (!["\""] ~ (["\\\""] | any))* ~ ["\""] }
+        array_literal = { ["["] ~ literal? ~ ([","] ~ literal)* ~ ["]"] }
+        object_literal = { ["{"] ~ (literal? ~ [":"] ~ literal? ~ [","]?)* ~ ["}"] }
+
+        symbol_and_path = { ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["."]|["@"]|["$"] }
+
+        identifier = @{ symbol_and_path+ }
+        name = { subexpression | identifier }
+
+        param = { literal | name }
+        hash = { identifier ~ ["="] ~ param }
+        exp_line = { whitespace_omitter? ~ name ~ (hash|param)* ~ whitespace_omitter? }
+
+        subexpression = { ["("] ~ name ~ (hash|param)* ~ [")"] }
+
+        whitespace_omitter = { ["~"] }
+
+        expression = { ["{{"] ~ exp_line ~ ["}}"] }
+        html_expression = { ["{{{"] ~ exp_line ~ ["}}}"] }
+        invert_tag = { ["{{else}}"]|["{{^}}"] }
+        helper_block_start = { ["{{#"] ~ exp_line ~ ["}}"] }
+        helper_block_end = { ["{{/"] ~ whitespace_omitter? ~ name ~ whitespace_omitter? ~ ["}}"] }
+        helper_block = { helper_block_start ~ template ~ invert_tag? ~
+                         template? ~ helper_block_end}
+        raw_block_start = { ["{{{{#"] ~ exp_line ~ ["}}}}"] }
+        raw_block_end = { ["{{{{/"] ~ whitespace_omitter? ~ name ~ whitespace_omitter? ~ ["}}}}"] }
+        raw_block = { raw_block_start ~ raw_block_text ~ raw_block_end }
+
+        comment = { ["{{!"] ~ (!["}}"] ~ any)* ~ ["}}"] }
+
+        template = _{ (
+            raw_text |
+            expression |
+            html_expression |
+            helper_block |
+            raw_block |
+            comment)*
+        }
+    }
+}
+
+#[test]
+fn test_raw_text() {
+    let mut rdp = Rdp::new(StringInput::new("<h1> helloworld </h1>"));
+    assert!(rdp.raw_text());
+    assert!(rdp.end());
+}
+
+#[test]
+fn test_name() {
+    let s = vec!["if", "(abc)"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.name());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_param() {
+    let s = vec!["hello", "\"json literal\""];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.param());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_hash() {
+    let s = vec!["hello=world", "hello=\"world\"", "hello=(world)"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.hash());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_json_literal() {
+    let s = vec!["\"json string\"", "quot: \\\""];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.string_literal());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_escape_literal() {
+    let mut rdp = Rdp::new(StringInput::new("nice\\\"anc"));
+    assert!(rdp.escape_literal());
+    assert!(rdp.end());
+}
+
+#[test]
+fn test_comment() {
+    let s = vec!["{{! hello }}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.comment());
+        assert!(rdp.end());
+    }
+}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -17,10 +17,10 @@ impl_rdp! {
                      null_literal |
                      boolean_literal }
 
-        null_literal = @{ ["null"] }
-        boolean_literal = @{ ["true"]|["false"] }
+        null_literal = { ["null"] }
+        boolean_literal = { ["true"]|["false"] }
         number_literal = @{ ["-"]? ~ ['0'..'9']+ ~ ["."]? ~ ['0'..'9']* ~ (["E"] ~ ["-"]? ~ ['0'..'9']+)? }
-        string_literal = { ["\""] ~ (!["\""] ~ (["\\\""] | any))* ~ ["\""] }
+        string_literal = @{ ["\""] ~ (!["\""] ~ (["\\\""] | any))* ~ ["\""] }
         array_literal = { ["["] ~ literal? ~ ([","] ~ literal)* ~ ["]"] }
         object_literal = { ["{"] ~ (string_literal ~ [":"] ~ literal)? ~ ([","] ~ string_literal ~ [":"] ~ literal)* ~ ["}"] }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -10,12 +10,12 @@ impl_rdp! {
 // Note: this is not full and strict json literal definition, just for tokenize string,
 // array and object types which may contains whitespace. We will use a real json parser
 // for real json processing
-        literal = _{ string_literal |
-                     array_literal |
-                     object_literal |
-                     number_literal |
-                     null_literal |
-                     boolean_literal }
+        literal = { string_literal |
+                    array_literal |
+                    object_literal |
+                    number_literal |
+                    null_literal |
+                    boolean_literal }
 
         null_literal = { ["null"] }
         boolean_literal = { ["true"]|["false"] }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -59,7 +59,7 @@ impl_rdp! {
                          (invert_tag ~ template)? ~
                          helper_block_end }
 
-        raw_block_start = { ["{{{{"] ~ pre_whitespace_omitter? ~ ["#"] ~ exp_line ~
+        raw_block_start = { ["{{{{"] ~ pre_whitespace_omitter? ~ exp_line ~
                                        pro_whitespace_omitter? ~ ["}}}}"] }
         raw_block_end = { ["{{{{"] ~ pre_whitespace_omitter? ~ ["/"] ~ name ~
                                      pro_whitespace_omitter? ~ ["}}}}"] }
@@ -251,8 +251,8 @@ fn test_helper_block() {
 
 #[test]
 fn test_raw_block() {
-    let s = vec!["{{{{#if hello}}}}good {{hello}}{{{{/if}}}}",
-                 "{{{{#if hello}}}}{{#if nice}}{{/if}}{{{{/if}}}}"];
+    let s = vec!["{{{{if hello}}}}good {{hello}}{{{{/if}}}}",
+                 "{{{{if hello}}}}{{#if nice}}{{/if}}{{{{/if}}}}"];
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
         assert!(rdp.raw_block());

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -5,7 +5,7 @@ impl_rdp! {
         whitespace = _{ [" "]|["\t"]|["\n"]|["\r"] }
 
         raw_text = @{ ( !["{{"] ~ any )+ }
-        raw_block_text = @{ ( !["{{{{"] ~ any )+ }
+        raw_block_text = @{ ( !["{{{{"] ~ any )* }
 
 // Note: this is not full and strict json literal definition, just for tokenize string,
 // array and object types which may contains whitespace. We will use a real json parser
@@ -55,7 +55,7 @@ impl_rdp! {
                                         pro_whitespace_omitter? ~ ["}}"] }
         helper_block_end = { ["{{"] ~ pre_whitespace_omitter? ~ ["/"] ~ name ~
                                       pro_whitespace_omitter? ~ ["}}"] }
-        helper_block = { helper_block_start ~ template ~
+        helper_block = _{ helper_block_start ~ template ~
                          (invert_tag ~ template)? ~
                          helper_block_end }
 
@@ -63,7 +63,7 @@ impl_rdp! {
                                        pro_whitespace_omitter? ~ ["}}}}"] }
         raw_block_end = { ["{{{{"] ~ pre_whitespace_omitter? ~ ["/"] ~ name ~
                                      pro_whitespace_omitter? ~ ["}}}}"] }
-        raw_block = { raw_block_start ~ raw_block_text ~ raw_block_end }
+        raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
         hbs_comment = { ["{{!"] ~ (!["}}"] ~ any)* ~ ["}}"] }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -30,7 +30,7 @@ impl_rdp! {
 
         identifier = @{ symbol_char ~ ( symbol_char | path_char )* }
         reference = @{ identifier ~ (["["] ~ (string_literal|['0'..'9']+) ~ ["]"])* ~ reference* }
-        name = { subexpression | identifier }
+        name = _{ subexpression | identifier }
 
         param = { literal | reference | subexpression }
         hash = @{ identifier ~ ["="] ~ param }
@@ -41,14 +41,14 @@ impl_rdp! {
         pre_whitespace_omitter = { ["~"] }
         pro_whitespace_omitter = { ["~"] }
 
-        expression = { ["{{"] ~ pre_whitespace_omitter? ~ name ~
-                                pro_whitespace_omitter? ~ ["}}"] }
+        expression = { !invert_tag ~ ["{{"] ~ pre_whitespace_omitter? ~ name ~
+                        pro_whitespace_omitter? ~ ["}}"] }
 
         html_expression = { ["{{{"] ~ pre_whitespace_omitter? ~ name ~
                                       pro_whitespace_omitter? ~ ["}}}"] }
 
-        helper_expression = { ["{{"] ~ pre_whitespace_omitter? ~ exp_line ~
-                                       pro_whitespace_omitter? ~ ["}}"] }
+        helper_expression = { !invert_tag ~ ["{{"] ~ pre_whitespace_omitter? ~ exp_line ~
+                               pro_whitespace_omitter? ~ ["}}"] }
 
         invert_tag = { ["{{else}}"]|["{{^}}"] }
         helper_block_start = { ["{{"] ~ pre_whitespace_omitter? ~ ["#"] ~ exp_line ~

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -2,62 +2,107 @@ use pest::prelude::*;
 
 impl_rdp! {
     grammar! {
-        whitespace = _{ [" "] }
+        whitespace = _{ [" "]|["\t"]|["\n"]|["\r"] }
 
-        raw_text = { ( !["{{"] ~ any )+ }
-        raw_block_text = { ( !["{{{{"] ~ any )+ }
+        raw_text = @{ ( !["{{"] ~ any )+ }
+        raw_block_text = @{ ( !["{{{{"] ~ any )+ }
 
 // Note: this is not full and strict json literal definition, just for tokenize string,
 // array and object types which may contains whitespace. We will use a real json parser
 // for real json processing
-        literal = _{ string_literal | array_literal | object_literal }
-        escape_literal = { (!["\""] ~ (["\\\""] | any))* }
+        literal = _{ string_literal |
+                     array_literal |
+                     object_literal |
+                     number_literal |
+                     null_literal |
+                     boolean_literal }
+
+        null_literal = @{ ["null"] }
+        boolean_literal = @{ ["true"]|["false"] }
+        number_literal = @{ ["-"]? ~ ['0'..'9']+ ~ ["."]? ~ ['0'..'9']* ~ (["E"] ~ ["-"]? ~ ['0'..'9']+)? }
         string_literal = { ["\""] ~ (!["\""] ~ (["\\\""] | any))* ~ ["\""] }
         array_literal = { ["["] ~ literal? ~ ([","] ~ literal)* ~ ["]"] }
-        object_literal = { ["{"] ~ (literal? ~ [":"] ~ literal? ~ [","]?)* ~ ["}"] }
+        object_literal = { ["{"] ~ (string_literal ~ [":"] ~ literal)? ~ ([","] ~ string_literal ~ [":"] ~ literal)* ~ ["}"] }
 
-        symbol_and_path = { ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["."]|["@"]|["$"] }
+// FIXME: a[0], a["b]
+        symbol_char = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["."]|["@"]|["$"] }
+        path_char = _{ ["/"] }
 
-        identifier = @{ symbol_and_path+ }
+        identifier = @{ symbol_char ~ ( symbol_char | path_char )* }
+        reference = @{ identifier ~ (["["] ~ (string_literal|['0'..'9']+) ~ ["]"])* ~ reference* }
         name = { subexpression | identifier }
 
-        param = { literal | name }
-        hash = { identifier ~ ["="] ~ param }
-        exp_line = { whitespace_omitter? ~ name ~ (hash|param)* ~ whitespace_omitter? }
+        param = { literal | reference | subexpression }
+        hash = @{ identifier ~ ["="] ~ param }
+        exp_line = _{ name ~ (hash|param)* }
 
         subexpression = { ["("] ~ name ~ (hash|param)* ~ [")"] }
 
         whitespace_omitter = { ["~"] }
 
-        expression = { ["{{"] ~ exp_line ~ ["}}"] }
-        html_expression = { ["{{{"] ~ exp_line ~ ["}}}"] }
+        expression = { ["{{"] ~ whitespace_omitter? ~ exp_line ~
+                                whitespace_omitter? ~ ["}}"] }
+
+        html_expression = { ["{{{"] ~ whitespace_omitter? ~ exp_line ~
+                                      whitespace_omitter? ~ ["}}}"] }
+
         invert_tag = { ["{{else}}"]|["{{^}}"] }
-        helper_block_start = { ["{{#"] ~ exp_line ~ ["}}"] }
-        helper_block_end = { ["{{/"] ~ whitespace_omitter? ~ name ~ whitespace_omitter? ~ ["}}"] }
-        helper_block = { helper_block_start ~ template ~ invert_tag? ~
-                         template? ~ helper_block_end}
-        raw_block_start = { ["{{{{#"] ~ exp_line ~ ["}}}}"] }
-        raw_block_end = { ["{{{{/"] ~ whitespace_omitter? ~ name ~ whitespace_omitter? ~ ["}}}}"] }
+        helper_block_start = { ["{{"] ~ whitespace_omitter? ~ ["#"] ~ exp_line ~
+                                        whitespace_omitter? ~ ["}}"] }
+        helper_block_end = { ["{{"] ~ whitespace_omitter? ~ ["/"] ~ name ~
+                                      whitespace_omitter? ~ ["}}"] }
+        helper_block = { helper_block_start ~ template ~
+                         (invert_tag ~ template)? ~
+                         helper_block_end }
+
+        raw_block_start = { ["{{{{"] ~ whitespace_omitter? ~ ["#"] ~ exp_line ~
+                                       whitespace_omitter? ~ ["}}}}"] }
+        raw_block_end = { ["{{{{"] ~ whitespace_omitter? ~ ["/"] ~ name ~
+                                     whitespace_omitter? ~ ["}}}}"] }
         raw_block = { raw_block_start ~ raw_block_text ~ raw_block_end }
 
         comment = { ["{{!"] ~ (!["}}"] ~ any)* ~ ["}}"] }
 
-        template = _{ (
+        template = { (
             raw_text |
             expression |
             html_expression |
             helper_block |
             raw_block |
-            comment)*
+            comment )*
         }
     }
 }
 
 #[test]
 fn test_raw_text() {
-    let mut rdp = Rdp::new(StringInput::new("<h1> helloworld </h1>"));
+    let mut rdp = Rdp::new(StringInput::new("<h1> helloworld </h1>    "));
     assert!(rdp.raw_text());
     assert!(rdp.end());
+}
+
+#[test]
+fn test_raw_block_text() {
+    let mut rdp = Rdp::new(StringInput::new("<h1> {{hello}} </h1>"));
+    assert!(rdp.raw_block_text());
+    assert!(rdp.end());
+}
+
+#[test]
+fn test_reference() {
+    let s = vec!["a",
+                 "abc",
+                 "../a",
+                 "a.b",
+                 "@abc",
+                 "a[\"abc\"]",
+                 "aBc[\"abc\"]",
+                 "abc[0][\"nice\"]"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.reference());
+        assert!(rdp.end());
+    }
 }
 
 #[test]
@@ -92,19 +137,19 @@ fn test_hash() {
 
 #[test]
 fn test_json_literal() {
-    let s = vec!["\"json string\"", "quot: \\\""];
+    let s = vec!["\"json string\"",
+                 "\"quot: \\\"\"",
+                 "[]",
+                 "[\"hello\"]",
+                 "[1,2,3,4,true]",
+                 "{\"hello\": \"world\"}",
+                 "{}",
+                 "{\"a\":1, \"b\":2 }"];
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
-        assert!(rdp.string_literal());
+        assert!(rdp.literal());
         assert!(rdp.end());
     }
-}
-
-#[test]
-fn test_escape_literal() {
-    let mut rdp = Rdp::new(StringInput::new("nice\\\"anc"));
-    assert!(rdp.escape_literal());
-    assert!(rdp.end());
 }
 
 #[test]
@@ -113,6 +158,94 @@ fn test_comment() {
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
         assert!(rdp.comment());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_expression() {
+    let s = vec!["{{exp}}",
+                 "{{exp 1}}",
+                 "{{exp \"literal\"}}",
+                 "{{exp ref}}",
+                 "{{exp (sub)}}",
+                 "{{exp (sub 123)}}",
+                 "{{exp []}}",
+                 "{{exp {}}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.expression());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_html_expression() {
+    let s = vec!["{{{html}}}",
+                 "{{{html 1}}}",
+                 "{{{html \"literal\"}}}",
+                 "{{{html ref}}}",
+                 "{{{html (sub)}}}",
+                 "{{{html (sub 123)}}}",
+                 "{{{html []}}}",
+                 "{{{html {}}}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.html_expression());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_helper_start() {
+    let s = vec!["{{#if hello}}",
+                 "{{#if (hello)}}",
+                 "{{#if hello=world}}",
+                 "{{#if hello hello=world}}",
+                 "{{#if []}}",
+                 "{{#if {}}}",
+                 "{{#if}}",
+                 "{{~#if hello~}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.helper_block_start());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_helper_end() {
+    let s = vec!["{{/if}}", "{{~/if}}", "{{~/if ~}}", "{{/if   ~}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.helper_block_end());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_helper_block() {
+    let s = vec!["{{#if hello}}hello{{/if}}",
+                 "{{#if true}}hello{{/if}}",
+                 "{{#if nice ok=1}}hello{{/if}}",
+                 "{{#if}}hello{{else}}world{{/if}}",
+                 "{{#if}}hello{{^}}world{{/if}}",
+                 "{{#if}}{{#if}}hello{{/if}}{{/if}}",
+                 "{{#if}}{{/if}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.helper_block());
+        assert!(rdp.end());
+    }
+}
+
+#[test]
+fn test_raw_block() {
+    let s = vec!["{{{{#if hello}}}}good {{hello}}{{{{/if}}}}",
+                 "{{{{#if hello}}}}{{#if nice}}{{/if}}{{{{/if}}}}"];
+    for i in s.iter() {
+        let mut rdp = Rdp::new(StringInput::new(i));
+        assert!(rdp.raw_block());
         assert!(rdp.end());
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -65,7 +65,7 @@ impl_rdp! {
                                      pro_whitespace_omitter? ~ ["}}}}"] }
         raw_block = { raw_block_start ~ raw_block_text ~ raw_block_end }
 
-        comment = { ["{{!"] ~ (!["}}"] ~ any)* ~ ["}}"] }
+        hbs_comment = { ["{{!"] ~ (!["}}"] ~ any)* ~ ["}}"] }
 
         template = { (
             raw_text |
@@ -74,10 +74,11 @@ impl_rdp! {
             helper_expression |
             helper_block |
             raw_block |
-            comment )*
+            hbs_comment )*
         }
 
-        handlebars = _ { template ~ eoi }
+        parameter = _{ param ~ eoi }
+        handlebars = _{ template ~ eoi }
     }
 }
 
@@ -164,7 +165,7 @@ fn test_comment() {
     let s = vec!["{{! hello }}"];
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
-        assert!(rdp.comment());
+        assert!(rdp.hbs_comment());
         assert!(rdp.end());
     }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -202,7 +202,7 @@ mod test {
 
     #[test]
     fn test_empty_key() {
-        let t0 = Template::compile("{{#each this}}{{@key}}-{{value}}${{/each}}".to_owned())
+        let t0 = Template::compile("{{#each this}}{{@key}}-{{value}}\n{{/each}}".to_owned())
                      .unwrap();
 
         let mut handlebars = Registry::new();
@@ -225,7 +225,7 @@ mod test {
                                    }))
                            .unwrap();
 
-        let mut r0_sp: Vec<_> = r0.split('$').collect();
+        let mut r0_sp: Vec<_> = r0.split('\n').collect();
         r0_sp.sort();
 
         assert_eq!(r0_sp, vec!["", "-baz", "foo-bar"]);

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -202,9 +202,10 @@ mod test {
 
     #[test]
     fn test_empty_key() {
-        let t0 = Template::compile("{{#each this}}{{@key}}-{{value}}\n{{/each}}".to_owned())
+        let t0 = Template::compile("{{#each this}}{{@key}}-{{value}}${{/each}}".to_owned())
                      .unwrap();
 
+        println!("{:?}", t0);
         let mut handlebars = Registry::new();
         handlebars.register_template("t0", t0);
 
@@ -225,7 +226,7 @@ mod test {
                                    }))
                            .unwrap();
 
-        let mut r0_sp: Vec<_> = r0.split('\n').collect();
+        let mut r0_sp: Vec<_> = r0.split('$').collect();
         r0_sp.sort();
 
         assert_eq!(r0_sp, vec!["", "-baz", "foo-bar"]);

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -205,7 +205,6 @@ mod test {
         let t0 = Template::compile("{{#each this}}{{@key}}-{{value}}${{/each}}".to_owned())
                      .unwrap();
 
-        println!("{:?}", t0);
         let mut handlebars = Registry::new();
         handlebars.register_template("t0", t0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,6 @@
 //!
 
 
-#![allow(dead_code)]
 #![recursion_limit = "200"]
 
 #[macro_use]
@@ -263,7 +262,6 @@ extern crate maplit;
 #[cfg(feature = "rustc_ser_type")]
 extern crate rustc_serialize as serialize;
 extern crate regex;
-extern crate itertools;
 
 #[cfg(feature = "serde_type")]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,12 +244,18 @@
 //! * `{{log ...}}` log value with rust logger, default level: INFO. Currently you cannot change the level.
 //!
 
+
+#![allow(dead_code)]
+#![recursion_limit = "200"]
+
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate quick_error;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate pest;
 #[cfg(test)]
 #[macro_use]
 extern crate maplit;
@@ -271,6 +277,7 @@ pub use self::render::{Renderable, RenderError, RenderContext, Helper, ContextJs
 pub use self::helpers::HelperDef;
 pub use self::context::{Context, JsonRender, JsonTruthy};
 
+mod grammar;
 mod template;
 mod error;
 mod registry;

--- a/src/render.rs
+++ b/src/render.rs
@@ -567,7 +567,9 @@ fn test_render_subexpression() {
         m.insert("const".to_string(), "\"truthy\"".to_string());
 
         let ctx = Context::wraps(&m);
-        template.render(&ctx, &r, &mut rc).ok().unwrap();
+        if let Err(e) = template.render(&ctx, &r, &mut rc) {
+            panic!("{}", e);
+        }
     }
 
     assert_eq!(sw.to_string(), "<h1>nice</h1>".to_string());

--- a/src/render.rs
+++ b/src/render.rs
@@ -341,13 +341,12 @@ impl Parameter {
                     // disable html escape for subexpression
                     local_rc.disable_escape = true;
 
-                    t.render(ctx, registry, &mut local_rc)
+                    t.as_template().render(ctx, registry, &mut local_rc)
                 };
 
                 match result {
                     Ok(_) => {
                         let n = local_writer.to_string();
-
                         try!(Parameter::parse(&n).map_err(|_| {
                             RenderError::new("subexpression generates invalid value")
                         }))

--- a/src/template.rs
+++ b/src/template.rs
@@ -296,10 +296,6 @@ impl Template {
             return Err(TemplateError::Unknown);
         }
 
-        for i in parser.queue() {
-            println!("{:?}", i);
-        }
-
         let mut it = parser.queue().iter().peekable();
         loop {
             if let Some(ref token) = it.next() {
@@ -384,7 +380,6 @@ impl Template {
                             } else {
                                 h.template = Some(prev_t);
                             }
-                            println!("{:?}", template_stack);
                             let t = template_stack.front_mut().unwrap();
                             t.elements.push(HelperBlock(h));
                         } else {

--- a/src/template.rs
+++ b/src/template.rs
@@ -517,8 +517,8 @@ pub enum TemplateElement {
 
 #[test]
 fn test_parse_template() {
-    let source = "<h1>{{title}} nihao</h1> {{{content}}}
-{{#if date}}<p>good</p>{{else}}<p>bad</p>{{/if}}<img>{{foo bar}}niheo
+    let source = "<h1>{{title}} 你好</h1> {{{content}}}
+{{#if date}}<p>good</p>{{else}}<p>bad</p>{{/if}}<img>{{foo bar}}中文你好
 {{#unless true}}kitkat{{^}}lollipop{{/unless}}";
     let t = Template::compile(source.to_string()).ok().unwrap();
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,6 +13,7 @@ use serde_json::value::Value as Json;
 #[cfg(feature = "serde_type")]
 use std::str::FromStr;
 
+use grammar::Rdp;
 use TemplateError;
 use TemplateError::*;
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,12 +1,8 @@
 use std::slice::Iter;
 use std::iter::Peekable;
-use std::ops::BitOr;
-use std::str::Chars;
+use std::convert::From;
 // use std::fmt;
 use std::collections::{BTreeMap, VecDeque};
-use std::string::ToString;
-use regex::Regex;
-use itertools::{PutBack, PutBackN};
 use pest::prelude::*;
 
 #[cfg(feature = "rustc_ser_type")]
@@ -19,7 +15,6 @@ use std::str::FromStr;
 use grammar::{Rdp, Rule};
 
 use TemplateError;
-use TemplateError::*;
 
 use self::TemplateElement::{RawString, Expression, HelperExpression, HTMLExpression, HelperBlock,
                             Comment};
@@ -34,24 +29,28 @@ pub struct Template {
     pub mapping: Option<Vec<TemplateMapping>>,
 }
 
-#[derive(PartialEq, Debug)]
-enum ParserState {
-    Text,
-    HtmlExpression,
-    Comment,
-    HelperStart,
-    HelperEnd,
-    Expression,
-    RawHelperStart,
-    RawHelperEnd,
-    RawText,
-}
-
 #[derive(PartialEq, Clone, Debug)]
 pub struct Subexpression {
     pub name: String,
     pub params: Vec<Parameter>,
     pub hash: BTreeMap<String, Parameter>,
+}
+
+impl Subexpression {
+    pub fn is_helper(&self) -> bool {
+        self.params.is_empty() && self.hash.is_empty()
+    }
+
+    pub fn as_template(&self) -> Template {
+        let mut t = Template::new(false);
+        let el = if self.is_helper() {
+            HelperExpression(HelperTemplate::from(self))
+        } else {
+            Expression(Parameter::Name(self.name.clone()))
+        };
+        t.elements.push(el);
+        t
+    }
 }
 
 #[derive(PartialEq, Clone, Debug)]
@@ -80,100 +79,20 @@ pub struct HelperTemplate {
     pub block: bool,
 }
 
-fn find_tokens(source: &str) -> Vec<String> {
-    let tokenizer = Regex::new(r"[^\s\(\)]+|\([^\)]*\)").unwrap();
-
-    let mut hash_key: Option<&str> = None;
-    let mut results: Vec<String> = vec![];
-    tokenizer.captures_iter(&source)
-             .map(|c| c.at(0).unwrap())
-             .fold(&mut results, |r, item| {
-                 match hash_key {
-                     Some(k) => {
-                         r.push(format!("{}{}", k, item));
-                         hash_key = None
-                     }
-                     None => {
-                         if item.ends_with("=") {
-                             hash_key = Some(item);
-                         } else {
-                             r.push(item.to_string());
-                         }
-                     }
-                 }
-                 r
-             });
-    results
-}
-
-impl HelperTemplate {
-    pub fn parse<S: AsRef<str>>(source: S,
-                                block: bool,
-                                line_no: usize,
-                                col_no: usize)
-                                -> Result<HelperTemplate, TemplateError> {
-        let source = source.as_ref();
-        let tokens_vec = find_tokens(&source);
-        let mut tokens = tokens_vec.iter();
-
-        let name = tokens.next();
-        match name {
-            Some(n) => {
-                let mut params: Vec<Parameter> = Vec::new();
-                let mut hash: BTreeMap<String, Parameter> = BTreeMap::new();
-
-                for t in tokens {
-                    if t.contains('=') {
-                        let kv = t.split('=').collect::<Vec<&str>>();
-                        let value = try!(Parameter::parse(kv.get(1).unwrap().to_string()));
-                        hash.insert(kv.get(0).unwrap().to_string(), value);
-                    } else {
-                        let value = try!(Parameter::parse(t.to_string()));
-                        params.push(value);
-                    }
-                }
-
-                Ok(HelperTemplate{
-                    name: n.to_string(),
-                    params: params,
-                    hash: hash,
-                    template: Option::None,
-                    inverse: Option::None,
-                    block: block
-                })
-            },
-            None =>
-                // As far as I can see this is bare "{{" at the end of file.
-                Err(TemplateError::UnclosedBraces(line_no, col_no))
+impl<'a> From<&'a Subexpression> for HelperTemplate {
+    fn from(s: &Subexpression) -> HelperTemplate {
+        HelperTemplate {
+            name: s.name.clone(),
+            params: s.params.clone(),
+            hash: s.hash.clone(),
+            template: None,
+            inverse: None,
+            block: false,
         }
     }
 }
 
 impl Parameter {
-    pub fn parse<S: AsRef<str>>(source: S) -> Result<Parameter, TemplateError> {
-        let source = source.as_ref();
-        // move this to static scope when regex! is stable
-        let subexpr_regex = Regex::new(r"\(([^\)]+)\)").unwrap();
-
-        if let Some(caps) = subexpr_regex.captures(&source) {
-            let parameter = caps.at(1).unwrap();
-
-            let mut temp = String::with_capacity(source.len());
-            temp.push_str("{{");
-            temp.push_str(parameter);
-            temp.push_str("}}");
-
-            let sub_template = try!(Template::compile(temp));
-            Ok(Parameter::Subexpression(sub_template))
-        } else {
-            if let Ok(json) = Json::from_str(source) {
-                Ok(Parameter::Literal(json))
-            } else {
-                Ok(Parameter::Name(source.to_owned()))
-            }
-        }
-    }
-
     pub fn as_name(self) -> Option<String> {
         if let Parameter::Name(n) = self {
             Some(n)
@@ -181,67 +100,15 @@ impl Parameter {
             None
         }
     }
-}
 
-#[derive(PartialEq)]
-enum WhiteSpaceOmit {
-    Left = 0x01,
-    Right = 0x10,
-    Both = 0x11,
-    None = 0x00,
-}
-
-impl From<u8> for WhiteSpaceOmit {
-    fn from(n: u8) -> WhiteSpaceOmit {
-        match n {
-            0x01 => WhiteSpaceOmit::Left,
-            0x10 => WhiteSpaceOmit::Right,
-            0x11 => WhiteSpaceOmit::Both,
-            0x00 => WhiteSpaceOmit::None,
-            _ => WhiteSpaceOmit::None,
+    pub fn parse(s: &str) -> Result<Parameter, TemplateError> {
+        let mut parser = Rdp::new(StringInput::new(s));
+        if !parser.parameter() {
+            return Err(TemplateError::Unknown);
         }
-    }
-}
 
-impl BitOr<WhiteSpaceOmit> for WhiteSpaceOmit {
-    type Output = WhiteSpaceOmit;
-
-    fn bitor(self, right: WhiteSpaceOmit) -> WhiteSpaceOmit {
-        WhiteSpaceOmit::from((self as u8) | (right as u8))
-    }
-}
-
-
-fn process_whitespace(buf: &str, wso: &mut WhiteSpaceOmit) -> String {
-    let result = match *wso {
-        WhiteSpaceOmit::Left => buf.trim_left().to_string(),
-        WhiteSpaceOmit::Right => buf.trim_right().to_string(),
-        WhiteSpaceOmit::Both => buf.trim().to_string(),
-        WhiteSpaceOmit::None => buf.to_string(),
-    };
-    *wso = WhiteSpaceOmit::None;
-    result
-}
-
-fn peek_chars(it: &mut PutBackN<Chars>, n: usize) -> Option<String> {
-    let mut tmp = String::new();
-
-    for _ in 0..n {
-        if let Some(c) = it.next() {
-            tmp.push(c);
-        }
-    }
-
-    for i in tmp.chars().rev() {
-        it.put_back(i);
-    }
-
-    Some(tmp)
-}
-
-fn iter_skip<I: Iterator>(it: &mut I, n: usize) {
-    for _ in 0..n {
-        it.next();
+        let mut it = parser.queue().iter().peekable();
+        Template::parse_param(s, &mut it, s.len() - 1)
     }
 }
 
@@ -269,11 +136,12 @@ impl Template {
         Template::compile2(source, false)
     }
 
-    fn parse_subexpression<'a>(parser: &'a Rdp<'a, StringInput<'a>>,
-                               it: &'a mut Peekable<Iter<Token<Rule>>>,
+    #[inline]
+    fn parse_subexpression<'a>(source: &'a str,
+                               it: &mut Peekable<Iter<Token<Rule>>>,
                                limit: usize)
                                -> Result<Parameter, TemplateError> {
-        let espec = try!(Template::parse_expression(parser, it, limit));
+        let espec = try!(Template::parse_expression(source, it, limit));
         if let Parameter::Name(name) = espec.name {
             Ok(Parameter::Subexpression(Subexpression {
                 name: name,
@@ -286,102 +154,110 @@ impl Template {
         }
     }
 
-    fn parse_name<'a>(parser: &'a Rdp<'a, StringInput<'a>>,
-                      it: &'a mut Peekable<Iter<Token<Rule>>>,
-                      limit: usize)
+    #[inline]
+    fn parse_name<'a>(source: &'a str,
+                      it: &mut Peekable<Iter<Token<Rule>>>,
+                      _: usize)
                       -> Result<Parameter, TemplateError> {
         let name_node = it.next().unwrap();
         match name_node.rule {
-            Rule::literal => {
-                Ok(Parameter::Name(parser.slice_input(name_node.start, name_node.end).to_owned()))
-            }
-            Rule::subexpression => Template::parse_subexpression(parser, it, name_node.end),
+            Rule::literal => Ok(Parameter::Name(source[name_node.start..name_node.end].to_owned())),
+            Rule::subexpression => Template::parse_subexpression(source, it, name_node.end),
             _ => unreachable!(),
         }
     }
 
-    fn parse_param<'a>(parser: &'a Rdp<'a, StringInput<'a>>,
-                       it: &'a mut Peekable<Iter<Token<Rule>>>,
-                       limit: usize)
+    #[inline]
+    fn parse_param<'a>(source: &'a str,
+                       it: &mut Peekable<Iter<Token<Rule>>>,
+                       _: usize)
                        -> Result<Parameter, TemplateError> {
         let param = it.next().unwrap();
         let result = match param.rule {
-            Rule::reference => {
-                Parameter::Name(parser.slice_input(param.start, param.end).to_owned())
-            }
+            Rule::reference => Parameter::Name(source[param.start..param.end].to_owned()),
             Rule::literal => {
-                let s = parser.slice_input(param.start, param.end);
+                let s = &source[param.start..param.end];
                 if let Ok(json) = Json::from_str(s) {
                     Parameter::Literal(json)
                 } else {
                     Parameter::Name(s.to_owned())
                 }
             }
-            Rule::subexpression => try!(Template::parse_subexpression(parser, it, param.end)),
+            Rule::subexpression => try!(Template::parse_subexpression(source, it, param.end)),
             _ => unreachable!(),
         };
+
         loop {
-            if let Some(n) = it.peek() {
-                if n.end <= param.end {
-                    it.next();
-                } else {
+            if let Some(ref n) = it.peek() {
+                if n.end > param.end {
                     break;
                 }
             } else {
                 break;
             }
+
+            it.next();
         }
+
         Ok(result)
     }
 
-    fn parse_hash<'a>(parser: &'a Rdp<'a, StringInput<'a>>,
-                      it: &'a mut Peekable<Iter<Token<Rule>>>,
+    #[inline]
+    fn parse_hash<'a>(source: &'a str,
+                      it: &mut Peekable<Iter<Token<Rule>>>,
                       limit: usize)
                       -> Result<(String, Parameter), TemplateError> {
         let name = it.next().unwrap();
         // identifier
-        let key = parser.slice_input(name.start, name.end).to_owned();
+        let key = source[name.start..name.end].to_owned();
 
         // param
-        let value = try!(Template::parse_param(parser, it, limit));
+        let value = try!(Template::parse_param(source, it, limit));
         Ok((key, value))
     }
 
-    fn parse_expression<'a>(parser: &'a Rdp<'a, StringInput<'a>>,
-                            it: &'a mut Peekable<Iter<Token<Rule>>>,
+    #[inline]
+    fn parse_expression<'a>(source: &'a str,
+                            it: &mut Peekable<Iter<Token<Rule>>>,
                             limit: usize)
                             -> Result<ExpressionSpec, TemplateError> {
-        let name = try!(Template::parse_name(parser, it, limit));
+        let name = try!(Template::parse_name(source, it, limit));
         let mut params: Vec<Parameter> = Vec::new();
         let mut hashes: BTreeMap<String, Parameter> = BTreeMap::new();
         let mut omit_pre_ws = false;
         let mut omit_pro_ws = false;
         loop {
+            let rule;
+            let end;
             if let Some(ref token) = it.peek() {
                 if token.end <= limit {
-                    let node = it.next().unwrap();
-                    match node.rule {
-                        Rule::param => {
-                            params.push(try!(Template::parse_param(parser, it, node.end)));
-                        }
-                        Rule::hash => {
-                            let (key, value) = try!(Template::parse_hash(parser, it, node.end));
-                            hashes.insert(key, value);
-                        }
-                        Rule::pre_whitespace_omitter => {
-                            omit_pre_ws = true;
-                        }
-                        Rule::pro_whitespace_omitter => {
-                            omit_pro_ws = true;
-                        }
-                        _ => unreachable!(),
-                    }
+                    rule = token.rule;
+                    end = token.end;
                 } else {
                     break;
                 }
             } else {
                 break;
             }
+
+            match rule {
+                Rule::param => {
+                    params.push(try!(Template::parse_param(source, it, end)));
+                }
+                Rule::hash => {
+                    let (key, value) = try!(Template::parse_hash(source, it, end));
+                    hashes.insert(key, value);
+                }
+                Rule::pre_whitespace_omitter => {
+                    omit_pre_ws = true;
+                }
+                Rule::pro_whitespace_omitter => {
+                    omit_pro_ws = true;
+                }
+                _ => unreachable!(),
+            }
+
+            it.next();
         }
         Ok(ExpressionSpec {
             name: name,
@@ -392,7 +268,7 @@ impl Template {
         })
     }
 
-    pub fn compile3<S: AsRef<str>>(source: S, mapping: bool) -> Result<Template, TemplateError> {
+    pub fn compile2<S: AsRef<str>>(source: S, mapping: bool) -> Result<Template, TemplateError> {
         let source = source.as_ref();
         let mut helper_stack: VecDeque<HelperTemplate> = VecDeque::new();
         let mut template_stack: VecDeque<Template> = VecDeque::new();
@@ -410,13 +286,9 @@ impl Template {
 
         let mut it = parser.queue().iter().peekable();
         loop {
-            let mut t = template_stack.front_mut().unwrap();
-
-
-
             if let Some(ref token) = it.next() {
-                let (line_no, col_no) = i2.line_col(token.start);
 
+                let (line_no, col_no) = i2.line_col(token.start);
                 match token.rule {
                     Rule::template => {
                         template_stack.push_front(Template::new(mapping));
@@ -426,11 +298,12 @@ impl Template {
                         if omit_pro_ws {
                             text = text.trim_left();
                         }
+                        let mut t = template_stack.front_mut().unwrap();
                         t.push_element(RawString(text.to_owned()), line_no, col_no);
                     }
                     Rule::helper_block => {}
                     Rule::helper_block_start | Rule::raw_block_start => {
-                        let exp = try!(Template::parse_expression(&parser, &mut it, token.end));
+                        let exp = try!(Template::parse_expression(source, &mut it, token.end));
                         let helper_template = HelperTemplate {
                             name: exp.name.as_name().unwrap(),
                             params: exp.params,
@@ -440,6 +313,8 @@ impl Template {
                             inverse: None,
                         };
                         helper_stack.push_front(helper_template);
+
+                        let mut t = template_stack.front_mut().unwrap();
                         if exp.omit_pre_ws {
                             if let Some(el) = t.elements.pop() {
                                 if let RawString(ref text) = el {
@@ -467,8 +342,10 @@ impl Template {
                         template_stack.push_front(t);
                     }
                     Rule::helper_block_end | Rule::raw_block_end => {
-                        let exp = try!(Template::parse_expression(&parser, &mut it, token.end));
+                        let exp = try!(Template::parse_expression(source, &mut it, token.end));
+
                         if exp.omit_pre_ws {
+                            let mut t = template_stack.front_mut().unwrap();
                             if let Some(el) = t.elements.pop() {
                                 if let RawString(ref text) = el {
                                     t.elements.push(RawString(text.trim_right().to_owned()));
@@ -479,17 +356,18 @@ impl Template {
                         }
                         omit_pro_ws = exp.omit_pro_ws;
 
-                        let mut h = helper_stack.front_mut().unwrap();
+                        let mut h = helper_stack.pop_front().unwrap();
                         let close_tag_name = exp.name.as_name().unwrap();
                         if h.name == close_tag_name {
-                            let t = template_stack.pop_front().unwrap();
+                            let prev_t = template_stack.pop_front().unwrap();
                             if h.template.is_some() {
-                                h.inverse = Some(t);
+                                h.inverse = Some(prev_t);
                             } else {
-                                h.template = Some(t);
+                                h.template = Some(prev_t);
                             }
-                            let ht = helper_stack.pop_front().unwrap();
-                            t.push_element(HelperBlock(ht), line_no, col_no);
+
+                            let t = template_stack.front_mut().unwrap();
+                            t.push_element(HelperBlock(h), line_no, col_no);
                         } else {
                             return Err(TemplateError::MismatchingClosedHelper(line_no,
                                                                               col_no,
@@ -500,7 +378,8 @@ impl Template {
                     Rule::expression => {
                         // expression or helper expression
                         // ( identifier | subexpression )
-                        let exp = try!(Template::parse_expression(&parser, &mut it, token.end));
+                        let exp = try!(Template::parse_expression(source, &mut it, token.end));
+                        let mut t = template_stack.front_mut().unwrap();
                         if exp.omit_pre_ws {
                             if let Some(el) = t.elements.pop() {
                                 if let RawString(ref text) = el {
@@ -519,7 +398,8 @@ impl Template {
                     Rule::html_expression => {
                         // expression or helper expression
                         // ( identifier | subexpression )
-                        let exp = try!(Template::parse_expression(&parser, &mut it, token.end));
+                        let exp = try!(Template::parse_expression(source, &mut it, token.end));
+                        let mut t = template_stack.front_mut().unwrap();
                         if exp.omit_pre_ws {
                             if let Some(el) = t.elements.pop() {
                                 if let RawString(ref text) = el {
@@ -535,7 +415,8 @@ impl Template {
                         t.push_element(el, line_no, col_no);
                     }
                     Rule::helper_expression => {
-                        let exp = try!(Template::parse_expression(&parser, &mut it, token.end));
+                        let exp = try!(Template::parse_expression(source, &mut it, token.end));
+                        let mut t = template_stack.front_mut().unwrap();
                         if exp.omit_pre_ws {
                             if let Some(el) = t.elements.pop() {
                                 if let RawString(ref text) = el {
@@ -559,7 +440,11 @@ impl Template {
                         t.push_element(el, line_no, col_no);
                     }
                     Rule::raw_block => {}
-                    Rule::comment => {}
+                    Rule::hbs_comment => {
+                        let text = parser.slice_input(token.start + 3, token.end - 2);
+                        let mut t = template_stack.front_mut().unwrap();
+                        t.push_element(Comment(text.to_owned()), line_no, col_no);
+                    }
                     Rule::eoi => {
                         return Ok(template_stack.pop_front().unwrap());
                     }
@@ -569,303 +454,6 @@ impl Template {
                 return Ok(template_stack.pop_front().unwrap());
             }
         }
-    }
-
-    pub fn compile2<S: AsRef<str>>(source: S, mapping: bool) -> Result<Template, TemplateError> {
-        let source = source.as_ref();
-        let mut helper_stack: VecDeque<HelperTemplate> = VecDeque::new();
-        let mut template_stack: VecDeque<Template> = VecDeque::new();
-        template_stack.push_front(Template::new(mapping));
-
-        let mut buffer: String = String::new();
-        let mut state = ParserState::Text;
-
-        let mut line_no: usize = 1;
-        let mut col_no: usize = 0;
-        let mut ws_omitter = WhiteSpaceOmit::None;
-        let mut it = PutBackN::new(source.chars());
-
-        loop {
-            if let Some(c) = it.next() {
-                if c == '\n' {
-                    line_no = line_no + 1;
-                    col_no = 0;
-                } else {
-                    col_no = col_no + 1;
-                }
-
-                match c {
-                    // interested characters, peek more chars
-                    '{' | '~' | '}' => {
-                        it.put_back(c);
-
-                        // raw helper
-                        if let Some(slice) = peek_chars(&mut it, 5) {
-                            if slice == "{{{{/" {
-                                iter_skip(&mut it, 5);
-                                // TODO: remove dup code
-                                if !buffer.is_empty() {
-                                    let mut t = template_stack.front_mut().unwrap();
-                                    let buf_clone = process_whitespace(&buffer, &mut ws_omitter);
-                                    t.push_element(RawString(buf_clone), line_no, col_no);
-                                    buffer.clear();
-                                }
-                                let t = template_stack.pop_front().unwrap();
-                                let h = helper_stack.front_mut().unwrap();
-                                h.template = Some(t);
-                                state = ParserState::RawHelperEnd;
-                                continue;
-                            }
-                        }
-
-                        if let Some(slice) = peek_chars(&mut it, 4) {
-                            if slice == "{{{{" {
-                                iter_skip(&mut it, 4);
-                                // TODO: remove dup code
-                                if !buffer.is_empty() {
-                                    let mut t = template_stack.front_mut().unwrap();
-                                    let buf_clone = process_whitespace(&buffer, &mut ws_omitter);
-                                    t.push_element(RawString(buf_clone), line_no, col_no);
-                                    buffer.clear();
-                                }
-                                state = ParserState::RawHelperStart;
-                                continue;
-                            } else if slice == "}}}}" {
-                                match state {
-                                    ParserState::RawHelperStart => {
-                                        iter_skip(&mut it, 4);
-                                        let helper = try!(HelperTemplate::parse(buffer.clone(),
-                                                                                true,
-                                                                                line_no,
-                                                                                col_no));
-                                        helper_stack.push_front(helper);
-                                        template_stack.push_front(Template::new(mapping));
-
-                                        buffer.clear();
-                                        state = ParserState::RawText;
-                                        continue;
-                                    }
-
-                                    ParserState::RawHelperEnd => {
-                                        iter_skip(&mut it, 4);
-                                        let name = buffer.trim_matches(' ').to_string();
-                                        if name == helper_stack.front().unwrap().name {
-                                            let h = helper_stack.pop_front().unwrap();
-                                            let mut t = template_stack.front_mut().unwrap();
-                                            t.push_element(HelperBlock(h), line_no, col_no);
-                                            buffer.clear();
-                                            state = ParserState::Text;
-                                            continue;
-                                        } else {
-                                            return Err(MismatchingClosedHelper(
-                                                line_no, col_no,
-                                                helper_stack.front().unwrap().name.clone(),
-                                                name));
-                                        }
-                                    }
-
-                                    _ => {}
-                                }
-                            }
-                        }
-
-                        // within a raw helper, any character will be treated as raw string
-                        if state == ParserState::RawText {
-                            iter_skip(&mut it, 1);
-                            buffer.push(c);
-                            continue;
-                        }
-
-                        if let Some(mut slice) = peek_chars(&mut it, 3) {
-                            if slice == "{{~" {
-                                ws_omitter = ws_omitter | WhiteSpaceOmit::Right;
-                                // read another char and remove ~
-                                slice = peek_chars(&mut it, 4).unwrap();
-                                slice.remove(2);
-                                iter_skip(&mut it, 1);
-                            }
-                            if slice == "~}}" {
-                                ws_omitter = ws_omitter | WhiteSpaceOmit::Left;
-                                iter_skip(&mut it, 1);
-                                slice = peek_chars(&mut it, 3).unwrap();
-                            }
-                            state = match slice.as_ref() {
-                                "{{{" | "{{!" | "{{#" | "{{/" => {
-                                    iter_skip(&mut it, 3);
-                                    if !buffer.is_empty() {
-                                        let mut t = template_stack.front_mut().unwrap();
-                                        let buf_clone = process_whitespace(&buffer,
-                                                                           &mut ws_omitter);
-                                        t.push_element(RawString(buf_clone), line_no, col_no);
-                                        buffer.clear();
-                                    }
-                                    match slice.as_ref() {
-                                        "{{{" => ParserState::HtmlExpression,
-                                        "{{!" => ParserState::Comment,
-                                        "{{#" => ParserState::HelperStart,
-                                        "{{/" => {
-                                            let t = template_stack.pop_front().unwrap();
-                                            let h = helper_stack.front_mut().unwrap();
-                                            if h.template.is_some() {
-                                                h.inverse = Some(t);
-                                            } else {
-                                                h.template = Some(t);
-                                            }
-                                            ParserState::HelperEnd
-                                        }
-                                        _ => unreachable!(),  // because of check above
-                                    }
-                                }
-                                "}}}" => {
-                                    iter_skip(&mut it, 3);
-                                    let mut t = template_stack.front_mut().unwrap();
-                                    t.push_element(HTMLExpression(try!(Parameter::parse(buffer.clone().trim_matches(' ').to_string()))), line_no, col_no);
-                                    buffer.clear();
-                                    ParserState::Text
-                                }
-                                _ => {
-                                    match if slice.len() > 2 {
-                                        &slice[0..2]
-                                    } else {
-                                        slice.as_ref()
-                                    } {
-                                        "{{" => {
-                                            iter_skip(&mut it, 2);
-                                            if !buffer.is_empty() {
-                                                let mut t = template_stack.front_mut().unwrap();
-                                                let buf_clone = process_whitespace(&buffer,
-                                                                                   &mut ws_omitter);
-
-                                                t.push_element(RawString(buf_clone),
-                                                               line_no,
-                                                               col_no);
-                                                buffer.clear();
-                                            }
-                                            ParserState::Expression
-                                        }
-                                        "}}" => {
-                                            iter_skip(&mut it, 2);
-                                            match state {
-                                                ParserState::Expression => {
-                                                    if !buffer.is_empty() {
-                                                        // {{else}} or {{^}} within a helper block
-                                                        if buffer.trim() == "else" ||
-                                                           buffer.trim() == "^" {
-                                                            buffer.clear(); // drop else
-                                                            let t = template_stack.pop_front()
-                                                                                  .unwrap();
-                                                            let h = helper_stack.front_mut()
-                                                                                .unwrap();
-                                                            h.template = Some(t);
-                                                            template_stack.push_front(Template::new(mapping));
-                                                            ParserState::Text
-                                                        } else {
-                                                            if find_tokens(&buffer).len() > 1 {
-                                                                // inline helper
-                                                                let helper = try!(HelperTemplate::parse(buffer.clone(), false, line_no, col_no));
-                                                                let mut t =
-                                                                    template_stack.front_mut()
-                                                                                  .unwrap();
-                                                                t.push_element(HelperExpression(helper), line_no, col_no);
-                                                                buffer.clear();
-                                                                ParserState::Text
-                                                            } else {
-                                                                let mut t =
-                                                                    template_stack.front_mut()
-                                                                                  .unwrap();
-                                                                t.push_element(Expression(
-                                                                    try!(Parameter::parse(buffer.clone().trim_matches(' ').to_string()))), line_no, col_no);
-                                                                buffer.clear();
-                                                                ParserState::Text
-                                                            }
-                                                        }
-                                                    } else {
-                                                        return Err(UnclosedBraces(line_no, col_no));
-                                                    }
-                                                }
-                                                ParserState::Comment => {
-                                                    let mut t = template_stack.front_mut().unwrap();
-                                                    t.push_element(Comment(buffer.clone()),
-                                                                   line_no,
-                                                                   col_no);
-                                                    buffer.clear();
-                                                    ParserState::Text
-                                                }
-                                                ParserState::HelperStart => {
-                                                    let helper =
-                                                        try!(HelperTemplate::parse(buffer.clone(),
-                                                                                   true,
-                                                                                   line_no,
-                                                                                   col_no));
-                                                    helper_stack.push_front(helper);
-                                                    template_stack.push_front(Template::new(mapping));
-
-                                                    buffer.clear();
-                                                    ParserState::Text
-                                                }
-                                                ParserState::HelperEnd => {
-                                                    let name = buffer.trim_matches(' ').to_string();
-                                                    if name == helper_stack.front().unwrap().name {
-                                                        let h = helper_stack.pop_front().unwrap();
-                                                        let mut t = template_stack.front_mut()
-                                                                                  .unwrap();
-                                                        t.push_element(HelperBlock(h),
-                                                                       line_no,
-                                                                       col_no);
-                                                        buffer.clear();
-                                                        ParserState::Text
-                                                    } else {
-                                                        return Err(MismatchingClosedHelper(
-                                                            line_no, col_no,
-                                                            helper_stack.front().unwrap().name.clone(),
-                                                            name));
-                                                    }
-                                                }
-                                                _ => {
-                                                    return Err(UnexpectedClosingBraces(line_no,
-                                                                                       col_no))
-                                                }
-                                            }
-                                        }
-                                        _ => {
-                                            iter_skip(&mut it, 1);
-                                            buffer.push(c);
-                                            state
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    _ => {
-                        buffer.push(c);
-                    }
-                }
-            } else {
-                break;
-            }
-        }
-
-        if !buffer.is_empty() {
-            let mut t = template_stack.front_mut().unwrap();
-            let buf_clone = process_whitespace(&buffer, &mut ws_omitter);
-            t.push_element(RawString(buf_clone), line_no, col_no);
-        }
-
-        if !helper_stack.is_empty() {
-            return Err(UnclosedHelper(line_no, col_no, helper_stack.front().unwrap().name.clone()));
-        }
-
-        if state != ParserState::Text {
-            return Err(UnclosedExpression(line_no, col_no));
-        }
-
-        let mut t = template_stack.pop_front().unwrap();
-        if let Some(ref mut mapping) = t.mapping {
-            mapping.pop();
-        }
-
-        return Ok(t);
     }
 
     pub fn compile_with_name<S: AsRef<str>>(source: S,
@@ -886,20 +474,6 @@ pub enum TemplateElement {
     HelperExpression(HelperTemplate),
     HelperBlock(HelperTemplate),
     Comment(String),
-}
-
-#[test]
-fn test_parse_helper_start_tag() {
-    let source = "if not name compare=1".to_string();
-    let h = HelperTemplate::parse(source, true, 0, 0).ok().unwrap();
-
-    assert_eq!(h.name, "if".to_string());
-    assert_eq!(h.params,
-               vec![Parameter::Name("not".into()), Parameter::Name("name".into())]);
-
-    let key = "compare".to_string();
-    let value = h.hash.get(&key).unwrap();
-    assert_eq!(*value, Parameter::Literal(Json::U64(1)));
 }
 
 #[test]
@@ -971,11 +545,10 @@ fn test_subexpression() {
     assert_eq!(t.elements.len(), 4);
     match *t.elements.get(0).unwrap() {
         HelperExpression(ref h) => {
-            assert_eq!(h.name, "foo".to_string());
+            assert_eq!(h.name, "foo".to_owned());
             assert_eq!(h.params.len(), 1);
             if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
-                assert_eq!(*t.elements.get(0).unwrap(),
-                           Expression(Parameter::Name("bar".to_string())));
+                assert_eq!(t.name, "bar".to_owned());
             } else {
                 panic!("Subexpression expected");
             }
@@ -990,15 +563,12 @@ fn test_subexpression() {
             assert_eq!(h.name, "foo".to_string());
             assert_eq!(h.params.len(), 1);
             if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
-                assert_eq!(*t.elements.get(0).unwrap(),
-                           HelperExpression(HelperTemplate {
-                               name: "bar".to_owned(),
-                               params: vec![Parameter::Name("baz".to_owned())],
-                               hash: BTreeMap::new(),
-                               template: None,
-                               inverse: None,
-                               block: false,
-                           }));
+                assert_eq!(t.name, "bar".to_owned());
+                if let Some(&Parameter::Name(ref n)) = t.params.get(0) {
+                    assert_eq!(n, "baz");
+                } else {
+                    panic!("non-empty param expected ");
+                }
             } else {
                 panic!("Subexpression expected");
             }
@@ -1015,22 +585,19 @@ fn test_subexpression() {
             assert_eq!(h.hash.len(), 1);
 
             if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
-                assert_eq!(*t.elements.get(0).unwrap(),
-                           HelperExpression(HelperTemplate {
-                               name: "baz".to_owned(),
-                               params: vec![Parameter::Name("bar".to_owned())],
-                               hash: BTreeMap::new(),
-                               template: None,
-                               inverse: None,
-                               block: false,
-                           }));
+                assert_eq!(t.name, "baz".to_owned());
+                if let Some(&Parameter::Name(ref n)) = t.params.get(0) {
+                    assert_eq!(n, "bar");
+                } else {
+                    panic!("non-empty param expected ");
+                }
+
             } else {
                 panic!("Subexpression expected (baz bar)");
             }
 
             if let &Parameter::Subexpression(ref t) = h.hash.get("then").unwrap() {
-                assert_eq!(*t.elements.get(0).unwrap(),
-                           Expression(Parameter::Name("bar".to_string())));
+                assert_eq!(t.name, "bar".to_owned());
             } else {
                 panic!("Subexpression expected (bar)");
             }
@@ -1054,30 +621,13 @@ fn test_white_space_omitter() {
 }
 
 #[test]
-fn test_find_tokens() {
-    let source: String = "hello   good (nice) (hello world)\n\t\t world hello=world hello=(world) \
-                          hello=(world 0)"
-                             .into();
-    let tokens: Vec<String> = find_tokens(&source[..]);
-    assert_eq!(tokens,
-               vec!["hello".to_string(),
-                    "good".to_string(),
-                    "(nice)".to_string(),
-                    "(hello world)".to_string(),
-                    "world".to_string(),
-                    "hello=world".to_string(),
-                    "hello=(world)".to_string(),
-                    "hello=(world 0)".to_string()]);
-}
-
-#[test]
 fn test_unclosed_expression() {
     let sources = ["{{invalid", "{{{invalid", "{{invalid}", "{{!hello"];
     for s in sources.iter() {
         let result = Template::compile(s.to_owned());
         if let Err(e) = result {
             match e {
-                TemplateError::UnclosedExpression(_, _) => {}
+                TemplateError::Unknown => {}
                 _ => {
                     panic!("Unexpected error type {}", e);
                 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -296,19 +296,9 @@ impl Template {
             return Err(TemplateError::Unknown);
         }
 
-        for i in parser.queue() {
-            println!("{:?} {:?}", i, source[i.start..i.end].to_owned());
-        }
-
-        println!("=======");
-
         let mut it = parser.queue().iter().peekable();
         loop {
             if let Some(ref token) = it.next() {
-                println!("++++ {:?} {:?}",
-                         token.rule,
-                         source[token.start..token.end].to_owned());
-
                 let (line_no, col_no) = i2.line_col(token.start);
                 match token.rule {
                     Rule::template => {
@@ -475,7 +465,6 @@ impl Template {
                     }
                     _ => {}
                 }
-                println!("----");
             } else {
                 return Ok(template_stack.pop_front().unwrap());
             }

--- a/src/template.rs
+++ b/src/template.rs
@@ -38,7 +38,7 @@ pub struct Subexpression {
 
 impl Subexpression {
     pub fn is_helper(&self) -> bool {
-        self.params.is_empty() && self.hash.is_empty()
+        !(self.params.is_empty() && self.hash.is_empty())
     }
 
     pub fn as_template(&self) -> Template {
@@ -245,7 +245,7 @@ impl Template {
             let rule;
             let end;
             if let Some(ref token) = it.peek() {
-                if token.end <= limit {
+                if token.end < limit {
                     rule = token.rule;
                     end = token.end;
                 } else {
@@ -294,6 +294,10 @@ impl Template {
 
         if !parser.handlebars() {
             return Err(TemplateError::Unknown);
+        }
+
+        for i in parser.queue() {
+            println!("{:?}", i);
         }
 
         let mut it = parser.queue().iter().peekable();
@@ -380,7 +384,7 @@ impl Template {
                             } else {
                                 h.template = Some(prev_t);
                             }
-
+                            println!("{:?}", template_stack);
                             let t = template_stack.front_mut().unwrap();
                             t.elements.push(HelperBlock(h));
                         } else {


### PR DESCRIPTION
Fixes #81 

I decided to use [pest](https://github.com/dragostis/pest) to replace current custom parser for maintainability and correctness. 

Tasks:

- [x] Grammar
- [x] Rebuild parser with pest Rdp.queue() results
- [x] Keeping error tracking: report template error with line/column number
- [x] Keeping template element maps, line/column number for each item
- [x] Retain leading whitespaces in text
