### PR TITLE
Added local path root for #if and #each

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,42 +32,11 @@ fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a str) {
                 continue;
             }
             ".." => {
-                let item = path_stack.pop_back();
-                if let Some(item) = item {
-                    if let (Some(a), Some(z)) = (item.chars().nth(0), item.chars().last()) {
-                        // if the item we just popped off is an array index,
-                        // pop off one more to make it behave more like the
-                        // Javascript implementation
-                        if a == '[' && z == ']' {
-                            path_stack.pop_back();
-                        }
-                    }
-                }
+                path_stack.pop_back();
             }
             _ => {
                 for dot_p in p.split('.') {
-                    let skip = match (path_stack.front(), path_stack.back()) {
-                        (Some(ref a), Some(ref z)) => {
-                            // if this path starts with "this", then we're not going
-                            // to skip anything
-                            if **a == "this" {
-                                false
-                            } else {
-                                // if the path doesn't start with "this" and
-                                // the last element on the deque is "p",
-                                // then don't push it
-                                **z == dot_p
-                            }
-
-                        }
-                        _ => false
-                    };
-
-                    if !skip {
-                        // if dot_p != "this" {
-                        path_stack.push_back(dot_p);
-                        // }
-                    }
+                    path_stack.push_back(dot_p);
                 }
             }
         }
@@ -319,9 +288,9 @@ mod test {
                    "programmer".to_string());
 
         assert_eq!(ctx.navigate(".", "titles[0]/../age").render(),
-                    "27".to_string());
+                   "27".to_string());
         assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
-                    "27".to_string());
+                   "27".to_string());
 
     }
 
@@ -450,9 +419,9 @@ mod test {
                    "programmer".to_string());
 
         assert_eq!(ctx.navigate(".", "titles[0]/../age").render(),
-                    "27".to_string());
+                   "27".to_string());
         assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
-                    "27".to_string());
+                   "27".to_string());
 
     }
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -30,6 +30,9 @@ impl HelperDef for EachHelper {
                 let path = rc.get_path().clone();
 
                 rc.promote_local_vars();
+                if let Some(path_root) = value.path_root() {
+                    rc.set_local_path_root(path_root.to_owned());
+                }
 
                 debug!("each value {:?}", value.value());
                 let rendered = match value.value() {
@@ -45,8 +48,6 @@ impl HelperDef for EachHelper {
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);
                             }
-                            // FIXME: context for literal
-
                             try!(t.render(c, r, rc));
                         }
                         Ok(())
@@ -195,15 +196,15 @@ mod test {
     #[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type")))]
     fn test_each_with_parent() {
 
-        let json_str = r#"{"a":{"b":99,"c":[{"d":100},{"d":200}]}}"#;
+        let json_str = r#"{"a":{"a":99,"c":[{"d":100},{"d":200}]}}"#;
 
         let data = Json::from_str(json_str).unwrap();
-        println!("data: {}", data);
+        // println!("data: {}", data);
 
         // previously, to access the parent in an each block,
         // a user would need to specify ../../b, as the path
         // that is computed includes the array index: ./a.c.[0]
-        let t0 = Template::compile("{{#each a.c}} d={{d}} b={{../a.b}} {{/each}}".to_string())
+        let t0 = Template::compile("{{#each a.c}} d={{d}} b={{../a.a}} {{/each}}".to_string())
                      .ok()
                      .unwrap();
 

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -19,6 +19,9 @@ impl HelperDef for IfHelper {
                           .ok_or_else(|| RenderError::new("Param not found for helper \"if\"")));
 
         let mut value = param.value().is_truthy();
+        if let Some(root_path) = param.path_root() {
+            rc.set_local_path_root(root_path.to_owned());
+        }
 
         if !self.positive {
             value = !value;
@@ -43,6 +46,9 @@ pub static UNLESS_HELPER: IfHelper = IfHelper { positive: false };
 mod test {
     use template::Template;
     use registry::Registry;
+    #[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type")))]
+    use serialize::json::Json;
+    use helpers::WITH_HELPER;
 
     #[test]
     fn test_if() {
@@ -65,4 +71,29 @@ mod test {
         assert_eq!(r2.ok().unwrap(), "".to_string());
     }
 
+    #[test]
+    #[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type")))]
+    fn test_if_context() {
+        let json_str = r#"{"a":{"b":99,"c":{"d": true}}}"#;
+        let data = Json::from_str(json_str).unwrap();
+
+        let t0 = Template::compile("{{#if a.c.d}}hello {{a.b}}{{/if}}".to_string())
+                     .ok()
+                     .unwrap();
+        let t1 = Template::compile("{{#with a}}{{#if c.d}}hello {{../a.b}}{{/if}}{{/with}}"
+                                       .to_string())
+                     .ok()
+                     .unwrap();
+
+        let mut handlebars = Registry::new();
+        handlebars.register_helper("with", Box::new(WITH_HELPER));
+        handlebars.register_template("t0", t0);
+        handlebars.register_template("t1", t1);
+
+        let r0 = handlebars.render("t0", &data);
+        assert_eq!(r0.ok().unwrap(), "hello 99".to_string());
+
+        let r1 = handlebars.render("t1", &data);
+        assert_eq!(r1.ok().unwrap(), "hello 99".to_string());
+    }
 }


### PR DESCRIPTION
This is to address issue seen at https://github.com/habitat-sh/habitat/issues/1083

The handlebars js implementation has a special path resolver, that when using `../` the base it set to block param root, while using `.` it's local root.

This patch is to keep handlebars-rust behaves same with js impl.