### PR TITLE
omit tag escape pattern from resulting RawString element output

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -135,11 +135,8 @@ impl Template {
         }
     }
 
-    fn unescape_tags<T>(txt: T) -> String
-    where
-        T: Into<String>,
-    {
-        txt.into().replace("\\{{", "{{")
+    fn unescape_tags(txt: &str) -> String {
+        txt.replace("\\{{", "{{")
     }
 
     fn push_element(&mut self, e: TemplateElement, line: usize, col: usize) {


### PR DESCRIPTION
I think I covered all the cases here. It did seem a bit repetitive but no more repetitive then the existing code for emitting `RawStrings`. 

Ideally I would have liked to find a way to do this in the grammar itself but I couldn't find a clear path for that. I'm new to the pest syntax but familiar with [scala's parser combinator library](https://github.com/scala/scala-parser-combinators#example) and couldn't find the equivalent of scala's `^^` operator to transform the grammar