### PR TITLE
Use Rc to maintain template reference across registry and render context

### DIFF
--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -27,7 +27,7 @@ impl DirectiveDef for InlineDirective {
         }));
 
 
-        rc.set_partial(name.to_owned(), template.clone());
+        rc.set_partial(name.to_owned(), template);
         Ok(())
     }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -111,9 +111,9 @@ impl HelperDef for EachHelper {
                         }
                         Ok(())
                     }
-                    _ => {
+                    (true, v) => {
                         Err(RenderError::new(
-                            format!("Param type is not iterable: {:?}", template),
+                            format!("Param type is not iterable: {:?}", v),
                         ))
                     }
                 };

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -24,7 +24,7 @@ pub fn expand_partial(
 
     let tname = d.name();
     let partial = rc.get_partial(tname);
-    let render_template = partial.as_ref().or(r.get_template(tname)).or(d.template());
+    let render_template = partial.or(r.get_template(tname)).or(d.template());
     match render_template {
         Some(t) => {
             let mut local_rc = rc.derive();
@@ -38,7 +38,7 @@ pub fn expand_partial(
 
             // @partial-block
             if let Some(t) = d.template() {
-                local_rc.set_partial("@partial-block".to_string(), t.clone());
+                local_rc.set_partial("@partial-block".to_string(), t);
             }
 
             let hash = d.hash();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
+use std::rc::Rc;
 
 use serde::Serialize;
 
@@ -53,7 +54,7 @@ pub fn no_escape(data: &str) -> String {
 ///
 /// It maintains compiled templates and registered helpers.
 pub struct Registry {
-    templates: HashMap<String, Template>,
+    templates: HashMap<String, Rc<Template>>,
     helpers: HashMap<String, Box<HelperDef + 'static>>,
     directives: HashMap<String, Box<DirectiveDef + 'static>>,
     escape_fn: EscapeFn,
@@ -109,7 +110,7 @@ impl Registry {
     {
         try!(
             Template::compile_with_name(tpl_str, name.to_owned(), self.source_map)
-                .and_then(|t| Ok(self.templates.insert(name.to_string(), t)))
+                .and_then(|t| Ok(self.templates.insert(name.to_string(), Rc::new(t))))
         );
         Ok(())
     }
@@ -196,8 +197,8 @@ impl Registry {
     }
 
     /// Return a registered template,
-    pub fn get_template(&self, name: &str) -> Option<&Template> {
-        self.templates.get(name)
+    pub fn get_template(&self, name: &str) -> Option<Rc<Template>> {
+        self.templates.get(name).map(|t| t.clone())
     }
 
     /// Return a registered helper
@@ -211,7 +212,7 @@ impl Registry {
     }
 
     /// Return all templates registered
-    pub fn get_templates(&self) -> &HashMap<String, Template> {
+    pub fn get_templates(&self) -> &HashMap<String, Rc<Template>> {
         &self.templates
     }
 


### PR DESCRIPTION
Previously, we have template reference in Registry (top level templates, helper inner template, per-registered partials) and RenderContext (partials). It has been a pain to maintain those references with different lifetime, which results in a few clones when associating templates into RenderContext.

This patch use Rc to store templates across the whole library. Based on previous benchmark, the overhead for Rc is not significant so we can keep code clean while not loosing performance.