### PR TITLE
Arc for data ref in Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -164,6 +164,10 @@ impl Context {
         Ok(data)
     }
 
+    pub fn update(&mut self, data: Json) {
+        self.data = Rc::new(data);
+    }
+
     pub fn data_clone(&self) -> Json {
         self.data.as_ref().clone()
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use serde::Serialize;
 use serde_json::value::{Value as Json, Map, to_value};
@@ -17,7 +17,7 @@ pub type Object = BTreeMap<String, Json>;
 ///
 #[derive(Debug, Clone)]
 pub struct Context {
-    data: Rc<Json>,
+    data: Arc<Json>,
 }
 
 #[inline]
@@ -121,13 +121,13 @@ pub fn merge_json(base: &Json, addition: &Object) -> Json {
 impl Context {
     /// Create a context with null data
     pub fn null() -> Context {
-        Context { data: Rc::new(Json::Null) }
+        Context { data: Arc::new(Json::Null) }
     }
 
     /// Create a context with given data
     pub fn wraps<T: Serialize>(e: &T) -> Result<Context, RenderError> {
         to_value(e).map_err(RenderError::from).map(|d| {
-            Context { data: Rc::new(d) }
+            Context { data: Arc::new(d) }
         })
     }
 
@@ -164,12 +164,8 @@ impl Context {
         Ok(data)
     }
 
-    pub fn update(&mut self, data: Json) {
-        self.data = Rc::new(data);
-    }
-
-    pub fn data_clone(&self) -> Json {
-        self.data.as_ref().clone()
+    pub fn data_mut(&mut self) -> &mut Json {
+        Arc::make_mut(&mut self.data)
     }
 }
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -21,12 +21,10 @@ pub use self::inline::INLINE_DIRECTIVE;
 /// fn update_data(_: &Decorator, _: &Handlebars, rc: &mut RenderContext)
 ///         -> Result<(), RenderError> {
 ///     // modify json object
-///     let mut ctx_ref = rc.context_mut();
-///     let mut data = ctx_ref.data_clone();
+///     let mut data = rc.context_mut().data_mut();
 ///     if let Some(ref mut m) = data.as_object_mut() {
 ///         m.insert("hello".to_string(), to_json(&"world".to_owned()));
 ///     }
-///     *ctx_ref = Context::wraps(&data)?;
 ///     Ok(())
 /// }
 ///
@@ -122,13 +120,12 @@ mod test {
              -> Result<(), RenderError> {
                 // modify json object
                 let mut ctx_ref = rc.context_mut();
-                let mut data = ctx_ref.data_clone();
+                let mut data = ctx_ref.data_mut();
 
                 if let Some(ref mut m) = data.as_object_mut().as_mut() {
                     m.insert("hello".to_string(), context::to_json(&"war".to_owned()));
                 }
 
-                ctx_ref.update(data);
                 Ok(())
             }),
         );

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -128,7 +128,7 @@ mod test {
                     m.insert("hello".to_string(), context::to_json(&"war".to_owned()));
                 }
 
-                *ctx_ref = Context::wraps(&data)?;
+                ctx_ref.update(data);
                 Ok(())
             }),
         );


### PR DESCRIPTION
This is follow up for #167 that I'm now using `Arc` for data ref so we don't have to clone data and create new context when changing data in directives.

The performance is almost identical to the Rc one:

```
test large_loop_helper ... bench:   3,238,791 ns/iter (+/- 187,867)
```
