### PR TITLE
(fix) impl escape that works for displayed strings vs debug string li…

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,6 +396,6 @@ mod test {
             "hello": "world"
         });
 
-        assert_eq!("{{hello}}", r.template_render("\\{{hello}}", &data).unwrap());
+        assert_eq!("{{hello}}", r.template_render("\\\\{{hello}}", &data).unwrap());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,6 +396,6 @@ mod test {
             "hello": "world"
         });
 
-        assert_eq!("{{hello}}", r.template_render("\\\\{{hello}}", &data).unwrap());
+        assert_eq!("{{hello}}", r.template_render(r"\\{{hello}}", &data).unwrap());
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -643,7 +643,7 @@ pub enum TemplateElement {
 
 #[test]
 fn test_parse_escaped_tag_raw_string() {
-    let source = "foo \\\\{{bar}}";
+    let source = r"foo \\{{bar}}";
     let t = Template::compile(source.to_string()).ok().unwrap();
     assert_eq!(t.elements.len(), 1);
     assert_eq!(
@@ -654,7 +654,7 @@ fn test_parse_escaped_tag_raw_string() {
 
 #[test]
 fn test_parse_escaped_block_raw_string() {
-    let source = "\\\\{{{{foo}}}} bar";
+    let source = r"\\{{{{foo}}}} bar";
     let t = Template::compile(source.to_string()).ok().unwrap();
     assert_eq!(t.elements.len(), 1);
     assert_eq!(

--- a/src/template.rs
+++ b/src/template.rs
@@ -137,7 +137,7 @@ impl Template {
 
     fn unescape_tags(txt: &str) -> String {
         // unescaped this is really \\
-        txt.replace("\\\\{{", "{{")
+        txt.replace(r"\\{{", "{{")
     }
 
     fn push_element(&mut self, e: TemplateElement, line: usize, col: usize) {

--- a/src/template.rs
+++ b/src/template.rs
@@ -136,7 +136,8 @@ impl Template {
     }
 
     fn unescape_tags(txt: &str) -> String {
-        txt.replace("\\{{", "{{")
+        // unescaped this is really \\
+        txt.replace("\\\\{{", "{{")
     }
 
     fn push_element(&mut self, e: TemplateElement, line: usize, col: usize) {
@@ -642,7 +643,7 @@ pub enum TemplateElement {
 
 #[test]
 fn test_parse_escaped_tag_raw_string() {
-    let source = "foo \\{{bar}}";
+    let source = "foo \\\\{{bar}}";
     let t = Template::compile(source.to_string()).ok().unwrap();
     assert_eq!(t.elements.len(), 1);
     assert_eq!(
@@ -653,7 +654,7 @@ fn test_parse_escaped_tag_raw_string() {
 
 #[test]
 fn test_parse_escaped_block_raw_string() {
-    let source = "\\{{{{foo}}}} bar";
+    let source = "\\\\{{{{foo}}}} bar";
     let t = Template::compile(source.to_string()).ok().unwrap();
     assert_eq!(t.elements.len(), 1);
     assert_eq!(

--- a/src/template.rs
+++ b/src/template.rs
@@ -136,7 +136,6 @@ impl Template {
     }
 
     fn unescape_tags(txt: &str) -> String {
-        // unescaped this is really \\
         txt.replace(r"\\{{", "{{")
     }
 


### PR DESCRIPTION
fix for #171. tests are updated an change was integration tested against https://github.com/softprops/porteurbars locally