### PR TITLE
Revert "Use Rc to maintain template reference across registry and render context"

### DIFF
--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -27,7 +27,7 @@ impl DirectiveDef for InlineDirective {
         }));
 
 
-        rc.set_partial(name.to_owned(), template);
+        rc.set_partial(name.to_owned(), template.clone());
         Ok(())
     }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -111,9 +111,9 @@ impl HelperDef for EachHelper {
                         }
                         Ok(())
                     }
-                    (true, v) => {
+                    _ => {
                         Err(RenderError::new(
-                            format!("Param type is not iterable: {:?}", v),
+                            format!("Param type is not iterable: {:?}", template),
                         ))
                     }
                 };

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -24,7 +24,7 @@ pub fn expand_partial(
 
     let tname = d.name();
     let partial = rc.get_partial(tname);
-    let render_template = partial.or(r.get_template(tname)).or(d.template());
+    let render_template = partial.as_ref().or(r.get_template(tname)).or(d.template());
     match render_template {
         Some(t) => {
             let mut local_rc = rc.derive();
@@ -38,7 +38,7 @@ pub fn expand_partial(
 
             // @partial-block
             if let Some(t) = d.template() {
-                local_rc.set_partial("@partial-block".to_string(), t);
+                local_rc.set_partial("@partial-block".to_string(), t.clone());
             }
 
             let hash = d.hash();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
-use std::rc::Rc;
 
 use serde::Serialize;
 
@@ -54,7 +53,7 @@ pub fn no_escape(data: &str) -> String {
 ///
 /// It maintains compiled templates and registered helpers.
 pub struct Registry {
-    templates: HashMap<String, Rc<Template>>,
+    templates: HashMap<String, Template>,
     helpers: HashMap<String, Box<HelperDef + 'static>>,
     directives: HashMap<String, Box<DirectiveDef + 'static>>,
     escape_fn: EscapeFn,
@@ -110,7 +109,7 @@ impl Registry {
     {
         try!(
             Template::compile_with_name(tpl_str, name.to_owned(), self.source_map)
-                .and_then(|t| Ok(self.templates.insert(name.to_string(), Rc::new(t))))
+                .and_then(|t| Ok(self.templates.insert(name.to_string(), t)))
         );
         Ok(())
     }
@@ -197,8 +196,8 @@ impl Registry {
     }
 
     /// Return a registered template,
-    pub fn get_template(&self, name: &str) -> Option<Rc<Template>> {
-        self.templates.get(name).map(|t| t.clone())
+    pub fn get_template(&self, name: &str) -> Option<&Template> {
+        self.templates.get(name)
     }
 
     /// Return a registered helper
@@ -212,7 +211,7 @@ impl Registry {
     }
 
     /// Return all templates registered
-    pub fn get_templates(&self) -> &HashMap<String, Rc<Template>> {
+    pub fn get_templates(&self) -> &HashMap<String, Template> {
         &self.templates
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -23,7 +23,7 @@ use partial;
 /// content is written to.
 ///
 pub struct RenderContext<'a> {
-    partials: HashMap<String, Rc<Template>>,
+    partials: HashMap<String, Template>,
     path: String,
     local_path_root: VecDeque<String>,
     local_variables: HashMap<String, Json>,
@@ -100,12 +100,12 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    pub fn get_partial(&self, name: &str) -> Option<Rc<Template>> {
-        self.partials.get(name).map(|trc| trc.clone())
+    pub fn get_partial(&self, name: &str) -> Option<Template> {
+        self.partials.get(name).map(|t| t.clone())
     }
 
-    pub fn set_partial(&mut self, name: String, tpl: Rc<Template>) {
-        self.partials.insert(name, tpl);
+    pub fn set_partial(&mut self, name: String, result: Template) {
+        self.partials.insert(name, result);
     }
 
     pub fn get_path(&self) -> &String {
@@ -292,8 +292,8 @@ pub struct Helper<'a> {
     params: Vec<ContextJson>,
     hash: BTreeMap<String, ContextJson>,
     block_param: &'a Option<BlockParam>,
-    template: Option<Rc<Template>>,
-    inverse: Option<Rc<Template>>,
+    template: &'a Option<Template>,
+    inverse: &'a Option<Template>,
     block: bool,
 }
 
@@ -320,8 +320,8 @@ impl<'a, 'b> Helper<'a> {
             params: evaluated_params,
             hash: evaluated_hash,
             block_param: &ht.block_param,
-            template: ht.template.clone(),
-            inverse: ht.inverse.clone(),
+            template: &ht.template,
+            inverse: &ht.inverse,
             block: ht.block,
         })
     }
@@ -387,13 +387,13 @@ impl<'a, 'b> Helper<'a> {
     ///
     /// Typically you will render the template via: `template.render(registry, render_context)`
     ///
-    pub fn template(&self) -> Option<Rc<Template>> {
-        self.template.as_ref().map(|t| t.clone())
+    pub fn template(&self) -> Option<&Template> {
+        (*self.template).as_ref().map(|t| t)
     }
 
     /// Returns the template of `else` branch if any
-    pub fn inverse(&self) -> Option<Rc<Template>> {
-        self.inverse.as_ref().map(|t| t.clone())
+    pub fn inverse(&self) -> Option<&Template> {
+        (*self.inverse).as_ref().map(|t| t)
     }
 
     /// Returns if the helper is a block one `{{#helper}}{{/helper}}` or not `{{helper 123}}`
@@ -423,19 +423,19 @@ impl<'a, 'b> Helper<'a> {
 }
 
 /// Render-time Decorator data when using in a decorator definition
-pub struct Directive {
+pub struct Directive<'a> {
     name: String,
     params: Vec<ContextJson>,
     hash: BTreeMap<String, ContextJson>,
-    template: Option<Rc<Template>>,
+    template: &'a Option<Template>,
 }
 
-impl<'a> Directive {
+impl<'a, 'b> Directive<'a> {
     fn from_template(
-        dt: &DirectiveTemplate,
+        dt: &'a DirectiveTemplate,
         registry: &Registry,
-        rc: &'a mut RenderContext,
-    ) -> Result<Directive, RenderError> {
+        rc: &'b mut RenderContext,
+    ) -> Result<Directive<'a>, RenderError> {
         let name = try!(dt.name.expand_as_name(registry, rc));
 
         let mut evaluated_params = Vec::new();
@@ -454,7 +454,7 @@ impl<'a> Directive {
             name: name,
             params: evaluated_params,
             hash: evaluated_hash,
-            template: dt.template.clone(),
+            template: &dt.template,
         })
     }
 
@@ -484,8 +484,8 @@ impl<'a> Directive {
     }
 
     /// Returns the default inner template if any
-    pub fn template(&self) -> Option<Rc<Template>> {
-        self.template.as_ref().map(|t| t.clone())
+    pub fn template(&self) -> Option<&Template> {
+        (*self.template).as_ref().map(|t| t)
     }
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,6 @@
 use std::iter::Peekable;
 use std::convert::From;
 use std::collections::{BTreeMap, VecDeque};
-use std::rc::Rc;
 
 use pest::Parser;
 use pest::Error as PestError;
@@ -77,8 +76,8 @@ pub struct HelperTemplate {
     pub params: Vec<Parameter>,
     pub hash: BTreeMap<String, Parameter>,
     pub block_param: Option<BlockParam>,
-    pub template: Option<Rc<Template>>,
-    pub inverse: Option<Rc<Template>>,
+    pub template: Option<Template>,
+    pub inverse: Option<Template>,
     pub block: bool,
 }
 
@@ -101,7 +100,7 @@ pub struct Directive {
     pub name: Parameter,
     pub params: Vec<Parameter>,
     pub hash: BTreeMap<String, Parameter>,
-    pub template: Option<Rc<Template>>,
+    pub template: Option<Template>,
 }
 
 impl Parameter {
@@ -493,7 +492,7 @@ impl Template {
 
                         let t = template_stack.pop_front().unwrap();
                         let h = helper_stack.front_mut().unwrap();
-                        h.template = Some(Rc::new(t));
+                        h.template = Some(t);
                     }
                     Rule::raw_block_text => {
                         let mut text = span.as_str();
@@ -568,9 +567,9 @@ impl Template {
                                 if h.name == close_tag_name {
                                     let prev_t = template_stack.pop_front().unwrap();
                                     if h.template.is_some() {
-                                        h.inverse = Some(Rc::new(prev_t));
+                                        h.inverse = Some(prev_t);
                                     } else {
-                                        h.template = Some(Rc::new(prev_t));
+                                        h.template = Some(prev_t);
                                     }
                                     let t = template_stack.front_mut().unwrap();
                                     t.elements.push(HelperBlock(h));
@@ -591,7 +590,7 @@ impl Template {
                                 let close_tag_name = exp.name;
                                 if d.name == close_tag_name {
                                     let prev_t = template_stack.pop_front().unwrap();
-                                    d.template = Some(Rc::new(prev_t));
+                                    d.template = Some(prev_t);
                                     let t = template_stack.front_mut().unwrap();
                                     if rule == Rule::directive_block_end {
                                         t.elements.push(DirectiveBlock(d));


### PR DESCRIPTION
Reverts sunng87/handlebars-rust#186

This breaks `Send` and `Sync` for `Registry`, which is required in some web framework