### PR TITLE
(feat) use cow to maintain context-json-lifetime

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -12,7 +12,12 @@ use error::RenderError;
 pub struct EachHelper;
 
 impl HelperDef for EachHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
+    fn call<'reg, 'rc: 'reg>(
+        &self,
+        h: &'reg Helper<'reg, 'rc>,
+        r: &'reg Registry,
+        rc: &'rc mut RenderContext<'rc>,
+    ) -> HelperResult {
         let value = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"each\"")
         }));

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -10,7 +10,12 @@ pub struct IfHelper {
 }
 
 impl HelperDef for IfHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
+    fn call<'a, 'b: 'a>(
+        &self,
+        h: &'a Helper<'a, 'b>,
+        r: &'a Registry,
+        rc: &'b mut RenderContext<'b>,
+    ) -> HelperResult {
         let param = try!(
             h.param(0)
                 .ok_or_else(|| { RenderError::new("Param not found for helper \"if\"") })

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -8,7 +8,12 @@ use error::RenderError;
 pub struct LogHelper;
 
 impl HelperDef for LogHelper {
-    fn call(&self, h: &Helper, _: &Registry, _: &mut RenderContext) -> HelperResult {
+    fn call<'reg, 'rc: 'reg>(
+        &self,
+        h: &'reg Helper<'reg, 'rc>,
+        _: &'reg Registry,
+        _: &'rc mut RenderContext<'rc>,
+    ) -> HelperResult {
         let param = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"log\"")
         }));

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -10,7 +10,12 @@ use error::RenderError;
 pub struct LookupHelper;
 
 impl HelperDef for LookupHelper {
-    fn call(&self, h: &Helper, _: &Registry, rc: &mut RenderContext) -> HelperResult {
+    fn call<'reg, 'rc: 'reg>(
+        &self,
+        h: &'reg Helper<'reg, 'rc>,
+        _: &'reg Registry,
+        rc: &'rc mut RenderContext<'rc>,
+    ) -> HelperResult {
         let collection_value = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"lookup\"")
         }));

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -6,7 +6,12 @@ use render::{Helper, RenderContext, Renderable};
 pub struct RawHelper;
 
 impl HelperDef for RawHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
+    fn call<'reg, 'rc: 'reg>(
+        &self,
+        h: &'reg Helper<'reg, 'rc>,
+        r: &'reg Registry,
+        rc: &'rc mut RenderContext<'rc>,
+    ) -> HelperResult {
         let tpl = h.template();
         if let Some(t) = tpl {
             t.render(r, rc)

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -10,7 +10,12 @@ use error::RenderError;
 pub struct WithHelper;
 
 impl HelperDef for WithHelper {
-    fn call(&self, h: &Helper, r: &Registry, rc: &mut RenderContext) -> HelperResult {
+    fn call<'reg, 'rc: 'reg>(
+        &self,
+        h: &'reg Helper<'reg, 'rc>,
+        r: &'reg Registry,
+        rc: &'rc mut RenderContext<'rc>,
+    ) -> HelperResult {
         let param = try!(h.param(0).ok_or_else(|| {
             RenderError::new("Param not found for helper \"with\"")
         }));

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -9,11 +9,11 @@ use context::{merge_json, Context};
 use render::{Directive, Evaluable, RenderContext, Renderable};
 use error::RenderError;
 
-fn render_partial(
-    t: &Template,
-    d: &Directive,
-    r: &Registry,
-    local_rc: &mut RenderContext,
+fn render_partial<'reg, 'rc: 'reg>(
+    t: &'reg Template,
+    d: &'reg Directive<'reg, 'rc>,
+    r: &'reg Registry,
+    local_rc: &'rc mut RenderContext<'rc>,
 ) -> Result<(), RenderError> {
     let context_param = d.params().get(0).and_then(|p| p.path());
     if let Some(p) = context_param {
@@ -40,10 +40,10 @@ fn render_partial(
     }
 }
 
-pub fn expand_partial(
-    d: &Directive,
-    r: &Registry,
-    rc: &mut RenderContext,
+pub fn expand_partial<'reg, 'rc: 'reg>(
+    d: &'reg Directive<'reg, 'rc>,
+    r: &'reg Registry,
+    rc: &'rc mut RenderContext<'rc>,
 ) -> Result<(), RenderError> {
     // try eval inline partials first
     if let Some(t) = d.template() {


### PR DESCRIPTION
Currently, in order to bypass lifetime check, JSON data from context are cloned everytime when there is a reference to it. This adds way too much overhead in rendering time. 

This patch is to reduce clones as much as possible by using a `Cow` to hold a borrowed reference (from context) or owned Json (computed)