### PR TITLE
WIP: Allow HelperDef returns Json value

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::value::Value as Json;
 
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use context::{JsonTruthy, to_json};
 use render::{Renderable, RenderContext, Helper};
@@ -12,7 +12,7 @@ use error::RenderError;
 pub struct EachHelper;
 
 impl HelperDef for EachHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         let value = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"each\"")
         }));

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -1,4 +1,4 @@
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use context::JsonTruthy;
 use render::{Renderable, RenderContext, Helper};
@@ -10,7 +10,7 @@ pub struct IfHelper {
 }
 
 impl HelperDef for IfHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         let param = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"if\"")
         }));

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,4 +1,4 @@
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use context::JsonRender;
 use render::{RenderContext, Helper};
@@ -8,7 +8,7 @@ use error::RenderError;
 pub struct LogHelper;
 
 impl HelperDef for LogHelper {
-    fn call(&self, h: &Helper, _: &Registry, _: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, _: &Registry, _: &mut RenderContext) -> HelperResult {
         let param = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"log\"")
         }));

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -1,6 +1,6 @@
 use serde_json::value::Value as Json;
 
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use context::JsonRender;
 use render::{RenderContext, Helper};
@@ -10,7 +10,7 @@ use error::RenderError;
 pub struct LookupHelper;
 
 impl HelperDef for LookupHelper {
-    fn call(&self, h: &Helper, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, _: &Registry, rc: &mut RenderContext) -> HelperResult {
         let collection_value = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"lookup\"")
         }));

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -1,7 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use render::{Renderable, RenderContext, Helper};
-use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct RawHelper;

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -1,4 +1,4 @@
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use render::{Renderable, RenderContext, Helper};
 use error::RenderError;
@@ -7,7 +7,7 @@ use error::RenderError;
 pub struct RawHelper;
 
 impl HelperDef for RawHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         let tpl = h.template();
         if let Some(t) = tpl {
             t.render(r, rc)

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use helpers::HelperDef;
+use helpers::{HelperDef, HelperResult};
 use registry::Registry;
 use context::{JsonTruthy, to_json};
 use render::{Renderable, RenderContext, Helper};
@@ -10,7 +10,7 @@ use error::RenderError;
 pub struct WithHelper;
 
 impl HelperDef for WithHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         let param = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"with\"")
         }));

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -2,7 +2,7 @@ use render::{RenderContext, Helper};
 use context::JsonRender;
 use registry::Registry;
 use error::RenderError;
-use serde_json::Value;
+use serde_json::Value as Json;
 
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
 pub use self::helper_each::EACH_HELPER;
@@ -26,7 +26,7 @@ pub use self::helper_log::LOG_HELPER;
 /// ```ignore
 /// use handlebars::*;
 ///
-/// fn upper(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+/// fn upper(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> HelperResult {
 ///    // get parameter from helper or throw an error
 ///    let param = h.param(0).and_then(|v| v.value().as_string()).unwrap_or("");
 ///    try!(rc.writer.write(param.to_uppercase().into_bytes().as_ref()));
@@ -41,7 +41,7 @@ pub use self::helper_log::LOG_HELPER;
 /// ```
 /// use handlebars::*;
 ///
-/// fn dummy_block(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+/// fn dummy_block(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> HelperResult {
 ///     h.template().map(|t| t.render(r, rc)).unwrap_or(Ok(()))
 /// }
 /// ```
@@ -57,7 +57,7 @@ pub trait HelperDef: Send + Sync {
         _: &Helper,
         _: &Registry,
         _: &mut RenderContext,
-    ) -> Result<Option<Value>, RenderError> {
+    ) -> Result<Option<Json>, RenderError> {
         Ok(None)
     }
 
@@ -74,7 +74,7 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'b, 'c, 'd, 'e> Fn(&'b Helper, &'c Registry, &'d mut RenderContext) -> HelperResult,
+        + for<'b, 'c, 'd> Fn(&'b Helper, &'c Registry, &'d mut RenderContext) -> HelperResult,
 > HelperDef for F {
     fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         (*self)(h, r, rc)

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,6 +1,7 @@
 use render::{RenderContext, Helper};
 use registry::Registry;
 use error::RenderError;
+use serde_json::Value;
 
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
 pub use self::helper_each::EACH_HELPER;
@@ -45,18 +46,21 @@ pub use self::helper_log::LOG_HELPER;
 /// ```
 ///
 ///
+
+
+pub type HelperResult = Result<(), RenderError>;
+
 pub trait HelperDef: Send + Sync {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError>;
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult;
 }
 
 /// implement HelperDef for bare function so we can use function as helper
 impl<
     F: Send
         + Sync
-        + for<'b, 'c, 'd, 'e> Fn(&'b Helper, &'c Registry, &'d mut RenderContext)
-                           -> Result<(), RenderError>,
+        + for<'b, 'c, 'd, 'e> Fn(&'b Helper, &'c Registry, &'d mut RenderContext) -> HelperResult,
 > HelperDef for F {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
         (*self)(h, r, rc)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,14 +200,14 @@
 //!
 //! ```
 //! use std::io::Write;
-//! use handlebars::{Handlebars, HelperDef, RenderError, RenderContext, Helper, Context, JsonRender};
+//! use handlebars::{Handlebars, HelperDef, RenderContext, Helper, Context, JsonRender, HelperResult};
 //!
 //! // implement by a structure impls HelperDef
 //! #[derive(Clone, Copy)]
 //! struct SimpleHelper;
 //!
 //! impl HelperDef for SimpleHelper {
-//!   fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+//!   fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> HelperResult {
 //!     let param = h.param(0).unwrap();
 //!
 //!     try!(rc.writer.write("1st helper: ".as_bytes()));
@@ -217,7 +217,7 @@
 //! }
 //!
 //! // implement via bare function
-//! fn another_simple_helper (h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+//! fn another_simple_helper (h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> HelperResult {
 //!     let param = h.param(0).unwrap();
 //!
 //!     try!(rc.writer.write("2nd helper: ".as_bytes()));
@@ -232,7 +232,7 @@
 //!   handlebars.register_helper("another-simple-helper", Box::new(another_simple_helper));
 //!   // via closure
 //!   handlebars.register_helper("closure-helper",
-//!       Box::new(|h: &Helper, r: &Handlebars, rc: &mut RenderContext| -> Result<(), RenderError>{
+//!       Box::new(|h: &Helper, r: &Handlebars, rc: &mut RenderContext| -> HelperResult {
 //!           let param = h.param(0).unwrap();
 //!
 //!           try!(rc.writer.write("3rd helper: ".as_bytes()));
@@ -252,7 +252,7 @@
 //!
 //! #### Built-in Helpers
 //!
-//! * `{{#raw}} ... {{/raw}}` escape handlebars expression within the block
+//! * `{{{{#raw}}}} ... {{{{/raw}}}}` escape handlebars expression within the block
 //! * `{{#if ...}} ... {{else}} ... {{/if}}` if-else block
 //! * `{{#unless ...}} ... {{else}} .. {{/unless}}` if-not-else block
 //! * `{{#each ...}} ... {{/each}}` iterates over an array or object. Handlebar-rust doesn't support mustach iteration syntax so use this instead.
@@ -298,7 +298,7 @@ pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRen
 pub use self::registry::{EscapeFn, no_escape, html_escape, Registry as Handlebars};
 pub use self::render::{Renderable, Evaluable, RenderContext, Helper, ContextJson,
                        Directive as Decorator};
-pub use self::helpers::HelperDef;
+pub use self::helpers::{HelperDef, HelperResult};
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::context::{Context, JsonRender, to_json};
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -38,15 +38,12 @@ impl Subexpression {
         !(self.params.is_empty() && self.hash.is_empty())
     }
 
-    pub fn as_template(&self) -> Template {
-        let mut t = Template::new(false);
-        let el = if self.is_helper() {
+    pub fn into_element(&self) -> TemplateElement {
+        if self.is_helper() {
             HelperExpression(HelperTemplate::from(self))
         } else {
             Expression(Parameter::Name(self.name.clone()))
-        };
-        t.elements.push(el);
-        t
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #181 

This patch adds support for `HelperDef` to return typed Json value instead of writing it into writer as bytes. This makes it possible to get typed result from subexpression.

