### PR TITLE
fixed #each helper to access parent via ../ instead of ../../

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,13 +32,42 @@ fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a str) {
                 continue;
             }
             ".." => {
-                path_stack.pop_back();
+                let item = path_stack.pop_back();
+                if let Some(item) = item {
+                    if let (Some(a), Some(z)) = (item.chars().nth(0), item.chars().last()) {
+                        // if the item we just popped off is an array index,
+                        // pop off one more to make it behave more like the
+                        // Javascript implementation
+                        if a == '[' && z == ']' {
+                            path_stack.pop_back();
+                        }
+                    }
+                }
             }
             _ => {
                 for dot_p in p.split('.') {
-                    // if dot_p != "this" {
-                    path_stack.push_back(dot_p);
-                    // }
+                    let skip = match (path_stack.front(), path_stack.back()) {
+                        (Some(ref a), Some(ref z)) => {
+                            // if this path starts with "this", then we're not going
+                            // to skip anything
+                            if **a == "this" {
+                                false
+                            } else {
+                                // if the path doesn't start with "this" and
+                                // the last element on the deque is "p",
+                                // then don't push it
+                                **z == dot_p
+                            }
+
+                        }
+                        _ => false
+                    };
+
+                    if !skip {
+                        // if dot_p != "this" {
+                        path_stack.push_back(dot_p);
+                        // }
+                    }
                 }
             }
         }
@@ -288,6 +317,12 @@ mod test {
                    "programmer".to_string());
         assert_eq!(ctx.navigate(".", "titles.[0]").render(),
                    "programmer".to_string());
+
+        assert_eq!(ctx.navigate(".", "titles[0]/../age").render(),
+                    "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
+                    "27".to_string());
+
     }
 
     #[test]
@@ -413,6 +448,12 @@ mod test {
                    "programmer".to_string());
         assert_eq!(ctx.navigate(".", "titles.[0]").render(),
                    "programmer".to_string());
+
+        assert_eq!(ctx.navigate(".", "titles[0]/../age").render(),
+                    "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
+                    "27".to_string());
+
     }
 
     #[test]

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -22,7 +22,7 @@ impl HelperDef for LookupHelper {
             RenderError::new("Param not found for helper \"lookup\"")
         }));
         let index = try!(h.param(1).ok_or_else(|| {
-            RenderError::new("Insuffitient params for helper \"lookup\"")
+            RenderError::new("Insufficient params for helper \"lookup\"")
         }));
 
         let null = Json::Null;


### PR DESCRIPTION
We're using handlebars-rust in [Habitat](https://www.habitat.sh/). It's fanstastic, thank you!

A [user reported](https://github.com/habitat-sh/habitat/issues/1083) that `../` is not working correctly in an `each` block. Specifically, when a template should be able to use `../` to access a parent value, it instead requires `../../`, as the array index is included in the path as part of the logic in [context:: parse_json_visitor](https://github.com/sunng87/handlebars-rust/blob/565c1353cbc36e81479804510a98123131e0aaf0/src/context.rs#L28). This PR contains a fix for this issue.

Included is a test based off the following manual test via [http://tryhandlebarsjs.com/](http://tryhandlebarsjs.com/):

If I use this template:

```
{{#each a.c}} 
  d={{d}} b={{../a.b}} 
{{/each}}
```

and the following JSON:

```
{
  "a": {
    "b": 99,
    "c": [
      { "d": 100},
      { "d": 200}
    ]
  }
}
```

tryhandlebarsjs.com renders:

```
  d=100 b=99 
  d=200 b=99 
```  

handlebars-rust currently renders the same template and data like this:

```
  d=100 b=
  d=200 b=
```  

Cheers -
Dave


