### PR TITLE
Fix bug where nested scopes don't resolve parent context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -291,6 +291,18 @@ mod test {
                    "27".to_string());
         assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
                    "27".to_string());
+        assert_eq!(ctx.navigate(".", "titles.[0]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles.[0]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "titles[1]/../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles[1]/../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "titles.[1]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles.[1]/../../age").render(),
+                   "27".to_string());
 
     }
 
@@ -422,7 +434,18 @@ mod test {
                    "27".to_string());
         assert_eq!(ctx.navigate(".", "this.titles[0]/../age").render(),
                    "27".to_string());
-
+        assert_eq!(ctx.navigate(".", "titles.[0]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles.[0]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "titles[1]/../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles[1]/../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "titles.[1]/../../age").render(),
+                   "27".to_string());
+        assert_eq!(ctx.navigate(".", "this.titles.[1]/../../age").render(),
+                   "27".to_string());
     }
 
     #[test]

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -49,7 +49,14 @@ impl HelperDef for EachHelper {
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);
                             }
+
+                            let current_path = rc.get_path().clone();
+                            let local_path_root = rc.get_local_path_root().to_string().clone();
+                            let current_template = rc.current_template.clone();
                             try!(t.render(c, r, rc));
+                            rc.set_path(current_path);
+                            rc.set_local_path_root(local_path_root);
+                            rc.current_template = current_template;
                         }
                         Ok(())
                     }
@@ -67,8 +74,13 @@ impl HelperDef for EachHelper {
                                 let new_path = format!("{}/{}.[{}]", path, inner_path, k);
                                 rc.set_path(new_path);
                             }
-
+                            let current_path = rc.get_path().clone();
+                            let local_path_root = rc.get_local_path_root().to_string().clone();
+                            let current_template = rc.current_template.clone();
                             try!(t.render(c, r, rc));
+                            rc.set_path(current_path);
+                            rc.set_local_path_root(local_path_root);
+                            rc.current_template = current_template;
                         }
 
                         Ok(())
@@ -121,7 +133,13 @@ impl HelperDef for EachHelper {
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);
                             }
+                            let current_path = rc.get_path().clone();
+                            let local_path_root = rc.get_local_path_root().to_string().clone();
+                            let current_template = rc.current_template.clone();
                             try!(t.render(c, r, rc));
+                            rc.set_path(current_path);
+                            rc.set_local_path_root(local_path_root);
+                            rc.current_template = current_template;
                         }
                         Ok(())
                     }
@@ -139,8 +157,13 @@ impl HelperDef for EachHelper {
                                 debug!("each value {:?}", new_path);
                                 rc.set_path(new_path);
                             }
-
+                            let current_path = rc.get_path().clone();
+                            let local_path_root = rc.get_local_path_root().to_string().clone();
+                            let current_template = rc.current_template.clone();
                             try!(t.render(c, r, rc));
+                            rc.set_path(current_path);
+                            rc.set_local_path_root(local_path_root);
+                            rc.current_template = current_template;
                         }
 
                         Ok(())
@@ -239,6 +262,23 @@ mod test {
         assert_eq!(r1.ok().unwrap(), "100:200".to_string());
     }
 
+    #[test]
+    #[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type")))]
+    fn test_nested_each_with_parent_if() {
+        let json_str = r#"{"a": [{"b": true}], "b": [[1, 2, 3],[4, 5]]}"#;
+
+        let data = Json::from_str(json_str).unwrap();
+        let t0 = Template::compile("{{#each b}}{{#if ../../a}}{{#each this}}{{this}}{{/each}}{{/if}}{{/each}}"
+                                   .to_string())
+            .ok()
+            .unwrap();
+
+        let mut handlebars = Registry::new();
+        handlebars.register_template("t0", t0);
+
+        let r1 = handlebars.render("t0", &data);
+        assert_eq!(r1.ok().unwrap(), "12345".to_string());
+    }
     #[test]
     fn test_nested_array() {
         let t0 = Template::compile("{{#each this.[0]}}{{this}}{{/each}}".to_owned()).ok().unwrap();


### PR DESCRIPTION
This change fixes a bug where for the template

```
{{#each b}}{{#if ../../a}}{{#each this}}{{this}}{{/each}}{{/if}}{{/each}}
```

and the input

```
{"a": [{"b": true}], "b": [[1, 2, 3],[4, 5]]}
```

the output `123` would be produced. The correct output `12345`
is produced after the fix. While this change definitely fixes the problem,
a cleaner solution would be to have `RenderContext` implement  the `Clone` trait and cloning it in the call to `render` in the `each` helper.