### PR TITLE
Fix object key with slash

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -111,7 +111,7 @@ impl_rdp! {
         path_ident = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["@"]|["$"]|["<"]|[">"]|["-"]}
         path_id = { path_ident+ }
         path_num_id = { ['0'..'9']+ }
-        path_raw_id = { path_ident* }
+        path_raw_id = { (path_ident|["/"])* }
         path_sep = _{ ["/"] | ["."] }
         path_up = { [".."] }
         path_var = { path_id }
@@ -233,7 +233,7 @@ impl_rdp! {
         path_ident = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["@"]|["$"]|["<"]|[">"]|["-"]}
         path_id = { path_ident+ }
         path_num_id = { ['0'..'9']+ }
-        path_raw_id = { path_ident* }
+        path_raw_id = { (path_ident|["/"])* }
         path_sep = _{ ["/"] | ["."] }
         path_up = { [".."] }
         path_var = { path_id }
@@ -482,7 +482,8 @@ fn test_path() {
                  "a[\"bbc\"]/b/c/../d",
                  "../a/b[0][1]",
                  "./this[0][1]/this/../a",
-                 "./this_name"];
+                 "./this_name",
+                 "./goo[/bar]"];
     for i in s.iter() {
         let mut rdp = Rdp::new(StringInput::new(i));
         assert!(rdp.path());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,8 @@ extern crate serde_derive;
 
 extern crate regex;
 extern crate serde;
+#[allow(unused_imports)]
+#[macro_use]
 extern crate serde_json;
 
 pub use self::template::Template;

--- a/src/render.rs
+++ b/src/render.rs
@@ -915,3 +915,17 @@ fn test_partial_failback_render() {
     let r = r.render("child", &true).expect("should work");
     assert_eq!(r, "<html>content</html>");
 }
+
+#[test]
+fn test_key_with_slash() {
+    let mut r = Registry::new();
+
+    assert!(r.register_template_string("t", "{{#each}}{{@key}}: {{this}}\n{{/each}}").is_ok());
+
+    let r = r.render("t", &json!({
+        "/foo": "bar",
+        "/baz": "boom"
+    })).expect("should work");
+
+    assert_eq!(r, "/foo: bar\n/baz: boom\n");
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -920,12 +920,11 @@ fn test_partial_failback_render() {
 fn test_key_with_slash() {
     let mut r = Registry::new();
 
-    assert!(r.register_template_string("t", "{{#each}}{{@key}}: {{this}}\n{{/each}}").is_ok());
+    assert!(r.register_template_string("t", "{{#each .}}{{@key}}: {{this}}\n{{/each}}").is_ok());
 
     let r = r.render("t", &json!({
-        "/foo": "bar",
-        "/baz": "boom"
+        "/foo": "bar"
     })).expect("should work");
 
-    assert_eq!(r, "/foo: bar\n/baz: boom\n");
+    assert_eq!(r, "/foo: bar\n");
 }


### PR DESCRIPTION
Fixes #152 

When object key contains slash `/`, it's ignored by error. This patch should fix it.