### PR TITLE
Modified HTML escaping to make it much faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "^0.8.0", optional = true }
 serde_json = { version = "^0.8.0", optional = true }
 serde_derive = { version = "^0.8.10", optional = true }
 pest = "^0.3.0"
+lazy_static = "0.2.1"
+regex = "0.1.77"
 
 [features]
 default = ["rustc_ser_type"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,10 @@ extern crate serde;
 #[cfg(feature = "serde_type")]
 extern crate serde_json;
 
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
+
 pub use self::template::Template;
 pub use self::error::{TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::registry::{EscapeFn, no_escape, html_escape, Registry as Handlebars};


### PR DESCRIPTION
I was able to change the performance of the html escaping as said in #109. But I was unable to use `Cow` due to lifetime issues. This means that when we don't have HTML to scape in the text the function is not as fast as it could be. Here some stats:

```
test bench_hanlebars_old_no_html  ... bench:       1,120 ns/iter (+/- 13)
test bench_hanlebars_old_xml      ... bench:     998,707 ns/iter (+/- 37,883)
test bench_hanlebars_new_no_html  ... bench:         224 ns/iter (+/- 6)
test bench_handlebars_new_xml     ... bench:     316,160 ns/iter (+/- 5,578)
test bench_regex_iter_no_html     ... bench:         198 ns/iter (+/- 4)
test bench_regex_iter_xml         ... bench:     323,962 ns/iter (+/- 4,807)
```

So, in the case of a text with no HTML characters, the escaping is done about 5 times faster (even though it could be a bit faster, from 224ns to 198ns). And in the case of text with HTML (I used a XML file) the reduction is in more that 3 times. In this case seems to be the fastest way to do it.
