### PR TITLE
Report path error / Fix partial context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -104,11 +104,7 @@ fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>,
 fn merge_json(base: &Json, addition: &Object) -> Json {
     let mut base_map = match base {
         &Json::Object(ref m) => m.clone(),
-        _ => {
-            let mut map = Map::new();
-            map.insert("this".to_owned(), base.clone());
-            map
-        }
+        _ => Map::new(),
     };
 
     for (k, v) in addition.iter() {
@@ -154,7 +150,7 @@ impl Context {
         let paths: Vec<&str> = path_stack.iter().map(|x| *x).collect();
         let mut data: &Json = &self.data;
         for p in paths.iter() {
-            if *p == "this" && data.as_object().and_then(|m| m.get("this")).is_none() {
+            if *p == "this" {
                 continue;
             }
             data = match *data {
@@ -344,7 +340,7 @@ mod test {
         assert_eq!(ctx1.navigate(".", &VecDeque::new(), "this")
                        .unwrap()
                        .render(),
-                   "hello".to_owned());
+                   "[object]".to_owned());
         assert_eq!(ctx2.navigate(".", &VecDeque::new(), "age")
                        .unwrap()
                        .render(),
@@ -380,7 +376,7 @@ mod test {
                        .navigate(".", &VecDeque::new(), "this")
                        .unwrap()
                        .render(),
-                   "hello".to_owned());
+                   "[object]".to_owned());
         assert_eq!(ctx_a2
                        .navigate(".", &VecDeque::new(), "tag")
                        .unwrap()

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,7 @@ use pest::prelude::*;
 use std::collections::{VecDeque, BTreeMap};
 
 use grammar::{Rdp, Rule};
+use error::RenderError;
 
 static DEFAULT_VALUE: Json = Json::Null;
 
@@ -18,7 +19,9 @@ pub struct Context {
 }
 
 #[inline]
-fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a str) {
+fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>,
+                                path: &'a str)
+                                -> Result<(), RenderError> {
     let path_in = StringInput::new(path);
     let mut parser = Rdp::new(path_in);
 
@@ -49,6 +52,9 @@ fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a st
             let id = &path[i.start..i.end];
             path_stack.push_back(id);
         }
+        Ok(())
+    } else {
+        Err(RenderError::new("Invalid JSON path"))
     }
 }
 
@@ -56,7 +62,8 @@ fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>, path: &'a st
 fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>,
                           base_path: &'a str,
                           path_context: &'a VecDeque<String>,
-                          relative_path: &'a str) {
+                          relative_path: &'a str)
+                          -> Result<(), RenderError> {
     let path_in = StringInput::new(relative_path);
     let mut parser = Rdp::new(path_in);
 
@@ -78,17 +85,20 @@ fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>,
 
         if path_context_depth >= 0 {
             if let Some(context_base_path) = path_context.get(path_context_depth as usize) {
-                parse_json_visitor_inner(path_stack, context_base_path);
+                parse_json_visitor_inner(path_stack, context_base_path)?;
             } else {
-                parse_json_visitor_inner(path_stack, base_path);
+                parse_json_visitor_inner(path_stack, base_path)?;
             }
         } else {
-            parse_json_visitor_inner(path_stack, base_path);
+            parse_json_visitor_inner(path_stack, base_path)?;
         }
 
-        parse_json_visitor_inner(path_stack, relative_path);
+        parse_json_visitor_inner(path_stack, relative_path)?;
+        Ok(())
+    } else {
+        Err(RenderError::new("Invalid JSON path."))
     }
-    // TODO: report invalid path
+
 }
 
 fn merge_json(base: &Json, addition: &Object) -> Json {
@@ -137,9 +147,9 @@ impl Context {
                     base_path: &str,
                     path_context: &VecDeque<String>,
                     relative_path: &str)
-                    -> &Json {
+                    -> Result<&Json, RenderError> {
         let mut path_stack: VecDeque<&str> = VecDeque::new();
-        parse_json_visitor(&mut path_stack, base_path, path_context, relative_path);
+        parse_json_visitor(&mut path_stack, base_path, path_context, relative_path)?;
 
         let paths: Vec<&str> = path_stack.iter().map(|x| *x).collect();
         let mut data: &Json = &self.data;
@@ -157,7 +167,7 @@ impl Context {
                 _ => &DEFAULT_VALUE,
             }
         }
-        data
+        Ok(data)
     }
 
     pub fn data(&self) -> &Json {
@@ -255,7 +265,9 @@ mod test {
     fn test_render() {
         let v = "hello";
         let ctx = Context::wraps(&v.to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this")
+                       .unwrap()
+                       .render(),
                    v.to_string());
     }
 
@@ -274,28 +286,46 @@ mod test {
         };
 
         let ctx = Context::wraps(&person);
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "./name/../addr/country").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "./name/../addr/country")
+                       .unwrap()
+                       .render(),
                    "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[country]").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[country]")
+                       .unwrap()
+                       .render(),
                    "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[\"country\"]").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[\"country\"]")
+                       .unwrap()
+                       .render(),
                    "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.['country']").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.['country']")
+                       .unwrap()
+                       .render(),
                    "China".to_string());
 
         let v = true;
         let ctx2 = Context::wraps(&v);
-        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "this").render(),
+        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "this")
+                       .unwrap()
+                       .render(),
                    "true".to_string());
 
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]")
+                       .unwrap()
+                       .render(),
                    "programmer".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles.[0]").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles.[0]")
+                       .unwrap()
+                       .render(),
                    "programmer".to_string());
 
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]/../../age").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]/../../age")
+                       .unwrap()
+                       .render(),
                    "27".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this.titles[0]/../../age").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this.titles[0]/../../age")
+                       .unwrap()
+                       .render(),
                    "27".to_string());
 
     }
@@ -311,9 +341,13 @@ mod test {
         map_without_this.insert("age".to_string(), context::to_json(&4usize));
         let ctx2 = Context::wraps(&map_without_this);
 
-        assert_eq!(ctx1.navigate(".", &VecDeque::new(), "this").render(),
+        assert_eq!(ctx1.navigate(".", &VecDeque::new(), "this")
+                       .unwrap()
+                       .render(),
                    "hello".to_owned());
-        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "age").render(),
+        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "age")
+                       .unwrap()
+                       .render(),
                    "4".to_owned());
     }
 
@@ -330,15 +364,27 @@ mod test {
         hash.insert("tag".to_owned(), context::to_json(&"h1"));
 
         let ctx_a1 = ctx1.extend(&hash);
-        assert_eq!(ctx_a1.navigate(".", &VecDeque::new(), "age").render(),
+        assert_eq!(ctx_a1
+                       .navigate(".", &VecDeque::new(), "age")
+                       .unwrap()
+                       .render(),
                    "4".to_owned());
-        assert_eq!(ctx_a1.navigate(".", &VecDeque::new(), "tag").render(),
+        assert_eq!(ctx_a1
+                       .navigate(".", &VecDeque::new(), "tag")
+                       .unwrap()
+                       .render(),
                    "h1".to_owned());
 
         let ctx_a2 = ctx2.extend(&hash);
-        assert_eq!(ctx_a2.navigate(".", &VecDeque::new(), "this").render(),
+        assert_eq!(ctx_a2
+                       .navigate(".", &VecDeque::new(), "this")
+                       .unwrap()
+                       .render(),
                    "hello".to_owned());
-        assert_eq!(ctx_a2.navigate(".", &VecDeque::new(), "tag").render(),
+        assert_eq!(ctx_a2
+                       .navigate(".", &VecDeque::new(), "tag")
+                       .unwrap()
+                       .render(),
                    "h1".to_owned());
     }
 
@@ -348,7 +394,9 @@ mod test {
             "this_name".to_string() => "the_value".to_string()
         };
         let ctx = Context::wraps(&m);
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this_name").render(),
+        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this_name")
+                       .unwrap()
+                       .render(),
                    "the_value".to_string());
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -1,6 +1,7 @@
 use directives::DirectiveDef;
 use registry::Registry;
-use render::{RenderError, RenderContext, Directive};
+use render::{RenderContext, Directive};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
@@ -10,8 +11,8 @@ fn get_name<'a>(d: &'a Directive) -> Result<&'a str, RenderError> {
         .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
         .and_then(|v| {
                       v.value()
-          .as_str()
-          .ok_or_else(|| RenderError::new("inline name must be string"))
+                          .as_str()
+                          .ok_or_else(|| RenderError::new("inline name must be string"))
                   })
 }
 
@@ -19,8 +20,8 @@ impl DirectiveDef for InlineDirective {
     fn call(&self, d: &Directive, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let name = try!(get_name(d));
 
-        let template =
-            try!(d.template().ok_or_else(|| RenderError::new("inline should have a block")));
+        let template = try!(d.template()
+                                .ok_or_else(|| RenderError::new("inline should have a block")));
 
 
         rc.set_partial(name.to_owned(), template.clone());

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -1,5 +1,6 @@
-use render::{RenderContext, RenderError, Directive};
+use render::{RenderContext, Directive};
 use registry::Registry;
+use error::RenderError;
 
 pub use self::inline::INLINE_DIRECTIVE;
 
@@ -66,7 +67,8 @@ mod inline;
 mod test {
     use registry::Registry;
     use context::{self, as_string, Context};
-    use render::{RenderContext, RenderError, Directive, Helper};
+    use render::{RenderContext, Directive, Helper};
+    use error::RenderError;
 
     #[test]
     fn test_register_decorator() {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -119,7 +119,7 @@ impl_rdp! {
         path_idx = { ["["] ~ path_num_id ~ ["]"]}
         path_item = _{ path_up|path_var }
         path_current = { ["this"] | ["."] }
-        path = _{ (path_current | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))*)) ~ eoi }
+        path = _{ (path_current ~ eoi) | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))* ~ eoi)  }
     }
 }
 
@@ -242,7 +242,7 @@ impl_rdp! {
         path_idx = { ["["] ~ path_num_id ~ ["]"]}
         path_item = _{ path_up|path_var }
         path_current = { ["this"] | ["."] }
-        path = _{ path_current | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))*) ~ eoi }
+        path = _{ (path_current ~ eoi) | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))* ~ eoi)  }
     }
 }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -118,7 +118,8 @@ impl_rdp! {
         path_key = { ["["] ~ (["\""]|["'"])? ~ path_raw_id ~ (["\""]|["'"])? ~ ["]"] }
         path_idx = { ["["] ~ path_num_id ~ ["]"]}
         path_item = _{ path_up|path_var }
-        path = _{ ["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))* ~ eoi }
+        path_current = { ["this"] | ["."] }
+        path = _{ (path_current | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))*)) ~ eoi }
     }
 }
 
@@ -240,7 +241,8 @@ impl_rdp! {
         path_key = { ["["] ~ (["\""]|["'"])? ~ path_raw_id ~ (["\""]|["'"])? ~ ["]"] }
         path_idx = { ["["] ~ path_num_id ~ ["]"]}
         path_item = _{ path_up|path_var }
-        path = _{ ["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))* ~ eoi }
+        path_current = { ["this"] | ["."] }
+        path = _{ path_current | (["./"]? ~ path_item ~ ((path_sep ~ path_item) | (path_sep? ~  (path_key | path_idx)))*) ~ eoi }
     }
 }
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -5,7 +5,8 @@ use serde_json::value::Value as Json;
 use helpers::HelperDef;
 use registry::Registry;
 use context::{JsonTruthy, to_json};
-use render::{Renderable, RenderContext, RenderError, Helper};
+use render::{Renderable, RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct EachHelper;

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -1,7 +1,8 @@
 use helpers::HelperDef;
 use registry::Registry;
 use context::JsonTruthy;
-use render::{Renderable, RenderContext, RenderError, Helper};
+use render::{Renderable, RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct IfHelper {

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,7 +1,8 @@
 use helpers::HelperDef;
 use registry::Registry;
 use context::JsonRender;
-use render::{RenderContext, RenderError, Helper};
+use render::{RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct LogHelper;
@@ -9,7 +10,8 @@ pub struct LogHelper;
 impl HelperDef for LogHelper {
     fn call(&self, h: &Helper, _: &Registry, _: &mut RenderContext) -> Result<(), RenderError> {
         let param =
-            try!(h.param(0).ok_or_else(|| RenderError::new("Param not found for helper \"log\"")));
+            try!(h.param(0)
+                     .ok_or_else(|| RenderError::new("Param not found for helper \"log\"")));
 
         info!("{}: {}",
               param.path().unwrap_or(&"".to_owned()),

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -3,7 +3,8 @@ use serde_json::value::Value as Json;
 use helpers::HelperDef;
 use registry::Registry;
 use context::JsonRender;
-use render::{RenderContext, RenderError, Helper};
+use render::{RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct LookupHelper;
@@ -20,14 +21,16 @@ impl HelperDef for LookupHelper {
         let null = Json::Null;
         let value = match collection_value.value() {
             &Json::Array(ref v) => {
-                index.value()
+                index
+                    .value()
                     .as_u64()
                     .and_then(|u| Some(u as usize))
                     .and_then(|u| v.get(u))
                     .unwrap_or(&null)
             }
             &Json::Object(ref m) => {
-                index.value()
+                index
+                    .value()
                     .as_str()
                     .and_then(|k| m.get(k))
                     .unwrap_or(&null)
@@ -51,11 +54,17 @@ mod test {
     #[test]
     fn test_lookup() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{#each v1}}{{lookup ../../v2 @index}}{{/each}}").is_ok());
-        assert!(handlebars.register_template_string("t1",
-                                                    "{{#each v1}}{{lookup ../../v2 1}}{{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "{{#each v1}}{{lookup ../../v2 @index}}{{/each}}")
                     .is_ok());
-        assert!(handlebars.register_template_string("t2", "{{lookup kk \"a\"}}").is_ok());
+        assert!(handlebars
+                    .register_template_string("t1",
+                                              "{{#each v1}}{{lookup ../../v2 1}}{{/each}}")
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("t2", "{{lookup kk \"a\"}}")
+                    .is_ok());
 
         let mut m: BTreeMap<String, Vec<u16>> = BTreeMap::new();
         m.insert("v1".to_string(), vec![1u16, 2u16, 3u16]);

--- a/src/helpers/helper_partial.rs
+++ b/src/helpers/helper_partial.rs
@@ -4,7 +4,8 @@ use std::iter::FromIterator;
 use helpers::HelperDef;
 use registry::Registry;
 use context::JsonRender;
-use render::{Renderable, RenderContext, RenderError, Helper};
+use render::{Renderable, RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct IncludeHelper;

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -1,6 +1,7 @@
 use helpers::HelperDef;
 use registry::Registry;
-use render::{Renderable, RenderContext, RenderError, Helper};
+use render::{Renderable, RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct RawHelper;
@@ -25,7 +26,10 @@ mod test {
     #[test]
     fn test_raw_helper() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "a{{{{raw}}}}{{content}}{{else}}hello{{{{/raw}}}}").is_ok());
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "a{{{{raw}}}}{{content}}{{else}}hello{{{{/raw}}}}")
+                    .is_ok());
 
         let r = handlebars.render("t0", &());
         assert_eq!(r.ok().unwrap(), "a{{content}}{{else}}hello");

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use helpers::HelperDef;
 use registry::Registry;
 use context::{JsonTruthy, to_json};
-use render::{Renderable, RenderContext, RenderError, Helper};
+use render::{Renderable, RenderContext, Helper};
+use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct WithHelper;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,6 @@
-use render::{RenderContext, RenderError, Helper};
+use render::{RenderContext, Helper};
 use registry::Registry;
+use error::RenderError;
 
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
 pub use self::helper_each::EACH_HELPER;
@@ -80,7 +81,8 @@ mod test {
     use context::JsonRender;
     use helpers::HelperDef;
     use registry::Registry;
-    use render::{RenderContext, RenderError, Renderable, Helper};
+    use render::{RenderContext, Renderable, Helper};
+    use error::RenderError;
 
     #[derive(Clone, Copy)]
     struct MetaHelper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,9 +294,9 @@ extern crate serde;
 extern crate serde_json;
 
 pub use self::template::Template;
-pub use self::error::{TemplateError, TemplateFileError, TemplateRenderError};
+pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::registry::{EscapeFn, no_escape, html_escape, Registry as Handlebars};
-pub use self::render::{Renderable, Evaluable, RenderError, RenderContext, Helper, ContextJson,
+pub use self::render::{Renderable, Evaluable, RenderContext, Helper, ContextJson,
                        Directive as Decorator};
 pub use self::helpers::HelperDef;
 pub use self::directives::DirectiveDef as DecoratorDef;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 use registry::Registry;
-use render::{RenderError, RenderContext, Directive, Evaluable, Renderable};
+use render::{RenderContext, Directive, Evaluable, Renderable};
+use error::RenderError;
 
 pub fn expand_partial(d: &Directive,
                       r: &Registry,


### PR DESCRIPTION
This patch added error reporting for JSON path. If your JSON path is invalid, handlebars should be able to report it as a `RenderError` and provide some information.

It also aligns partial context with handlebarsjs. For partial like `{{> my_partial a="b"}}`, if current context is a non-object JSON value, it will be ignored. `{"a": "b"}` becomes current context and there's no way to access previous context.

