### PR TITLE
Improve performance for 0.27 change on RenderContext

### DIFF
--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -22,9 +22,11 @@ pub use self::inline::INLINE_DIRECTIVE;
 ///         -> Result<(), RenderError> {
 ///     // modify json object
 ///     let mut ctx_ref = rc.context_mut();
-///     if let Some(ref mut m) = ctx_ref.data_mut().as_object_mut() {
+///     let mut data = ctx_ref.data_clone();
+///     if let Some(ref mut m) = data.as_object_mut() {
 ///         m.insert("hello".to_string(), to_json(&"world".to_owned()));
 ///     }
+///     *ctx_ref = Context::wraps(&data)?;
 ///     Ok(())
 /// }
 ///
@@ -120,9 +122,13 @@ mod test {
              -> Result<(), RenderError> {
                 // modify json object
                 let mut ctx_ref = rc.context_mut();
-                if let Some(ref mut m) = ctx_ref.data_mut().as_object_mut().as_mut() {
+                let mut data = ctx_ref.data_clone();
+
+                if let Some(ref mut m) = data.as_object_mut().as_mut() {
                     m.insert("hello".to_string(), context::to_json(&"war".to_owned()));
                 }
+
+                *ctx_ref = Context::wraps(&data)?;
                 Ok(())
             }),
         );


### PR DESCRIPTION
From 0.27, `RenderContext` now owns `Context`. During the render process, we need to clone the `RenderContext`, so `Context` and its wrapped data are cloned again and again. This patch made data in `Context` an `Rc`, the clone cost will be pretty cheap.

Address issue #166 .

Benchmark:

```
test large_loop_helper ... bench:   3,242,381 ns/iter (+/- 313,516)
```

Compared with 0.27:

```
test large_loop_helper ... bench: 496,376,347 ns/iter (+/- 148,433,745)
```

0.26:

```
test large_loop_helper ... bench:   3,148,455 ns/iter (+/- 72,797)
```
