### PR TITLE
Serialize error

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -121,8 +121,8 @@ impl Context {
     }
 
     /// Create a context with given data
-    pub fn wraps<T: Serialize>(e: &T) -> Context {
-        Context { data: to_json(e) }
+    pub fn wraps<T: Serialize>(e: &T) -> Result<Context, RenderError> {
+        to_json(e).map(|d| Context { data: d })
     }
 
     /// Navigate the context with base path and relative path
@@ -197,10 +197,10 @@ impl JsonRender for Json {
     }
 }
 
-pub fn to_json<T>(src: &T) -> Json
+pub fn to_json<T>(src: &T) -> Result<Json, RenderError>
     where T: Serialize
 {
-    to_value(src).unwrap_or(Json::Null)
+    to_value(src).map_err(RenderError::from)
 }
 
 pub fn as_string(src: &Json) -> Option<&str> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,9 +19,10 @@ pub struct Context {
 }
 
 #[inline]
-fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>,
-                                path: &'a str)
-                                -> Result<(), RenderError> {
+fn parse_json_visitor_inner<'a>(
+    path_stack: &mut VecDeque<&'a str>,
+    path: &'a str,
+) -> Result<(), RenderError> {
     let path_in = StringInput::new(path);
     let mut parser = Rdp::new(path_in);
 
@@ -59,11 +60,12 @@ fn parse_json_visitor_inner<'a>(path_stack: &mut VecDeque<&'a str>,
 }
 
 #[inline]
-fn parse_json_visitor<'a>(path_stack: &mut VecDeque<&'a str>,
-                          base_path: &'a str,
-                          path_context: &'a VecDeque<String>,
-                          relative_path: &'a str)
-                          -> Result<(), RenderError> {
+fn parse_json_visitor<'a>(
+    path_stack: &mut VecDeque<&'a str>,
+    base_path: &'a str,
+    path_context: &'a VecDeque<String>,
+    relative_path: &'a str,
+) -> Result<(), RenderError> {
     let path_in = StringInput::new(relative_path);
     let mut parser = Rdp::new(path_in);
 
@@ -122,9 +124,9 @@ impl Context {
 
     /// Create a context with given data
     pub fn wraps<T: Serialize>(e: &T) -> Result<Context, RenderError> {
-        to_value(e)
-            .map_err(RenderError::from)
-            .map(|d| Context { data: d })
+        to_value(e).map_err(RenderError::from).map(|d| {
+            Context { data: d }
+        })
     }
 
     /// Navigate the context with base path and relative path
@@ -132,11 +134,12 @@ impl Context {
     /// and set relative path to helper argument or so.
     ///
     /// If you want to navigate from top level, set the base path to `"."`
-    pub fn navigate(&self,
-                    base_path: &str,
-                    path_context: &VecDeque<String>,
-                    relative_path: &str)
-                    -> Result<&Json, RenderError> {
+    pub fn navigate(
+        &self,
+        base_path: &str,
+        path_context: &VecDeque<String>,
+        relative_path: &str,
+    ) -> Result<&Json, RenderError> {
         let mut path_stack: VecDeque<&str> = VecDeque::new();
         parse_json_visitor(&mut path_stack, base_path, path_context, relative_path)?;
 
@@ -200,7 +203,8 @@ impl JsonRender for Json {
 }
 
 pub fn to_json<T>(src: &T) -> Json
-    where T: Serialize
+where
+    T: Serialize,
 {
     to_value(src).unwrap_or_default()
 }
@@ -254,10 +258,12 @@ mod test {
     fn test_render() {
         let v = "hello";
         let ctx = Context::wraps(&v.to_string()).unwrap();
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this")
-                       .unwrap()
-                       .render(),
-                   v.to_string());
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "this")
+                .unwrap()
+                .render(),
+            v.to_string()
+        );
     }
 
     #[test]
@@ -275,47 +281,65 @@ mod test {
         };
 
         let ctx = Context::wraps(&person).unwrap();
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "./name/../addr/country")
-                       .unwrap()
-                       .render(),
-                   "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[country]")
-                       .unwrap()
-                       .render(),
-                   "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.[\"country\"]")
-                       .unwrap()
-                       .render(),
-                   "China".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "addr.['country']")
-                       .unwrap()
-                       .render(),
-                   "China".to_string());
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "./name/../addr/country")
+                .unwrap()
+                .render(),
+            "China".to_string()
+        );
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "addr.[country]")
+                .unwrap()
+                .render(),
+            "China".to_string()
+        );
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "addr.[\"country\"]")
+                .unwrap()
+                .render(),
+            "China".to_string()
+        );
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "addr.['country']")
+                .unwrap()
+                .render(),
+            "China".to_string()
+        );
 
         let v = true;
         let ctx2 = Context::wraps(&v).unwrap();
-        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "this")
-                       .unwrap()
-                       .render(),
-                   "true".to_string());
+        assert_eq!(
+            ctx2.navigate(".", &VecDeque::new(), "this")
+                .unwrap()
+                .render(),
+            "true".to_string()
+        );
 
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]")
-                       .unwrap()
-                       .render(),
-                   "programmer".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles.[0]")
-                       .unwrap()
-                       .render(),
-                   "programmer".to_string());
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "titles[0]")
+                .unwrap()
+                .render(),
+            "programmer".to_string()
+        );
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "titles.[0]")
+                .unwrap()
+                .render(),
+            "programmer".to_string()
+        );
 
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "titles[0]/../../age")
-                       .unwrap()
-                       .render(),
-                   "27".to_string());
-        assert_eq!(ctx.navigate(".", &VecDeque::new(), "this.titles[0]/../../age")
-                       .unwrap()
-                       .render(),
-                   "27".to_string());
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "titles[0]/../../age")
+                .unwrap()
+                .render(),
+            "27".to_string()
+        );
+        assert_eq!(
+            ctx.navigate(".", &VecDeque::new(), "this.titles[0]/../../age")
+                .unwrap()
+                .render(),
+            "27".to_string()
+        );
 
     }
 
@@ -330,21 +354,26 @@ mod test {
         map_without_this.insert("age".to_string(), context::to_json(&4usize));
         let ctx2 = Context::wraps(&map_without_this).unwrap();
 
-        assert_eq!(ctx1.navigate(".", &VecDeque::new(), "this")
-                       .unwrap()
-                       .render(),
-                   "[object]".to_owned());
-        assert_eq!(ctx2.navigate(".", &VecDeque::new(), "age")
-                       .unwrap()
-                       .render(),
-                   "4".to_owned());
+        assert_eq!(
+            ctx1.navigate(".", &VecDeque::new(), "this")
+                .unwrap()
+                .render(),
+            "[object]".to_owned()
+        );
+        assert_eq!(
+            ctx2.navigate(".", &VecDeque::new(), "age")
+                .unwrap()
+                .render(),
+            "4".to_owned()
+        );
     }
 
     #[test]
     fn test_merge_json() {
         let map = json!({ "age": 4 });
         let s = "hello".to_owned();
-        let hash = btreemap!{
+        let hash =
+            btreemap!{
             "tag".to_owned() => context::to_json(&"h1")
         };
 
@@ -375,7 +404,8 @@ mod test {
 
     #[test]
     fn test_key_name_with_this() {
-        let m = btreemap!{
+        let m =
+            btreemap!{
             "this_name".to_string() => "the_value".to_string()
         };
         let ctx = Context::wraps(&m).unwrap();
@@ -383,5 +413,25 @@ mod test {
                        .unwrap()
                        .render(),
                    "the_value".to_string());
+    }
+
+    use serde::{Serialize, Serializer};
+    use serde::ser::Error as SerdeError;
+
+    struct UnserializableType {}
+
+    impl Serialize for UnserializableType {
+        fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Err(SerdeError::custom("test"))
+        }
+    }
+
+    #[test]
+    fn test_serialize_error() {
+        let d = UnserializableType {};
+        assert!(Context::wraps(&d).is_err());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use std::io::Error as IOError;
 use std::error::Error;
 use std::fmt;
 
+use serde_json::error::Error as SerdeError;
+
 use template::Parameter;
 
 /// Error when rendering data on template.
@@ -39,8 +41,14 @@ impl Error for RenderError {
 }
 
 impl From<IOError> for RenderError {
-    fn from(_: IOError) -> RenderError {
-        RenderError::new("IO Error")
+    fn from(e: IOError) -> RenderError {
+        RenderError::new(e.description())
+    }
+}
+
+impl From<SerdeError> for RenderError {
+    fn from(e: SerdeError) -> RenderError {
+        RenderError::new(e.description())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,12 +7,13 @@ use serde_json::error::Error as SerdeError;
 use template::Parameter;
 
 /// Error when rendering data on template.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RenderError {
     pub desc: String,
     pub template_name: Option<String>,
     pub line_no: Option<usize>,
     pub column_no: Option<usize>,
+    cause: Option<Box<Error>>,
 }
 
 impl fmt::Display for RenderError {
@@ -38,17 +39,21 @@ impl Error for RenderError {
     fn description(&self) -> &str {
         &self.desc[..]
     }
+
+    fn cause(&self) -> Option<&Error> {
+        self.cause.as_ref().map(|e| &**e)
+    }
 }
 
 impl From<IOError> for RenderError {
     fn from(e: IOError) -> RenderError {
-        RenderError::new(e.description())
+        RenderError::with(e)
     }
 }
 
 impl From<SerdeError> for RenderError {
     fn from(e: SerdeError) -> RenderError {
-        RenderError::new(e.description())
+        RenderError::with(e)
     }
 }
 
@@ -59,7 +64,17 @@ impl RenderError {
             template_name: None,
             line_no: None,
             column_no: None,
+            cause: None,
         }
+    }
+
+    pub fn with<E>(cause: E) -> RenderError
+        where E: Error + 'static
+    {
+        let mut e = RenderError::new(cause.description());
+        e.cause = Some(Box::new(cause));
+
+        e
     }
 }
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -14,14 +14,17 @@ pub struct EachHelper;
 impl HelperDef for EachHelper {
     fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let value =
-            try!(h.param(0).ok_or_else(|| RenderError::new("Param not found for helper \"each\"")));
+            try!(h.param(0)
+                     .ok_or_else(|| RenderError::new("Param not found for helper \"each\"")));
 
         let template = h.template();
 
         match template {
             Some(t) => {
                 rc.promote_local_vars();
-                let local_path_root = value.path_root().map(|p| format!("{}/{}", rc.get_path(), p));
+                let local_path_root = value
+                    .path_root()
+                    .map(|p| format!("{}/{}", rc.get_path(), p));
 
                 debug!("each value {:?}", value.value());
                 let rendered = match (value.value().is_truthy(), value.value()) {
@@ -33,9 +36,9 @@ impl HelperDef for EachHelper {
                                 local_rc.push_local_path_root(p.clone());
                             }
 
-                            local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize)));
-                            local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1)));
-                            local_rc.set_local_var("@index".to_string(), to_json(&i));
+                            local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize))?);
+                            local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1))?);
+                            local_rc.set_local_var("@index".to_string(), to_json(&i)?);
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
@@ -46,8 +49,8 @@ impl HelperDef for EachHelper {
 
                             if let Some(block_param) = h.block_param() {
                                 let mut map = BTreeMap::new();
-                                map.insert(block_param.to_string(), to_json(&list[i]));
-                                local_rc.push_block_context(&map);
+                                map.insert(block_param.to_string(), to_json(&list[i])?);
+                                local_rc.push_block_context(&map)?;
                             }
 
                             try!(t.render(r, &mut local_rc));
@@ -69,12 +72,12 @@ impl HelperDef for EachHelper {
                             if let Some(ref p) = local_path_root {
                                 local_rc.push_local_path_root(p.clone());
                             }
-                            local_rc.set_local_var("@first".to_string(), to_json(&first));
+                            local_rc.set_local_var("@first".to_string(), to_json(&first)?);
                             if first {
                                 first = false;
                             }
 
-                            local_rc.set_local_var("@key".to_string(), to_json(k));
+                            local_rc.set_local_var("@key".to_string(), to_json(k)?);
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
@@ -84,9 +87,9 @@ impl HelperDef for EachHelper {
 
                             if let Some((bp_key, bp_val)) = h.block_param_pair() {
                                 let mut map = BTreeMap::new();
-                                map.insert(bp_key.to_string(), to_json(k));
-                                map.insert(bp_val.to_string(), to_json(obj.get(k).unwrap()));
-                                local_rc.push_block_context(&map);
+                                map.insert(bp_key.to_string(), to_json(k)?);
+                                map.insert(bp_val.to_string(), to_json(obj.get(k).unwrap())?);
+                                local_rc.push_block_context(&map)?;
                             }
 
                             try!(t.render(r, &mut local_rc));
@@ -163,8 +166,9 @@ mod test {
         // previously, to access the parent in an each block,
         // a user would need to specify ../../b, as the path
         // that is computed includes the array index: ./a.c.[0]
-        assert!(handlebars.register_template_string("t0",
-                                                    "{{#each a.c}} d={{d}} b={{../a.a}} {{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "{{#each a.c}} d={{d}} b={{../a.a}} {{/each}}")
                     .is_ok());
 
         let r1 = handlebars.render("t0", &data);
@@ -202,7 +206,8 @@ mod test {
     #[test]
     fn test_nested_array() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{#each this.[0]}}{{this}}{{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0", "{{#each this.[0]}}{{this}}{{/each}}")
                     .is_ok());
 
         let r0 = handlebars.render("t0", &(vec![vec![1, 2, 3]]));
@@ -213,25 +218,27 @@ mod test {
     #[test]
     fn test_empty_key() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0",
-                                                    "{{#each this}}{{@key}}-{{value}}\n{{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "{{#each this}}{{@key}}-{{value}}\n{{/each}}")
                     .is_ok());
 
-        let r0 = handlebars.render("t0",
-                                   &({
-                                         let mut rv = BTreeMap::new();
-                                         rv.insert("foo".to_owned(), {
+        let r0 = handlebars
+            .render("t0",
+                    &({
+                         let mut rv = BTreeMap::new();
+                         rv.insert("foo".to_owned(), {
                     let mut rv = BTreeMap::new();
                     rv.insert("value".to_owned(), "bar".to_owned());
                     rv
                 });
-                                         rv.insert("".to_owned(), {
+                         rv.insert("".to_owned(), {
                     let mut rv = BTreeMap::new();
                     rv.insert("value".to_owned(), "baz".to_owned());
                     rv
                 });
-                                         rv
-                                     }))
+                         rv
+                     }))
             .unwrap();
 
         let mut r0_sp: Vec<_> = r0.split('\n').collect();
@@ -243,7 +250,8 @@ mod test {
     #[test]
     fn test_each_else() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{#each a}}1{{else}}empty{{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0", "{{#each a}}1{{else}}empty{{/each}}")
                     .is_ok());
         let m1 = btreemap! {
             "a".to_string() => Vec::<String>::new(),
@@ -261,7 +269,8 @@ mod test {
     #[test]
     fn test_block_param() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{#each a as |i|}}{{i}}{{/each}}")
+        assert!(handlebars
+                    .register_template_string("t0", "{{#each a as |i|}}{{i}}{{/each}}")
                     .is_ok());
         let m1 = btreemap! {
             "a".to_string() => vec![1,2,3,4,5]

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -36,9 +36,9 @@ impl HelperDef for EachHelper {
                                 local_rc.push_local_path_root(p.clone());
                             }
 
-                            local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize))?);
-                            local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1))?);
-                            local_rc.set_local_var("@index".to_string(), to_json(&i)?);
+                            local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize)));
+                            local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1)));
+                            local_rc.set_local_var("@index".to_string(), to_json(&i));
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
@@ -49,7 +49,7 @@ impl HelperDef for EachHelper {
 
                             if let Some(block_param) = h.block_param() {
                                 let mut map = BTreeMap::new();
-                                map.insert(block_param.to_string(), to_json(&list[i])?);
+                                map.insert(block_param.to_string(), to_json(&list[i]));
                                 local_rc.push_block_context(&map)?;
                             }
 
@@ -72,12 +72,12 @@ impl HelperDef for EachHelper {
                             if let Some(ref p) = local_path_root {
                                 local_rc.push_local_path_root(p.clone());
                             }
-                            local_rc.set_local_var("@first".to_string(), to_json(&first)?);
+                            local_rc.set_local_var("@first".to_string(), to_json(&first));
                             if first {
                                 first = false;
                             }
 
-                            local_rc.set_local_var("@key".to_string(), to_json(k)?);
+                            local_rc.set_local_var("@key".to_string(), to_json(k));
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
@@ -87,8 +87,8 @@ impl HelperDef for EachHelper {
 
                             if let Some((bp_key, bp_val)) = h.block_param_pair() {
                                 let mut map = BTreeMap::new();
-                                map.insert(bp_key.to_string(), to_json(k)?);
-                                map.insert(bp_val.to_string(), to_json(obj.get(k).unwrap())?);
+                                map.insert(bp_key.to_string(), to_json(k));
+                                map.insert(bp_val.to_string(), to_json(obj.get(k).unwrap()));
                                 local_rc.push_block_context(&map)?;
                             }
 

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -35,7 +35,7 @@ impl HelperDef for WithHelper {
 
                 if let Some(block_param) = h.block_param() {
                     let mut map = BTreeMap::new();
-                    map.insert(block_param.to_string(), to_json(param.value())?);
+                    map.insert(block_param.to_string(), to_json(param.value()));
                     local_rc.push_block_context(&map)?;
                 }
             }

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -12,7 +12,8 @@ pub struct WithHelper;
 impl HelperDef for WithHelper {
     fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
         let param =
-            try!(h.param(0).ok_or_else(|| RenderError::new("Param not found for helper \"with\"")));
+            try!(h.param(0)
+                     .ok_or_else(|| RenderError::new("Param not found for helper \"with\"")));
 
         rc.promote_local_vars();
 
@@ -34,8 +35,8 @@ impl HelperDef for WithHelper {
 
                 if let Some(block_param) = h.block_param() {
                     let mut map = BTreeMap::new();
-                    map.insert(block_param.to_string(), to_json(param.value()));
-                    local_rc.push_block_context(&map);
+                    map.insert(block_param.to_string(), to_json(param.value())?);
+                    local_rc.push_block_context(&map)?;
                 }
             }
 
@@ -96,13 +97,15 @@ mod test {
         };
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{#with addr}}{{city}}{{/with}}")
+        assert!(handlebars
+                    .register_template_string("t0", "{{#with addr}}{{city}}{{/with}}")
                     .is_ok());
-        assert!(handlebars.register_template_string("t1",
-                                                    "{{#with notfound}}hello{{else}}world{{/with}}")
+        assert!(handlebars
+                    .register_template_string("t1",
+                                              "{{#with notfound}}hello{{else}}world{{/with}}")
                     .is_ok());
-        assert!(handlebars.register_template_string("t2",
-                                                    "{{#with addr/country}}{{this}}{{/with}}")
+        assert!(handlebars
+                    .register_template_string("t2", "{{#with addr/country}}{{this}}{{/with}}")
                     .is_ok());
 
         let r0 = handlebars.render("t0", &person);
@@ -130,12 +133,14 @@ mod test {
         };
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0",
-                                                    "{{#with addr as |a|}}{{a.city}}{{/with}}")
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "{{#with addr as |a|}}{{a.city}}{{/with}}")
                     .is_ok());
         assert!(handlebars.register_template_string("t1", "{{#with notfound as |c|}}hello{{else}}world{{/with}}").is_ok());
-        assert!(handlebars.register_template_string("t2",
-                                                    "{{#with addr/country as |t|}}{{t}}{{/with}}")
+        assert!(handlebars
+                    .register_template_string("t2",
+                                              "{{#with addr/country as |t|}}{{t}}{{/with}}")
                     .is_ok());
 
         let r0 = handlebars.render("t0", &person);
@@ -194,9 +199,10 @@ mod test {
     #[test]
     fn test_path_up() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0",
-                                                    "{{#with a}}{{#with b}}{{../../d}}{{/with}}{{/with}}")
-                          .is_ok());
+        assert!(handlebars
+                    .register_template_string("t0",
+                                              "{{#with a}}{{#with b}}{{../../d}}{{/with}}{{/with}}")
+                    .is_ok());
         let data = btreemap! {
             "a".to_string() => to_json(&btreemap! {
                 "b".to_string() => vec![btreemap!{"c".to_string() => vec![1]}]

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -45,9 +45,11 @@ pub fn expand_partial(d: &Directive,
                 t.render(r, &mut local_rc)
             } else {
                 let hash_ctx =
-                    BTreeMap::from_iter(d.hash().iter().map(|(k, v)| (k.clone(), v.value().clone())));
+                    BTreeMap::from_iter(d.hash().iter().map(|(k, v)| {
+                                                                (k.clone(), v.value().clone())
+                                                            }));
                 let partial_context = merge_json(local_rc.evaluate(".")?, &hash_ctx);
-                let mut partial_rc = local_rc.with_context(Context::wraps(&partial_context));
+                let mut partial_rc = local_rc.with_context(Context::wraps(&partial_context)?);
                 t.render(r, &mut partial_rc)
             }
         }
@@ -63,16 +65,31 @@ mod test {
     #[test]
     fn test() {
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", "{{> t1}}").is_ok());
-        assert!(handlebars.register_template_string("t1", "{{this}}").is_ok());
-        assert!(handlebars.register_template_string("t2", "{{#> t99}}not there{{/t99}}").is_ok());
-        assert!(handlebars.register_template_string("t3", "{{#*inline \"t31\"}}{{this}}{{/inline}}{{> t31}}").is_ok());
+        assert!(handlebars
+                    .register_template_string("t0", "{{> t1}}")
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("t1", "{{this}}")
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("t2", "{{#> t99}}not there{{/t99}}")
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("t3",
+                                              "{{#*inline \"t31\"}}{{this}}{{/inline}}{{> t31}}")
+                    .is_ok());
         assert!(handlebars.register_template_string("t4", "{{#> t5}}{{#*inline \"nav\"}}navbar{{/inline}}{{/t5}}").is_ok());
-        assert!(handlebars.register_template_string("t5", "include {{> nav}}").is_ok());
-        assert!(handlebars.register_template_string("t6", "{{> t1 a}}").is_ok());
+        assert!(handlebars
+                    .register_template_string("t5", "include {{> nav}}")
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("t6", "{{> t1 a}}")
+                    .is_ok());
         assert!(handlebars.register_template_string("t7", "{{#*inline \"t71\"}}{{a}}{{/inline}}{{> t71 a=\"world\"}}").is_ok());
         assert!(handlebars.register_template_string("t8", "{{a}}").is_ok());
-        assert!(handlebars.register_template_string("t9", "{{> t8 a=2}}").is_ok());
+        assert!(handlebars
+                    .register_template_string("t9", "{{> t8 a=2}}")
+                    .is_ok());
 
         assert_eq!(handlebars.render("t0", &1).ok().unwrap(), "1".to_string());
         assert_eq!(handlebars.render("t2", &1).ok().unwrap(),
@@ -80,7 +97,8 @@ mod test {
         assert_eq!(handlebars.render("t3", &1).ok().unwrap(), "1".to_string());
         assert_eq!(handlebars.render("t4", &1).ok().unwrap(),
                    "include navbar".to_string());
-        assert_eq!(handlebars.render("t6", &btreemap!{"a".to_string() => "2".to_string()})
+        assert_eq!(handlebars
+                       .render("t6", &btreemap!{"a".to_string() => "2".to_string()})
                        .ok()
                        .unwrap(),
                    "2".to_string());
@@ -120,8 +138,12 @@ mod test {
         let two_partial = "--- two ---";
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("template", main_template).is_ok());
-        assert!(handlebars.register_template_string("two", two_partial).is_ok());
+        assert!(handlebars
+                    .register_template_string("template", main_template)
+                    .is_ok());
+        assert!(handlebars
+                    .register_template_string("two", two_partial)
+                    .is_ok());
 
         let r0 = handlebars.render("template", &true);
         assert_eq!(r0.ok().unwrap(), "one--- two ---three--- two ---");
@@ -133,7 +155,9 @@ mod test {
         let p_partial = "{{a}}";
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("template", main_template).is_ok());
+        assert!(handlebars
+                    .register_template_string("template", main_template)
+                    .is_ok());
         assert!(handlebars.register_template_string("p", p_partial).is_ok());
 
         let r0 = handlebars.render("template", &true);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -233,7 +233,7 @@ impl Registry {
         self.get_template(&name.to_string())
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
-                          let ctx = Context::wraps(data);
+                          let ctx = try!(Context::wraps(data));
                           let mut local_helpers = HashMap::new();
                           let mut render_context =
                               RenderContext::new(ctx, &mut local_helpers, writer);
@@ -265,7 +265,7 @@ impl Registry {
         where T: Serialize
     {
         let tpl = try!(Template::compile(template_string));
-        let ctx = Context::wraps(data);
+        let ctx = try!(Context::wraps(data));
         let mut local_helpers = HashMap::new();
         let mut render_context = RenderContext::new(ctx, &mut local_helpers, writer);
         tpl.render(self, &mut render_context)

--- a/src/render.rs
+++ b/src/render.rs
@@ -170,10 +170,11 @@ impl<'a> RenderContext<'a> {
         self.writer
     }
 
-    pub fn push_block_context<T>(&mut self, ctx: &T)
+    pub fn push_block_context<T>(&mut self, ctx: &T) -> Result<(), RenderError>
         where T: Serialize
     {
-        self.block_context.push_front(Context::wraps(ctx));
+        let r = self.block_context.push_front(Context::wraps(ctx)?);
+        Ok(r)
     }
 
     pub fn pop_block_context(&mut self) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -722,7 +722,7 @@ fn test_expression() {
     let mut m: HashMap<String, String> = HashMap::new();
     let value = "<p></p>".to_string();
     m.insert("hello".to_string(), value);
-    let ctx = Context::wraps(&m);
+    let ctx = Context::wraps(&m).unwrap();
     {
 
         let mut rc = RenderContext::new(ctx, &mut hlps, &mut sw);
@@ -742,7 +742,7 @@ fn test_html_expression() {
     let mut m: HashMap<String, String> = HashMap::new();
     let value = "world";
     m.insert("hello".to_string(), value.to_string());
-    let ctx = Context::wraps(&m);
+    let ctx = Context::wraps(&m).unwrap();
     {
 
         let mut rc = RenderContext::new(ctx, &mut hlps, &mut sw);
@@ -761,7 +761,7 @@ fn test_template() {
     let mut m: HashMap<String, String> = HashMap::new();
     let value = "world".to_string();
     m.insert("hello".to_string(), value);
-    let ctx = Context::wraps(&m);
+    let ctx = Context::wraps(&m).unwrap();
 
     {
 


### PR DESCRIPTION
Fixes #161

Don't eat `serde_json::error::Error` silently. We will raise `RenderError` when such error returned from serde API. 

Added `cause` for `RenderError` where you can access its root error.