### PR TITLE
Fix/145 nested each

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -25,21 +25,32 @@ fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a st
     let path_in = StringInput::new(path);
     let mut parser = Rdp::new(path_in);
 
+    let mut seg_stack: VecDeque<&Token<Rule>> = VecDeque::new();
     if parser.path() {
         for seg in parser.queue().iter() {
             match seg.rule {
                 Rule::path_var | Rule::path_idx | Rule::path_key => {}
                 Rule::path_up => {
                     path_stack.pop_back();
+                    if let Some(p) = seg_stack.pop_back() {
+                        // also pop array index like [1]
+                        if p.rule == Rule::path_raw_id {
+                            seg_stack.pop_back();
+                        }
+                    }
                 }
                 Rule::path_id |
                 Rule::path_raw_id |
                 Rule::path_num_id => {
-                    let id = &path[seg.start..seg.end];
-                    path_stack.push_back(id);
+                    seg_stack.push_back(seg);
                 }
                 _ => {}
             }
+        }
+
+        for i in seg_stack.iter() {
+            let id = &path[i.start..i.end];
+            path_stack.push_back(id);
         }
     }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -304,4 +304,16 @@ mod test {
         let r0 = handlebars.render("t0", &data);
         assert_eq!(r0.ok().unwrap(), "1".to_string());
     }
+
+    #[test]
+    fn test_nested_each_with_path_up_this() {
+        let mut handlebars = Registry::new();
+        assert!(handlebars.register_template_string("t0", "{{#each variant}}{{#each ../typearg}}{{#if @first}}template<{{/if}}{{this}}{{#if @last}}>{{else}},{{/if}}{{/each}}{{/each}}").is_ok());
+        let data = btreemap! {
+            "typearg".to_string() => vec!["T".to_string()],
+            "variant".to_string() => vec!["1".to_string(), "2".to_string()]
+        };
+        let r0 = handlebars.render("t0", &data);
+        assert_eq!(r0.ok().unwrap(), "template<T>template<T>".to_string());
+    }
 }


### PR DESCRIPTION
Fixes #145 

This patch improves Json object navigation and fixes path up used together with array index.