### PR TITLE
Block params [WIP]

### DIFF
--- a/examples/template.hbs
+++ b/examples/template.hbs
@@ -5,10 +5,10 @@
   <body>
     <h1>CSL {{year}}</h1>
     <ul>
-    {{#each teams~}}
+    {{#each teams as |t| ~}}
       <li class="{{ranking_label @index ../teams}}">
       {{~log @index~}}
-      <b>{{name}}</b>: {{format pts ~}}
+      <b>{{t.name}}</b>: {{format t.pts ~}}
       </li>
     {{/each~}}
     </ul>

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,7 +19,7 @@ pub type Object = BTreeMap<String, Json>;
 
 /// The context wrap data you render on your templates.
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Context {
     data: Json,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -178,6 +178,20 @@ impl JsonRender for Json {
     }
 }
 
+#[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type")))]
+pub fn to_json<T>(src: &T) -> Json
+    where T: ToJson
+{
+    src.to_json()
+}
+
+#[cfg(feature = "serde_type")]
+pub fn to_json<T>(src: &T) -> Json
+    where T: Serialize
+{
+    value::to_value(src)
+}
+
 impl JsonTruthy for Json {
     fn is_truthy(&self) -> bool {
         match *self {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -34,8 +34,8 @@ impl_rdp! {
 
         param = { !["as"] ~ (literal | reference | subexpression) }
         hash = { identifier ~ ["="] ~ param }
-        block_params = { ["as"] ~ ["|"] ~ identifier ~ identifier? ~ ["|"]}
-        exp_line = _{ identifier ~ (hash|param)* ~ block_params?}
+        block_param = { ["as"] ~ ["|"] ~ identifier ~ identifier? ~ ["|"]}
+        exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
 
         subexpression = { ["("] ~ name ~ (hash|param)* ~ [")"] }
 
@@ -292,11 +292,11 @@ fn test_raw_block() {
 }
 
 #[test]
-fn test_block_params() {
+fn test_block_param() {
     let s = vec!["as |person|", "as |key val|"];
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
-        assert!(rdp.block_params());
+        assert!(rdp.block_param());
         assert!(rdp.end());
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -34,7 +34,7 @@ impl_rdp! {
 
         param = { !["as"] ~ (literal | reference | subexpression) }
         hash = { identifier ~ ["="] ~ param }
-        block_params = { ["as"] ~ ["|"] ~ identifier+ ~ ["|"]}
+        block_params = { ["as"] ~ ["|"] ~ identifier ~ identifier? ~ ["|"]}
         exp_line = _{ identifier ~ (hash|param)* ~ block_params?}
 
         subexpression = { ["("] ~ name ~ (hash|param)* ~ [")"] }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -86,7 +86,6 @@ impl HelperDef for EachHelper {
                                 local_rc.set_path(new_path);
                             }
 
-                            try!(t.render(c, r, &mut local_rc));
                             if let Some((bp_key, bp_val)) = h.block_param_pair() {
                                 let mut map = BTreeMap::new();
                                 map.insert(bp_key.to_string(), k.to_json());

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -294,4 +294,20 @@ mod test {
         assert_eq!(r0, "12345");
     }
 
+    #[test]
+    fn test_each_object_block_param() {
+        let t0 = Template::compile("{{#each this as |k v|}}{{#with k as |inner_k|}}{{inner_k}}{{/with}}:{{v}}|{{/each}}".to_string())
+                     .ok()
+                     .unwrap();
+
+        let mut handlebars = Registry::new();
+        handlebars.register_template("t0", t0);
+
+        let m = btreemap!{
+            "ftp".to_string() => 21,
+            "http".to_string() => 80
+        };
+        let r0 = handlebars.render("t0", &m);
+        assert_eq!(r0.ok().unwrap(), "ftp:21|http:80|".to_string());
+    }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -54,7 +54,6 @@ impl HelperDef for EachHelper {
                             }
 
                             if let Some(block_param) = h.block_param() {
-                                // need better impl
                                 let mut map = BTreeMap::new();
                                 map.insert(block_param.to_string(), list[i].to_json());
                                 local_rc.push_block_context(&map);
@@ -88,6 +87,18 @@ impl HelperDef for EachHelper {
                             }
 
                             try!(t.render(c, r, &mut local_rc));
+                            if let Some((bp_key, bp_val)) = h.block_param_pair() {
+                                let mut map = BTreeMap::new();
+                                map.insert(bp_key.to_string(), k.to_json());
+                                map.insert(bp_val.to_string(), obj.get(k).unwrap().to_json());
+                                local_rc.push_block_context(&map);
+                            }
+
+                            try!(t.render(c, r, &mut local_rc));
+
+                            if h.block_param().is_some() {
+                                local_rc.pop_block_context();
+                            }
                         }
 
                         Ok(())
@@ -150,7 +161,18 @@ impl HelperDef for EachHelper {
                                 debug!("each value {:?}", new_path);
                                 local_rc.set_path(new_path);
                             }
+
+                            if let Some(block_param) = h.block_param() {
+                                let mut map = BTreeMap::new();
+                                map.insert(block_param.to_string(), value::to_value(&list[i]));
+                                local_rc.push_block_context(&map);
+                            }
+
                             try!(t.render(c, r, &mut local_rc));
+
+                            if h.block_param().is_some() {
+                                local_rc.pop_block_context();
+                            }
                         }
                         Ok(())
                     }
@@ -173,7 +195,19 @@ impl HelperDef for EachHelper {
                                 local_rc.set_path(new_path);
                             }
 
+                            if let Some((bp_key, bp_val)) = h.block_param_pair() {
+                                let mut map = BTreeMap::new();
+                                map.insert(bp_key.to_string(), value::to_value(&k));
+                                map.insert(bp_val.to_string(),
+                                           value::to_value(&obj.get(k).unwrap()));
+                                local_rc.push_block_context(&map);
+                            }
+
                             try!(t.render(c, r, &mut local_rc));
+
+                            if h.block_param().is_some() {
+                                local_rc.pop_block_context();
+                            }
                         }
 
                         Ok(())

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -140,6 +140,46 @@ mod test {
     }
 
     #[test]
+    fn test_with_block_param() {
+        let addr = Address {
+            city: "Beijing".to_string(),
+            country: "China".to_string(),
+        };
+
+        let person = Person {
+            name: "Ning Sun".to_string(),
+            age: 27,
+            addr: addr,
+            titles: vec!["programmer".to_string(), "cartographier".to_string()],
+        };
+
+        let t0 = Template::compile("{{#with addr as |a|}}{{a.city}}{{/with}}".to_string())
+                     .ok()
+                     .unwrap();
+        let t1 = Template::compile("{{#with notfound as |c|}}hello{{else}}world{{/with}}"
+                                       .to_string())
+                     .ok()
+                     .unwrap();
+        let t2 = Template::compile("{{#with addr/country as |t|}}{{t}}{{/with}}".to_string())
+                     .ok()
+                     .unwrap();
+
+        let mut handlebars = Registry::new();
+        handlebars.register_template("t0", t0);
+        handlebars.register_template("t1", t1);
+        handlebars.register_template("t2", t2);
+
+        let r0 = handlebars.render("t0", &person);
+        assert_eq!(r0.ok().unwrap(), "Beijing".to_string());
+
+        let r1 = handlebars.render("t1", &person);
+        assert_eq!(r1.ok().unwrap(), "world".to_string());
+
+        let r2 = handlebars.render("t2", &person);
+        assert_eq!(r2.ok().unwrap(), "China".to_string());
+    }
+
+    #[test]
     fn test_with_in_each() {
         let addr = Address {
             city: "Beijing".to_string(),


### PR DESCRIPTION
Fixes #42

Add support for block params like:

```handlebars
{{#each people as |person|}}
...
{{/each}}
```
Steps:

- [x] grammar
- [x] template parser
- [x] context support for block params
- update built-in helpers
  - [x] each
  - [x] with

