### PR TITLE
Making partial4 default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
 script:
   - |
       cargo test &&
-      cargo test --features partial4 &&
-      travis-cargo --only nightly test -- --no-default-features
+      cargo test --features partial_legacy &&
+      travis-cargo --only nightly test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,12 @@ serde = { version = "^0.8.0", optional = true }
 serde_derive = { version = "^0.8.10", optional = true }
 
 [features]
-default = ["rustc_ser_type"]
+default = ["rustc_ser_type", "partial4"]
 rustc_ser_type = ["rustc-serialize"]
 serde_type = ["serde_json"]
 unstable = ["serde_type", "serde", "serde_derive"]
 partial4 = []
+partial_legacy = []
 
 [dev-dependencies]
 env_logger = "^0.3.2"

--- a/README.md
+++ b/README.md
@@ -103,12 +103,10 @@ embed you page into this parent.
 You can find a real example for template inheritance in
 `examples/partials.rs`, and templates used by this file.
 
-From 0.21 we support Handlebars 4.0 partial syntax with crate feature
-`partial4`. Original partial syntax via `block`, `partial` helpers are
-still support at the moment. But no doubt `partial4` will become
-default in future releases. There is no rust code difference between
-the syntax, just template change. Examples can be find in
-`examples/partials.rs`.
+From 0.23 we support Handlebars 4.0 partial syntax by
+default. Original partial syntax via `block`, `partial` helpers are
+still supported via feature flag `partial_legacy`. Examples can be
+find in `examples/partials.rs`.
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,10 @@ find in `examples/partials.rs`.
   * if
   * with
   * lookup
-  * partial
-  * block
-  * include `>`
   * log
 * Custom helper
 * Parameter and hashes for helper, block params
-* Partials, include (new partial syntax via crate feature `partial4`)
+* Partials, include, template inheritance
 * Omitting whitespace with `~`
 * Subexpression `{{(foo bar)}}`
 * Json expression `a.b.[0]` and `a.b.[c]`
@@ -146,7 +143,7 @@ find in `examples/partials.rs`.
 
 * Mustache block (use `if`/`each` instead)
 * Chained else
-* ...
+* Decorators
 
 Feel free to report an issue if you find something broken. We aren't
 going to implement all features of handlebars-js, but we should have a

--- a/examples/partials.rs
+++ b/examples/partials.rs
@@ -45,7 +45,7 @@ fn main() {
 #[cfg(feature = "serde_type")]
 fn main() {}
 
-#[cfg(all(feature = "partial4", feature = "rustc_ser_type"))]
+#[cfg(all(feature = "partial4", feature = "rustc_ser_type", not(feature="serde_type")))]
 fn main() {
     env_logger::init().unwrap();
     let mut handlebars = Handlebars::new();

--- a/examples/partials.rs
+++ b/examples/partials.rs
@@ -9,18 +9,19 @@ extern crate maplit;
 use std::path::Path;
 use handlebars::Handlebars;
 
-#[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type"), not(feature = "partial4")))]
+#[cfg(all(feature = "rustc_ser_type", not(feature = "serde_type"), feature = "partial_legacy", not(feature = "partial4")))]
 fn main() {
     env_logger::init().unwrap();
     let mut handlebars = Handlebars::new();
 
-    handlebars.register_template_file("template", &Path::new("./examples/partials/template2.hbs"))
+    handlebars.register_template_file("template",
+                                      &Path::new("./examples/partials_legacy/template2.hbs"))
               .ok()
               .unwrap();
-    handlebars.register_template_file("base0", &Path::new("./examples/partials/base0.hbs"))
+    handlebars.register_template_file("base0", &Path::new("./examples/partials_legacy/base0.hbs"))
               .ok()
               .unwrap();
-    handlebars.register_template_file("base1", &Path::new("./examples/partials/base1.hbs"))
+    handlebars.register_template_file("base1", &Path::new("./examples/partials_legacy/base1.hbs"))
               .ok()
               .unwrap();
 
@@ -49,14 +50,14 @@ fn main() {
     env_logger::init().unwrap();
     let mut handlebars = Handlebars::new();
 
-    handlebars.register_template_file("template", &Path::new("./examples/partial4/template2.hbs"))
+    handlebars.register_template_file("template", &Path::new("./examples/partials/template2.hbs"))
               .ok()
               .unwrap();
 
-    handlebars.register_template_file("base0", &Path::new("./examples/partial4/base0.hbs"))
+    handlebars.register_template_file("base0", &Path::new("./examples/partials/base0.hbs"))
               .ok()
               .unwrap();
-    handlebars.register_template_file("base1", &Path::new("./examples/partial4/base1.hbs"))
+    handlebars.register_template_file("base1", &Path::new("./examples/partials/base1.hbs"))
               .ok()
               .unwrap();
 

--- a/examples/partials/base0.hbs
+++ b/examples/partials/base0.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base0.hbs</h1></div>
-    {{~#block page}}{{/block~}}
+    {{~> page}}
   </body>
 </html>

--- a/examples/partials/base1.hbs
+++ b/examples/partials/base1.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base1.hbs</h1></div>
-    {{~#block page}}{{/block~}}
+    {{~> page}}
   </body>
 </html>

--- a/examples/partials/template2.hbs
+++ b/examples/partials/template2.hbs
@@ -1,5 +1,5 @@
-{{#partial page}}
+{{#*inline "page"}}
   <p>Rendered in partial, parent is {{parent}}<p>
-{{/partial}}
+{{/inline}}
 {{! remove whitespaces with ~ }}
 {{~> (parent)~}}

--- a/examples/partials_legacy/base0.hbs
+++ b/examples/partials_legacy/base0.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base0.hbs</h1></div>
-    {{~> page}}
+    {{~#block page}}{{/block~}}
   </body>
 </html>

--- a/examples/partials_legacy/base1.hbs
+++ b/examples/partials_legacy/base1.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base1.hbs</h1></div>
-    {{~> page}}
+    {{~#block page}}{{/block~}}
   </body>
 </html>

--- a/examples/partials_legacy/template2.hbs
+++ b/examples/partials_legacy/template2.hbs
@@ -1,5 +1,5 @@
-{{#*inline "page"}}
+{{#partial page}}
   <p>Rendered in partial, parent is {{parent}}<p>
-{{/inline}}
+{{/partial}}
 {{! remove whitespaces with ~ }}
 {{~> (parent)~}}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,6 +1,6 @@
 use pest::prelude::*;
 
-#[cfg(not(feature="partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 impl_rdp! {
     grammar! {
         whitespace = _{ [" "]|["\t"]|["\n"]|["\r"] }

--- a/src/helpers/helper_partial.rs
+++ b/src/helpers/helper_partial.rs
@@ -17,7 +17,7 @@ pub struct BlockHelper;
 #[derive(Clone, Copy)]
 pub struct PartialHelper;
 
-#[cfg(not(feature = "partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 impl HelperDef for IncludeHelper {
     fn call(&self,
             c: &Context,
@@ -183,13 +183,13 @@ impl HelperDef for PartialHelper {
 }
 
 pub static INCLUDE_HELPER: IncludeHelper = IncludeHelper;
-#[cfg(not(feature = "partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 pub static BLOCK_HELPER: BlockHelper = BlockHelper;
-#[cfg(not(feature = "partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 pub static PARTIAL_HELPER: PartialHelper = PartialHelper;
 
 #[cfg(test)]
-#[cfg(not(feature = "partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 mod test {
     use template::Template;
     use registry::Registry;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -7,7 +7,7 @@ pub use self::helper_each::EACH_HELPER;
 pub use self::helper_with::WITH_HELPER;
 pub use self::helper_lookup::LOOKUP_HELPER;
 pub use self::helper_raw::RAW_HELPER;
-#[cfg(not(feature = "partial4"))]
+#[cfg(all(feature="partial_legacy", not(feature="partial4")))]
 pub use self::helper_partial::{INCLUDE_HELPER, BLOCK_HELPER, PARTIAL_HELPER};
 #[cfg(feature = "partial4")]
 pub use self::helper_partial::INCLUDE_HELPER;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -74,7 +74,7 @@ impl Registry {
         r.setup_builtins()
     }
 
-    #[cfg(not(feature = "partial4"))]
+    #[cfg(all(feature="partial_legacy", not(feature="partial4")))]
     fn setup_builtins(mut self) -> Registry {
         self.register_helper("if", Box::new(helpers::IF_HELPER));
         self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
@@ -290,7 +290,7 @@ mod test {
     use helpers::HelperDef;
     use context::Context;
     use support::str::StringWriter;
-    #[cfg(not(feature = "partial4"))]
+    #[cfg(all(feature="partial_legacy", not(feature="partial4")))]
     use error::TemplateRenderError;
 
     #[derive(Clone, Copy)]
@@ -308,11 +308,11 @@ mod test {
         }
     }
 
-    #[cfg(not(feature = "partial4"))]
+    #[cfg(all(feature="partial_legacy", not(feature="partial4")))]
     static DUMMY_HELPER: DummyHelper = DummyHelper;
 
     #[test]
-    #[cfg(not(feature = "partial4"))]
+    #[cfg(all(feature="partial_legacy", not(feature="partial4")))]
     fn test_registry_operations() {
         let mut r = Registry::new();
 
@@ -375,7 +375,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "partial4"))]
+    #[cfg(all(feature="partial_legacy", not(feature="partial4")))]
     fn test_template_render() {
         let mut r = Registry::new();
 


### PR DESCRIPTION
The `partial4` feature will be made default in next release. Current partial system is moved to feature flag `partial_legacy`.