### PR TITLE
Stop asking for &mut Write in Registry API

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -5,21 +5,18 @@ pub trait Output {
     fn write(&mut self, seg: &str) -> Result<(), IOError>;
 }
 
-pub struct WriteOutput<'a, W: 'a + Write> {
-    write: &'a mut W,
+pub struct WriteOutput<W: Write> {
+    write: W,
 }
 
-impl<'a, W: 'a + Write> Output for WriteOutput<'a, W> {
+impl<W: Write> Output for WriteOutput<W> {
     fn write(&mut self, seg: &str) -> Result<(), IOError> {
         self.write.write_all(seg.as_bytes())
     }
 }
 
-impl<'a, W: 'a + Write> WriteOutput<'a, W> {
-    pub fn new(write: &'a mut W) -> WriteOutput<'a, W>
-    where
-        W: Write + 'a,
-    {
+impl<W: Write> WriteOutput<W> {
+    pub fn new(write: W) -> WriteOutput<W> {
         WriteOutput { write }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -293,13 +293,13 @@ impl Registry {
         &self,
         name: &str,
         data: &T,
-        mut writer: W,
+        writer: W,
     ) -> Result<(), RenderError>
     where
         T: Serialize,
         W: Write,
     {
-        let mut output = WriteOutput::new(&mut writer);
+        let mut output = WriteOutput::new(writer);
         self.render_to_output(name, data, &mut output)
     }
 
@@ -322,7 +322,7 @@ impl Registry {
         &self,
         template_string: &str,
         data: &T,
-        mut writer: W,
+        writer: W,
     ) -> Result<(), TemplateRenderError>
     where
         T: Serialize,
@@ -332,7 +332,7 @@ impl Registry {
         let ctx = Context::wraps(data)?;
         let mut local_helpers = HashMap::new();
         let mut render_context = RenderContext::new(ctx, &mut local_helpers, None);
-        let mut out = WriteOutput::new(&mut writer);
+        let mut out = WriteOutput::new(writer);
         tpl.render(self, &mut render_context, &mut out)
             .map_err(TemplateRenderError::from)
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -293,13 +293,13 @@ impl Registry {
         &self,
         name: &str,
         data: &T,
-        writer: &mut W,
+        mut writer: W,
     ) -> Result<(), RenderError>
     where
         T: Serialize,
         W: Write,
     {
-        let mut output = WriteOutput::new(writer);
+        let mut output = WriteOutput::new(&mut writer);
         self.render_to_output(name, data, &mut output)
     }
 
@@ -322,7 +322,7 @@ impl Registry {
         &self,
         template_string: &str,
         data: &T,
-        writer: &mut W,
+        mut writer: W,
     ) -> Result<(), TemplateRenderError>
     where
         T: Serialize,
@@ -332,7 +332,7 @@ impl Registry {
         let ctx = Context::wraps(data)?;
         let mut local_helpers = HashMap::new();
         let mut render_context = RenderContext::new(ctx, &mut local_helpers, None);
-        let mut out = WriteOutput::new(writer);
+        let mut out = WriteOutput::new(&mut writer);
         tpl.render(self, &mut render_context, &mut out)
             .map_err(TemplateRenderError::from)
     }
@@ -342,7 +342,7 @@ impl Registry {
         &self,
         template_source: &mut Read,
         data: &T,
-        writer: &mut W,
+        writer: W,
     ) -> Result<(), TemplateRenderError>
     where
         T: Serialize,


### PR DESCRIPTION
Partial fix for #190.

There's no reason to have these `&mut`s here. Remove them. No other code changes are necessary, because Rust's stdlib fixes cases where people are already passing in `&mut`.