### PR TITLE
Don't overwrite template name in RenderError

### DIFF
--- a/examples/partials.rs
+++ b/examples/partials.rs
@@ -35,11 +35,13 @@ fn main() {
     };
 
     println!("Page 0");
-    println!("{}", handlebars.render("template", &data0).ok().unwrap());
+    println!("{}",
+             handlebars.render("template", &data0).unwrap_or_else(|e| format!("{}", e)));
     println!("=======================================================");
 
     println!("Page 1");
-    println!("{}", handlebars.render("template", &data1).ok().unwrap());
+    println!("{}",
+             handlebars.render("template", &data1).unwrap_or_else(|e| format!("{}", e)));
 }
 
 #[cfg(feature = "serde_type")]
@@ -71,9 +73,11 @@ fn main() {
     };
 
     println!("Page 0");
-    println!("{}", handlebars.render("template", &data0).ok().unwrap());
+    println!("{}",
+             handlebars.render("template", &data0).unwrap_or_else(|e| format!("{}", e)));
     println!("=======================================================");
 
     println!("Page 1");
-    println!("{}", handlebars.render("template", &data1).ok().unwrap());
+    println!("{}",
+             handlebars.render("template", &data1).unwrap_or_else(|e| format!("{}", e)));
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -588,6 +588,7 @@ impl Renderable for Template {
         let mut idx = 0;
         for t in iter {
             try!(t.render(registry, rc).map_err(|mut e| {
+                // add line/col number if the template has mapping data
                 if e.line_no.is_none() {
                     if let Some(ref mapping) = self.mapping {
                         if let Some(&TemplateMapping(line, col)) = mapping.get(idx) {
@@ -598,7 +599,10 @@ impl Renderable for Template {
                     }
                 }
 
-                e.template_name = self.name.clone();
+                if e.template_name.is_none() {
+                    e.template_name = self.name.clone();
+                }
+
                 e
             }));
             idx = idx + 1;


### PR DESCRIPTION
Fixes #128 

When there are multiple levels of template during rendering, keep the original one in error information.