### PR TITLE
Partial scope issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "handlebars"
-version = "0.26.2-pre"
+version = "0.26.2"
 authors = ["Ning Sun <sunng@about.me>"]
 description = "Handlebars templating implemented in Rust."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "handlebars"
-version = "0.26.2"
+version = "0.26.3-pre"
 authors = ["Ning Sun <sunng@about.me>"]
 description = "Handlebars templating implemented in Rust."
 license = "MIT"

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -51,10 +51,10 @@ mod test {
         let hbs = Registry::new();
 
         let mut sw = StringWriter::new();
-        let mut ctx = Context::null();
+        let ctx = Context::null();
         let mut hlps = HashMap::new();
 
-        let mut rc = RenderContext::new(&mut ctx, &mut hlps, &mut sw);
+        let mut rc = RenderContext::new(ctx, &mut hlps, &mut sw);
         t0.elements[0].eval(&hbs, &mut rc).unwrap();
 
         assert!(rc.get_partial(&"hello".to_owned()).is_some());

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -39,20 +39,11 @@ pub fn expand_partial(d: &Directive,
                 local_rc.set_partial("@partial-block".to_string(), t.clone());
             }
 
-            let hash = d.hash();
-            let r = if hash.is_empty() {
-                t.render(r, &mut local_rc)
-            } else {
-                let hash_ctx =
-                    BTreeMap::from_iter(hash.iter().map(|(k, v)| (k.clone(), v.value().clone())));
-                {
-                    let mut ctx_ref = local_rc.context_mut();
-                    *ctx_ref = ctx_ref.extend(&hash_ctx);
-                }
-                t.render(r, &mut local_rc)
-            };
-
-            r
+            let hash_ctx =
+                BTreeMap::from_iter(d.hash().iter().map(|(k, v)| (k.clone(), v.value().clone())));
+            let mut partial_context = local_rc.context().extend(&hash_ctx);
+            let mut partial_rc = local_rc.derive_partial_context(&mut partial_context);
+            t.render(r, &mut partial_rc)
         }
         None => Ok(()),
     }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -129,4 +129,28 @@ mod test {
         let r0 = handlebars.render("template", &true);
         assert_eq!(r0.ok().unwrap(), "one--- two ---three--- two ---");
     }
+
+    #[test]
+    fn test_hash_context_outscope() {
+        let main_template = "In: {{> p a=2}} Out: {{a}}";
+        let p_partial = "{{a}}";
+
+        let mut handlebars = Registry::new();
+        assert!(handlebars.register_template_string("template", main_template).is_ok());
+        assert!(handlebars.register_template_string("p", p_partial).is_ok());
+
+        let r0 = handlebars.render("template", &true);
+        assert_eq!(r0.ok().unwrap(), "In: 2 Out: ");
+    }
+
+    #[test]
+    fn test_nested_partial_scope() {
+        let t = "{{#inline* \"pp\"}}{{a}} {{b}}{{/inline}}{{#each c}}{{> pp a=2}}{{/each}}";
+        let data = json!({"c": [{"b": true}, {"b": false}]});
+
+        let mut handlebars = Registry::new();
+        assert!(handlebars.register_template_string("t", t).is_ok());
+        let r0 = handlebars.render("t", &data);
+        assert_eq!(r0.ok().unwrap(), "2 true2 false");
+    }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -41,8 +41,8 @@ pub fn expand_partial(d: &Directive,
 
             let hash_ctx =
                 BTreeMap::from_iter(d.hash().iter().map(|(k, v)| (k.clone(), v.value().clone())));
-            let mut partial_context = local_rc.context().extend(&hash_ctx);
-            let mut partial_rc = local_rc.derive_partial_context(&mut partial_context);
+            let partial_context = local_rc.context().extend(&hash_ctx);
+            let mut partial_rc = local_rc.with_context(partial_context);
             t.render(r, &mut partial_rc)
         }
         None => Ok(()),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -251,10 +251,10 @@ impl Registry {
         self.get_template(&name.to_string())
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
-                          let mut ctx = Context::wraps(data);
+                          let ctx = Context::wraps(data);
                           let mut local_helpers = HashMap::new();
                           let mut render_context =
-                              RenderContext::new(&mut ctx, &mut local_helpers, writer);
+                              RenderContext::new(ctx, &mut local_helpers, writer);
                           render_context.root_template = t.name.clone();
                           t.render(self, &mut render_context)
                       })
@@ -283,9 +283,9 @@ impl Registry {
         where T: Serialize
     {
         let tpl = try!(Template::compile(template_string));
-        let mut ctx = Context::wraps(data);
+        let ctx = Context::wraps(data);
         let mut local_helpers = HashMap::new();
-        let mut render_context = RenderContext::new(&mut ctx, &mut local_helpers, writer);
+        let mut render_context = RenderContext::new(ctx, &mut local_helpers, writer);
         tpl.render(self, &mut render_context)
             .map_err(TemplateRenderError::from)
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -209,6 +209,10 @@ impl<'a> RenderContext<'a> {
     pub fn get_local_helper(&self, name: &str) -> Option<Rc<Box<HelperDef + 'static>>> {
         self.local_helpers.get(name).map(|r| r.clone())
     }
+
+    pub fn evaluate(&self, path: &str) -> Result<&Json, RenderError> {
+        self.context.navigate(self.get_path(), self.get_local_path_root(), path)
+    }
 }
 
 impl<'a> fmt::Debug for RenderContext<'a> {
@@ -516,7 +520,7 @@ impl Parameter {
                 } else {
                     let block_context_value = rc.evaluate_in_block_context(name)?;
                     let value = if block_context_value.is_none() {
-                        rc.context().navigate(rc.get_path(), rc.get_local_path_root(), name)?
+                        rc.evaluate(name)?
                     } else {
                         block_context_value.unwrap()
                     };


### PR DESCRIPTION
Currently we are using `ctx.extend` to merge partial hash and render data. This approach will:

* ruin context and leave the data out of partial scope
* introduce path issue when partial included in `each`/`with` context

Template to reproduce:

```handlebars
{{#*inline "pp"}}{{a}} {{b}} {{../c}} {{@index}}{{/inline}}

{{#each d}}
  {{> pp a="2"}}
{{/each}}
```

Data:

```json
{
  "d": [{"b":true}],
  "c": "hello"
}
```

Expected result:

```
  2 true  0
```