### PR TITLE
Support unicode json paths

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -30,7 +30,7 @@ fn parse_json_visitor_inner<'a>(
 
     let mut seg_stack: VecDeque<&Token<Rule>> = VecDeque::new();
     if parser.path() {
-        for seg in parser.queue().iter() {
+        for mut seg in parser.queue_mut().iter_mut() {
             match seg.rule {
                 Rule::path_var | Rule::path_idx | Rule::path_key => {}
                 Rule::path_up => {
@@ -41,6 +41,13 @@ fn parse_json_visitor_inner<'a>(
                             seg_stack.pop_back();
                         }
                     }
+                }
+                Rule::path_literal_id => {
+                    // TODO only this type of seg needs to be mutable
+                    // is it better to use seg.copy() than to create a mutable iterator?
+                    seg.start += 1;
+                    seg.end -= 1;
+                    seg_stack.push_back(seg);
                 }
                 Rule::path_id |
                 Rule::path_raw_id |

--- a/src/context.rs
+++ b/src/context.rs
@@ -57,7 +57,7 @@ fn parse_json_visitor_inner<'a>(
         }
         Ok(())
     } else {
-        Err(RenderError::new("Invalid JSON path"))
+        Err(RenderError::new(format!("Invalid JSON path: {}", path)))
     }
 }
 
@@ -100,7 +100,7 @@ fn parse_json_visitor<'a>(
         parse_json_visitor_inner(path_stack, relative_path)?;
         Ok(())
     } else {
-        Err(RenderError::new("Invalid JSON path."))
+        Err(RenderError::new(format!("Invalid JSON path: {}", relative_path)))
     }
 
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -30,7 +30,7 @@ impl_rdp! {
         symbol_char = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["."]|["@"]|["$"]|["-"] }
         path_char = _{ ["/"] }
 
-        identifier = @{ symbol_char ~ ( symbol_char | path_char )* }
+        identifier = @{ ( path_literal_id | symbol_char ) ~ ( path_literal_id | symbol_char | path_char )* }
         reference = @{ identifier ~ (["["] ~ (string_literal|['0'..'9']+) ~ ["]"])*
                        ~ ["-"]* ~ reference* }
         name = _{ subexpression | reference }
@@ -111,12 +111,17 @@ impl_rdp! {
 
 // json path visitor
         path_ident = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["@"]|["$"]|["<"]|[">"]|["-"]}
+        // any unicode character except ], byte 0x5d
+        path_literal_char = _{['\u{1}'..'\u{5c}']|['\u{5e}'..'\u{7f}']|['\u{80}'..'\u{7ff}']|['\u{800}'..'\u{ffff}']|['\u{10000}'..'\u{10ffff}']}
+        // TODO use "" '' as delimiters
+        path_literal_id = { ["["] ~ path_literal_char+ ~ ["]"] }
+
         path_id = { path_ident+ }
         path_num_id = { ['0'..'9']+ }
         path_raw_id = { (path_ident|["/"])* }
         path_sep = _{ ["/"] | ["."] }
         path_up = { [".."] }
-        path_var = { path_id }
+        path_var = { path_id|path_literal_id }
         path_key = { ["["] ~ (["\""]|["'"])? ~ path_raw_id ~ (["\""]|["'"])? ~ ["]"] }
         path_idx = { ["["] ~ path_num_id ~ ["]"]}
         path_item = _{ path_up|path_var }


### PR DESCRIPTION
This mostly fixes issues #173 and #174.

There appears to be a bug when iterating through the entire context object using `{{#each .}} ... {{/each}}`. The `helper_with` may need to be adjusted. I'd also like to write some more tests for this feature.