### PR TITLE
eliminate use of try!

### DIFF
--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -18,10 +18,8 @@ fn format_helper(
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = try!(
-        h.param(0,)
-            .ok_or(RenderError::new("Param 0 is required for format helper.",),)
-    );
+    let param = h.param(0)
+        .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
     Ok(())
@@ -40,10 +38,8 @@ fn format_decorator(
         Box::new(
             move |h: &Helper, _: &Handlebars, _: &mut RenderContext, out: &mut Output| {
                 // get parameter from helper or throw an error
-                let param = try!(
-                    h.param(0,)
-                        .ok_or(RenderError::new("Param 0 is required for format helper.",),)
-                );
+                let param = h.param(0)
+                    .ok_or(RenderError::new("Param 0 is required for format helper."))?;
                 let rendered = format!("{} {}", param.value().render(), suffix);
                 out.write(rendered.as_ref())?;
                 Ok(())
@@ -60,20 +56,16 @@ fn rank_helper(
     _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = try!(
-        h.param(0,)
-            .and_then(|v| v.value().as_u64(),)
-            .ok_or(RenderError::new(
-                "Param 0 with u64 type is required for rank helper."
-            ),)
-    ) as usize;
-    let teams = try!(
-        h.param(1,)
-            .and_then(|v| v.value().as_array(),)
-            .ok_or(RenderError::new(
-                "Param 1 with array type is required for rank helper"
-            ),)
-    );
+    let rank = h.param(0)
+        .and_then(|v| v.value().as_u64())
+        .ok_or(RenderError::new(
+            "Param 0 with u64 type is required for rank helper.",
+        ))? as usize;
+    let teams = h.param(1)
+        .and_then(|v| v.value().as_array())
+        .ok_or(RenderError::new(
+            "Param 1 with array type is required for rank helper",
+        ))?;
     let total = teams.len();
     if rank == 0 {
         out.write("champion")?;

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -18,10 +18,8 @@ fn format_helper(
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = try!(
-        h.param(0,)
-            .ok_or(RenderError::new("Param 0 is required for format helper.",),)
-    );
+    let param = h.param(0)
+        .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
     Ok(())
@@ -34,20 +32,16 @@ fn rank_helper(
     _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = try!(
-        h.param(0,)
-            .and_then(|v| v.value().as_u64(),)
-            .ok_or(RenderError::new(
-                "Param 0 with u64 type is required for rank helper."
-            ),)
-    ) as usize;
-    let teams = try!(
-        h.param(1,)
-            .and_then(|v| v.value().as_array(),)
-            .ok_or(RenderError::new(
-                "Param 1 with array type is required for rank helper"
-            ),)
-    );
+    let rank = h.param(0)
+        .and_then(|v| v.value().as_u64())
+        .ok_or(RenderError::new(
+            "Param 0 with u64 type is required for rank helper.",
+        ))? as usize;
+    let teams = h.param(1)
+        .and_then(|v| v.value().as_array())
+        .ok_or(RenderError::new(
+            "Param 1 with array type is required for rank helper",
+        ))?;
     let total = teams.len();
     if rank == 0 {
         out.write("champion")?;

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -22,10 +22,8 @@ fn format_helper(
     _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let param = try!(
-        h.param(0,)
-            .ok_or(RenderError::new("Param 0 is required for format helper.",),)
-    );
+    let param = h.param(0)
+        .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
     Ok(())
@@ -38,20 +36,16 @@ fn rank_helper(
     _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = try!(
-        h.param(0,)
-            .and_then(|v| v.value().as_u64(),)
-            .ok_or(RenderError::new(
-                "Param 0 with u64 type is required for rank helper."
-            ),)
-    ) as usize;
-    let teams = try!(
-        h.param(1,)
-            .and_then(|v| v.value().as_array(),)
-            .ok_or(RenderError::new(
-                "Param 1 with array type is required for rank helper"
-            ),)
-    );
+    let rank = h.param(0)
+        .and_then(|v| v.value().as_u64())
+        .ok_or(RenderError::new(
+            "Param 0 with u64 type is required for rank helper.",
+        ))? as usize;
+    let teams = h.param(1)
+        .and_then(|v| v.value().as_array())
+        .ok_or(RenderError::new(
+            "Param 1 with array type is required for rank helper",
+        ))?;
     let total = teams.len();
     if rank == 0 {
         out.write("champion")?;

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -20,12 +20,10 @@ fn get_name<'a>(d: &'a Directive) -> Result<&'a str, RenderError> {
 
 impl DirectiveDef for InlineDirective {
     fn call(&self, d: &Directive, _: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
-        let name = try!(get_name(d));
+        let name = get_name(d)?;
 
-        let template = try!(
-            d.template()
-                .ok_or_else(|| RenderError::new("inline should have a block"))
-        );
+        let template = d.template()
+            .ok_or_else(|| RenderError::new("inline should have a block"))?;
 
         rc.set_partial(name.to_owned(), Rc::new(template.clone()));
         Ok(())

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -20,10 +20,8 @@ impl HelperDef for EachHelper {
         rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let value = try!(
-            h.param(0)
-                .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))
-        );
+        let value = h.param(0)
+            .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?;
 
         let template = h.template();
 
@@ -61,11 +59,11 @@ impl HelperDef for EachHelper {
                                 local_rc.push_block_context(&map)?;
                             }
 
-                            try!(t.render(r, &mut local_rc, out));
+                            t.render(r, &mut local_rc, out)?;
 
                             // local_rc is dropped at the end of each iteration
                             // so we don't need to cleanup
-                            // 
+                            //
                             // if h.block_param().is_some() {
                             //     local_rc.pop_block_context();
                             // }
@@ -103,7 +101,7 @@ impl HelperDef for EachHelper {
                                 local_rc.push_block_context(&map)?;
                             }
 
-                            try!(t.render(r, &mut local_rc, out));
+                            t.render(r, &mut local_rc, out)?;
 
                             // if h.block_param().is_some() {
                             //     local_rc.pop_block_context();
@@ -118,7 +116,7 @@ impl HelperDef for EachHelper {
                     }
                     (false, _) => {
                         if let Some(else_template) = h.inverse() {
-                            try!(else_template.render(r, rc, out));
+                            else_template.render(r, rc, out)?;
                         }
                         Ok(())
                     }

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -18,10 +18,8 @@ impl HelperDef for IfHelper {
         rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let param = try!(
-            h.param(0)
-                .ok_or_else(|| RenderError::new("Param not found for helper \"if\""))
-        );
+        let param = h.param(0)
+            .ok_or_else(|| RenderError::new("Param not found for helper \"if\""))?;
 
         let mut value = param.value().is_truthy();
 

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -16,10 +16,8 @@ impl HelperDef for LogHelper {
         _: &mut RenderContext,
         _: &mut Output,
     ) -> HelperResult {
-        let param = try!(
-            h.param(0)
-                .ok_or_else(|| RenderError::new("Param not found for helper \"log\""))
-        );
+        let param = h.param(0)
+            .ok_or_else(|| RenderError::new("Param not found for helper \"log\""))?;
 
         info!(
             "{}: {}",

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -18,14 +18,10 @@ impl HelperDef for LookupHelper {
         _: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let collection_value = try!(
-            h.param(0)
-                .ok_or_else(|| RenderError::new("Param not found for helper \"lookup\""))
-        );
-        let index = try!(
-            h.param(1)
-                .ok_or_else(|| RenderError::new("Insufficient params for helper \"lookup\""))
-        );
+        let collection_value = h.param(0)
+            .ok_or_else(|| RenderError::new("Param not found for helper \"lookup\""))?;
+        let index = h.param(1)
+            .ok_or_else(|| RenderError::new("Insufficient params for helper \"lookup\""))?;
 
         let null = Json::Null;
         let value = match collection_value.value() {
@@ -43,7 +39,7 @@ impl HelperDef for LookupHelper {
             _ => &null,
         };
         let r = value.render();
-        try!(out.write(r.as_ref()));
+        out.write(r.as_ref())?;
         Ok(())
     }
 }

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -18,10 +18,8 @@ impl HelperDef for WithHelper {
         rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let param = try!(
-            h.param(0)
-                .ok_or_else(|| RenderError::new("Param not found for helper \"with\""))
-        );
+        let param = h.param(0)
+            .ok_or_else(|| RenderError::new("Param not found for helper \"with\""))?;
 
         rc.promote_local_vars();
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -50,7 +50,7 @@ pub fn expand_partial(
 ) -> Result<(), RenderError> {
     // try eval inline partials first
     if let Some(t) = d.template() {
-        try!(t.eval(r, rc));
+        t.eval(r, rc)?;
     }
 
     if rc.is_current_template(d.name()) {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -143,10 +143,8 @@ impl Registry {
     where
         S: AsRef<str>,
     {
-        try!(
-            Template::compile_with_name(tpl_str, name.to_owned(), self.source_map)
-                .and_then(|t| Ok(self.templates.insert(name.to_string(), t)))
-        );
+        Template::compile_with_name(tpl_str, name.to_owned(), self.source_map)
+            .and_then(|t| Ok(self.templates.insert(name.to_string(), t)))?;
         Ok(())
     }
 
@@ -171,7 +169,7 @@ impl Registry {
         P: AsRef<Path>,
     {
         let mut file =
-            try!(File::open(tpl_path).map_err(|e| TemplateFileError::IOError(e, name.to_owned())));
+            File::open(tpl_path).map_err(|e| TemplateFileError::IOError(e, name.to_owned()))?;
         self.register_template_source(name, &mut file)
     }
 
@@ -182,12 +180,10 @@ impl Registry {
         tpl_source: &mut Read,
     ) -> Result<(), TemplateFileError> {
         let mut buf = String::new();
-        try!(
-            tpl_source
-                .read_to_string(&mut buf)
-                .map_err(|e| TemplateFileError::IOError(e, name.to_owned()))
-        );
-        try!(self.register_template_string(name, buf));
+        tpl_source
+            .read_to_string(&mut buf)
+            .map_err(|e| TemplateFileError::IOError(e, name.to_owned()))?;
+        self.register_template_string(name, buf)?;
         Ok(())
     }
 
@@ -269,7 +265,7 @@ impl Registry {
         self.get_template(&name.to_string())
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
-                let ctx = try!(Context::wraps(data));
+                let ctx = Context::wraps(data)?;
                 let mut local_helpers = HashMap::new();
                 let mut render_context =
                     RenderContext::new(ctx, &mut local_helpers, t.name.clone());
@@ -332,8 +328,8 @@ impl Registry {
         T: Serialize,
         W: Write,
     {
-        let tpl = try!(Template::compile2(template_string, self.source_map));
-        let ctx = try!(Context::wraps(data));
+        let tpl = Template::compile2(template_string, self.source_map)?;
+        let ctx = Context::wraps(data)?;
         let mut local_helpers = HashMap::new();
         let mut render_context = RenderContext::new(ctx, &mut local_helpers, None);
         let mut out = WriteOutput::new(writer);
@@ -353,11 +349,9 @@ impl Registry {
         W: Write,
     {
         let mut tpl_str = String::new();
-        try!(
-            template_source
-                .read_to_string(&mut tpl_str)
-                .map_err(|e| TemplateRenderError::IOError(e, "Unamed template source".to_owned()))
-        );
+        template_source
+            .read_to_string(&mut tpl_str)
+            .map_err(|e| TemplateRenderError::IOError(e, "Unamed template source".to_owned()))?;
         self.render_template_to_write(&tpl_str, data, writer)
     }
 
@@ -429,7 +423,7 @@ mod test {
             rc: &mut RenderContext,
             out: &mut Output,
         ) -> Result<(), RenderError> {
-            try!(h.template().unwrap().render(r, rc, out));
+            h.template().unwrap().render(r, rc, out)?;
             Ok(())
         }
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -150,7 +150,7 @@ impl Template {
         it: &mut Peekable<FlatPairs<Rule>>,
         limit: usize,
     ) -> Result<Parameter, TemplateError> {
-        let espec = try!(Template::parse_expression(source, it.by_ref(), limit));
+        let espec = Template::parse_expression(source, it.by_ref(), limit)?;
         if let Parameter::Name(name) = espec.name {
             Ok(Parameter::Subexpression(Subexpression {
                 name: name,
@@ -205,11 +205,9 @@ impl Template {
                     Parameter::Name(s.to_owned())
                 }
             }
-            Rule::subexpression => try!(Template::parse_subexpression(
-                source,
-                it.by_ref(),
-                param_span.end(),
-            )),
+            Rule::subexpression => {
+                Template::parse_subexpression(source, it.by_ref(), param_span.end())?
+            }
             _ => unreachable!(),
         };
 
@@ -240,7 +238,7 @@ impl Template {
         // identifier
         let key = name_node.as_str().to_owned();
 
-        let value = try!(Template::parse_param(source, it.by_ref(), limit));
+        let value = Template::parse_param(source, it.by_ref(), limit)?;
         Ok((key, value))
     }
 
@@ -292,7 +290,7 @@ impl Template {
             it.next();
         }
 
-        let name = try!(Template::parse_name(source, it.by_ref(), limit));
+        let name = Template::parse_name(source, it.by_ref(), limit)?;
 
         loop {
             let rule;
@@ -313,14 +311,14 @@ impl Template {
 
             match rule {
                 Rule::param => {
-                    params.push(try!(Template::parse_param(source, it.by_ref(), end)));
+                    params.push(Template::parse_param(source, it.by_ref(), end)?);
                 }
                 Rule::hash => {
-                    let (key, value) = try!(Template::parse_hash(source, it.by_ref(), end));
+                    let (key, value) = Template::parse_hash(source, it.by_ref(), end)?;
                     hashes.insert(key, value);
                 }
                 Rule::block_param => {
-                    block_param = Some(try!(Template::parse_block_param(source, it.by_ref(), end)));
+                    block_param = Some(Template::parse_block_param(source, it.by_ref(), end)?);
                 }
                 Rule::pro_whitespace_omitter => {
                     omit_pro_ws = true;
@@ -448,7 +446,7 @@ impl Template {
                     | Rule::raw_block_start
                     | Rule::directive_block_start
                     | Rule::partial_block_start => {
-                        let exp = try!(Template::parse_expression(source, it.by_ref(), span.end()));
+                        let exp = Template::parse_expression(source, it.by_ref(), span.end())?;
 
                         match rule {
                             Rule::helper_block_start | Rule::raw_block_start => {
@@ -488,7 +486,7 @@ impl Template {
                     Rule::invert_tag => {
                         // hack: invert_tag structure is similar to ExpressionSpec, so I
                         // use it here to represent the data
-                        let exp = try!(Template::parse_expression(source, it.by_ref(), span.end()));
+                        let exp = Template::parse_expression(source, it.by_ref(), span.end())?;
 
                         if exp.omit_pre_ws {
                             Template::remove_previous_whitespace(&mut template_stack);
@@ -517,7 +515,7 @@ impl Template {
                     | Rule::raw_block_end
                     | Rule::directive_block_end
                     | Rule::partial_block_end => {
-                        let exp = try!(Template::parse_expression(source, it.by_ref(), span.end()));
+                        let exp = Template::parse_expression(source, it.by_ref(), span.end())?;
                         if exp.omit_pre_ws {
                             Template::remove_previous_whitespace(&mut template_stack);
                         }

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -14,20 +14,16 @@ impl HelperDef for GtHelper {
         _: &Handlebars,
         _: &mut RenderContext,
     ) -> Result<Option<Value>, RenderError> {
-        let p1 = try!(
-            h.param(0,)
-                .and_then(|v| v.value().as_i64(),)
-                .ok_or(RenderError::new(
-                    "Param 0 with i64 type is required for gt helper."
-                ),)
-        );
-        let p2 = try!(
-            h.param(1,)
-                .and_then(|v| v.value().as_i64(),)
-                .ok_or(RenderError::new(
-                    "Param 1 with i64 type is required for gt helper."
-                ),)
-        );
+        let p1 = h.param(0)
+            .and_then(|v| v.value().as_i64())
+            .ok_or(RenderError::new(
+                "Param 0 with i64 type is required for gt helper.",
+            ))?;
+        let p2 = h.param(1)
+            .and_then(|v| v.value().as_i64())
+            .ok_or(RenderError::new(
+                "Param 1 with i64 type is required for gt helper.",
+            ))?;
 
         Ok(Some(Value::Bool(p1 > p2)))
     }
@@ -42,13 +38,11 @@ impl HelperDef for NotHelper {
         _: &Handlebars,
         _: &mut RenderContext,
     ) -> Result<Option<Value>, RenderError> {
-        let p1 = try!(
-            h.param(0,)
-                .and_then(|v| v.value().as_bool(),)
-                .ok_or(RenderError::new(
-                    "Param 0 with bool type is required for not helper."
-                ),)
-        );
+        let p1 = h.param(0)
+            .and_then(|v| v.value().as_bool())
+            .ok_or(RenderError::new(
+                "Param 0 with bool type is required for not helper.",
+            ))?;
 
         Ok(Some(Value::Bool(!p1)))
     }


### PR DESCRIPTION
IntelliJ can automatically eliminate `try!`. I have run it.

Afterwards, I ran `cargo +stable fmt`, which printed a load of errors about the rustfmt.toml, but seems to have done roughly the right thing; it's removed some trailing commas in places that they probably weren't needed.