### PR TITLE
Align path impl with original javascript version

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,7 @@ fn parse_json_visitor_inner<'a>(
     if parser.path() {
         for seg in parser.queue().iter() {
             match seg.rule {
-                Rule::path_var | Rule::path_idx | Rule::path_key => {}
+                Rule::path_var | Rule::path_key => {}
                 Rule::path_up => {
                     path_stack.pop_back();
                     if let Some(p) = seg_stack.pop_back() {
@@ -295,18 +295,6 @@ mod test {
                 .render(),
             "China".to_string()
         );
-        assert_eq!(
-            ctx.navigate(".", &VecDeque::new(), "addr.[\"country\"]")
-                .unwrap()
-                .render(),
-            "China".to_string()
-        );
-        assert_eq!(
-            ctx.navigate(".", &VecDeque::new(), "addr.['country']")
-                .unwrap()
-                .render(),
-            "China".to_string()
-        );
 
         let v = true;
         let ctx2 = Context::wraps(&v).unwrap();
@@ -318,12 +306,6 @@ mod test {
         );
 
         assert_eq!(
-            ctx.navigate(".", &VecDeque::new(), "titles[0]")
-                .unwrap()
-                .render(),
-            "programmer".to_string()
-        );
-        assert_eq!(
             ctx.navigate(".", &VecDeque::new(), "titles.[0]")
                 .unwrap()
                 .render(),
@@ -331,13 +313,13 @@ mod test {
         );
 
         assert_eq!(
-            ctx.navigate(".", &VecDeque::new(), "titles[0]/../../age")
+            ctx.navigate(".", &VecDeque::new(), "titles.[0]/../../age")
                 .unwrap()
                 .render(),
             "27".to_string()
         );
         assert_eq!(
-            ctx.navigate(".", &VecDeque::new(), "this.titles[0]/../../age")
+            ctx.navigate(".", &VecDeque::new(), "this.titles.[0]/../../age")
                 .unwrap()
                 .render(),
             "27".to_string()

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,6 @@ fn parse_json_visitor_inner<'a>(
     if parser.path() {
         for seg in parser.queue().iter() {
             match seg.rule {
-                Rule::path_var | Rule::path_key => {}
                 Rule::path_up => {
                     path_stack.pop_back();
                     if let Some(p) = seg_stack.pop_back() {
@@ -43,8 +42,7 @@ fn parse_json_visitor_inner<'a>(
                     }
                 }
                 Rule::path_id |
-                Rule::path_raw_id |
-                Rule::path_num_id => {
+                Rule::path_raw_id => {
                     seg_stack.push_back(seg);
                 }
                 _ => {}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -26,13 +26,11 @@ impl_rdp! {
         object_literal = { ["{"] ~ (string_literal ~ [":"] ~ literal)?
                            ~ ([","] ~ string_literal ~ [":"] ~ literal)* ~ ["}"] }
 
-        // FIXME: a[0], a["b]
-        symbol_char = _{ ['a'..'z']|['A'..'Z']|['0'..'9']|["_"]|["."]|["@"]|["$"]|["-"] }
+        symbol_char = _{['a'..'z']|['A'..'Z']|['0'..'9']|["-"]|["_"]|['\u{80}'..'\u{7ff}']|['\u{800}'..'\u{ffff}']|['\u{10000}'..'\u{10ffff}']}
         path_char = _{ ["/"] }
 
-        identifier = @{ symbol_char ~ ( symbol_char | path_char )* }
-        reference = @{ identifier ~ (["["] ~ (string_literal|['0'..'9']+) ~ ["]"])*
-                       ~ ["-"]* ~ reference* }
+        identifier = @{ symbol_char+ }
+        reference = @{ ["@"]? ~ path_inline }
         name = _{ subexpression | reference }
 
         param = { !["as"] ~ (literal | reference | subexpression) }
@@ -111,19 +109,18 @@ impl_rdp! {
 
         // json path visitor
         // Disallowed chars: Whitespace ! " # % & ' ( ) * + , . / ; < = > @ [ \ ] ^ ` { | } ~
-        js_path_char = _{['a'..'z']|['A'..'Z']|['0'..'9']|["-"]|["_"]|['\u{80}'..'\u{7ff}']|['\u{800}'..'\u{ffff}']|['\u{10000}'..'\u{10ffff}']}
-        path_id = { js_path_char+ }
 
-        path_num_id = { ['0'..'9']+ }
+        path_id = { symbol_char+ }
+
         path_raw_id = { (!["]"] ~ any)* }
         path_sep = _{ ["/"] | ["."] }
         path_up = { [".."] }
-        path_var = { path_id }
-        path_key = { ["["] ~  path_raw_id ~ ["]"] }
-        path_item = _{ path_up|path_var }
+        path_key = _{ ["["] ~  path_raw_id ~ ["]"] }
+        path_item = _{ path_up|path_id|path_current|path_key }
         path_current = { ["this"] | ["."] }
-        path = _{ (path_item | path_key | path_current)
-                  ~ (path_sep ~  (path_item | path_key | path_current))* ~ eoi }
+
+        path_inline = _{ path_item ~ (path_sep ~  path_item)* }
+        path = _{ path_inline ~ eoi }
     }
 }
 
@@ -157,13 +154,14 @@ fn test_reference() {
         "../a",
         "a.b",
         "@abc",
-        "a[\"abc\"]",
-        "aBc[\"abc\"]",
-        "abc[0][\"nice\"]",
+        "a.[abc]",
+        "aBc.[abc]",
+        "abc.[0].[nice]",
         "some-name",
         "this.[0].ok",
     ];
     for i in s.iter() {
+        println!("{}", i);
         let mut rdp = Rdp::new(StringInput::new(i));
         assert!(rdp.reference());
         assert!(rdp.end());

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -161,7 +161,6 @@ fn test_reference() {
         "this.[0].ok",
     ];
     for i in s.iter() {
-        println!("{}", i);
         let mut rdp = Rdp::new(StringInput::new(i));
         assert!(rdp.reference());
         assert!(rdp.end());

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -372,4 +372,27 @@ mod test {
         let r0 = handlebars.render("t0", &data);
         assert_eq!(r0.ok().unwrap(), "template<T>template<T>".to_string());
     }
+
+    #[test]
+    fn test_key_iteration_with_unicode() {
+        let mut handlebars = Registry::new();
+        assert!(
+            handlebars
+                .register_template_string("t0", "{{#each this}}{{@key}}: {{this}}\n{{/each}}")
+                .is_ok()
+        );
+        let data = json!({
+            "normal": 1,
+            "你好": 2,
+            "#special key": 3,
+            "😂": 4,
+            "me.dot.key": 5
+        });
+        let r0 = handlebars.render("t0", &data).ok().unwrap();
+        assert!(r0.contains("normal: 1"));
+        assert!(r0.contains("你好: 2"));
+        assert!(r0.contains("#special key: 3"));
+        assert!(r0.contains("😂: 4"));
+        assert!(r0.contains("me.dot.key: 5"));
+    }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -42,7 +42,7 @@ impl HelperDef for EachHelper {
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
-                                    format!("{}/{}.[{}]", local_rc.get_path(), inner_path, i);
+                                    format!("{}/{}/[{}]", local_rc.get_path(), inner_path, i);
                                 debug!("each path {:?}", new_path);
                                 local_rc.set_path(new_path.clone());
                             }
@@ -81,7 +81,7 @@ impl HelperDef for EachHelper {
 
                             if let Some(inner_path) = value.path() {
                                 let new_path =
-                                    format!("{}/{}.[{}]", local_rc.get_path(), inner_path, k);
+                                    format!("{}/{}/[{}]", local_rc.get_path(), inner_path, k);
                                 local_rc.set_path(new_path);
                             }
 


### PR DESCRIPTION
Fixes #173 and #174 

This patch is based work done in #175 by @hucal 

Removed path expression:

* a["a"]
* a['a']

Added support for:

* a.[a]
* a.[你好] // unicode 
