### PR TITLE
Fix mustach escape

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,7 +1,7 @@
 whitespace = _{ " "|"\t"|"\n"|"\r" }
 keywords = @{ "as" | "else" }
 
-escape = @{ "\\" ~ ("\\"+ | "{{" ~ "{{"?) }
+escape = @{ ("\\" ~ "{{" ~ "{{"?) | ("\\" ~ "\\"+ ~ &"{{") }
 raw_text = ${ ( escape | (!"{{" ~ any) )+ }
 raw_block_text = ${ ( escape | (!"{{{{" ~ any) )* }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,7 +1,11 @@
 whitespace = _{ " "|"\t"|"\n"|"\r" }
 keywords = @{ "as" | "else" }
 
-raw_text = @{ ( "\\{{{{"? ~ "\\{{"? ~ !"{{" ~ any )+ }
+escape = @{ "\\" }
+escape_slash = @{ "\\" ~ ("\\"+ | "{{" ~ "{{"?) }
+//escape_quote = @{ "\\" ~ "{{" ~ "{{"? }
+//raw_text = @{ (!("\\" | "{{") ~ any )* ~ (escape_slash ~ raw_text)? }
+raw_text = @{ ( escape_slash? ~ !"{{" ~ any )+ }
 raw_block_text = @{ ( !"{{{{" ~ any )* }
 
 literal = { string_literal |
@@ -37,52 +41,51 @@ subexpression = { "(" ~ name ~ (hash|param)* ~ ")" }
 
 pre_whitespace_omitter = { "~" }
 pro_whitespace_omitter = { "~" }
-escape = { "\\" }
 
-expression = { !escape ~ !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~ name ~
+expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~ name ~
 pro_whitespace_omitter? ~ "}}" }
 
-html_expression = { !escape ~ "{{{" ~ pre_whitespace_omitter? ~ name ~
+html_expression = { "{{{" ~ pre_whitespace_omitter? ~ name ~
 pro_whitespace_omitter? ~ "}}}" }
 
 helper_expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~ exp_line ~
 pro_whitespace_omitter? ~ "}}" }
 
-directive_expression = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
+directive_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
 pro_whitespace_omitter? ~ "}}" }
-partial_expression = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
+partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
                      ~ pro_whitespace_omitter? ~ "}}" }
 invert_tag_item = { "else"|"^" }
 invert_tag = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
              ~ pro_whitespace_omitter? ~ "}}"}
-helper_block_start = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
+helper_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
                      pro_whitespace_omitter? ~ "}}" }
-helper_block_end = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
                    pro_whitespace_omitter? ~ "}}" }
 helper_block = _{ helper_block_start ~ template ~
                   (invert_tag ~ template)? ~ helper_block_end }
 
-directive_block_start = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
+directive_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
                         ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-directive_block_end = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+directive_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
                         pro_whitespace_omitter? ~ "}}" }
 directive_block = _{ directive_block_start ~ template ~
                      directive_block_end }
 
-partial_block_start = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
+partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
                         ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
-partial_block_end = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
                       pro_whitespace_omitter? ~ "}}" }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
-raw_block_start = { !escape ~ "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
+raw_block_start = { "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
                     pro_whitespace_omitter? ~ "}}}}" }
-raw_block_end = { !escape ~ "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+raw_block_end = { "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
                   pro_whitespace_omitter? ~ "}}}}" }
 raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
-hbs_comment = { !escape ~ "{{!--" ~ (!"--}}" ~ any)* ~ "--}}" }
-hbs_comment_compact = { !escape ~ "{{!" ~ (!"}}" ~ any)* ~ "}}" }
+hbs_comment = { "{{!--" ~ (!"--}}" ~ any)* ~ "--}}" }
+hbs_comment_compact = { "{{!" ~ (!"}}" ~ any)* ~ "}}" }
 
 template = { (
             raw_text |

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,12 +1,9 @@
 whitespace = _{ " "|"\t"|"\n"|"\r" }
 keywords = @{ "as" | "else" }
 
-escape = @{ "\\" }
-escape_slash = @{ "\\" ~ ("\\"+ | "{{" ~ "{{"?) }
-//escape_quote = @{ "\\" ~ "{{" ~ "{{"? }
-//raw_text = @{ (!("\\" | "{{") ~ any )* ~ (escape_slash ~ raw_text)? }
-raw_text = @{ ( escape_slash? ~ !"{{" ~ any )+ }
-raw_block_text = @{ ( !"{{{{" ~ any )* }
+escape = @{ "\\" ~ ("\\"+ | "{{" ~ "{{"?) }
+raw_text = ${ ( escape | (!"{{" ~ any) )+ }
+raw_block_text = ${ ( escape | (!"{{{{" ~ any) )* }
 
 literal = { string_literal |
             array_literal |

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -26,13 +26,13 @@ macro_rules! assert_rule {
 macro_rules! assert_not_rule {
     ($rule:expr, $in:expr) => {
         assert!(
-            HandlebarsParser::parse($rule, $in)
-                .unwrap()
-                .last()
-                .unwrap()
-                .into_span()
-                .end() !=
-            $in.len()
+            HandlebarsParser::parse($rule, $in).is_err()
+                || HandlebarsParser::parse($rule, $in)
+                    .unwrap()
+                    .last()
+                    .unwrap()
+                    .into_span()
+                    .end() != $in.len()
         );
     };
 }
@@ -48,17 +48,15 @@ macro_rules! assert_rule_match {
 fn test_raw_text() {
     let s = vec![
         "<h1> helloworld </h1>    ",
-        // r"hello\{{world}}",
-        // r"hello\{{#if world}}nice\{{/if}}",
-        // r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
+        r"hello\{{world}}",
+        r"hello\{{#if world}}nice\{{/if}}",
+        r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
     ];
     for i in s.iter() {
         assert_rule!(Rule::raw_text, i);
     }
 
-    let s_not_escape = vec![
-        r"\\{{hello}}"
-    ];
+    let s_not_escape = vec![r"\\{{hello}}"];
     for i in s_not_escape.iter() {
         assert_not_rule!(Rule::raw_text, i);
     }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -23,6 +23,21 @@ macro_rules! assert_rule {
 }
 
 #[cfg(test)]
+macro_rules! assert_not_rule {
+    ($rule:expr, $in:expr) => {
+        assert!(!
+            HandlebarsParser::parse($rule, $in)
+                .unwrap()
+                .last()
+                .unwrap()
+                .into_span()
+                .end() ==
+            $in.len()
+        );
+    };
+}
+
+#[cfg(test)]
 macro_rules! assert_rule_match {
     ($rule:expr, $in:expr) => {
         assert!(HandlebarsParser::parse($rule, $in).is_ok());
@@ -33,12 +48,19 @@ macro_rules! assert_rule_match {
 fn test_raw_text() {
     let s = vec![
         "<h1> helloworld </h1>    ",
-        "hello\\{{world}}",
-        "hello\\{{#if world}}nice\\{{/if}}",
-        "hello \\{{{{raw}}}}hello\\{{{{/raw}}}}",
+        r"hello\{{world}}",
+        r"hello\{{#if world}}nice\{{/if}}",
+        r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
     ];
     for i in s.iter() {
         assert_rule!(Rule::raw_text, i);
+    }
+
+    let s_not_escape = vec![
+        r"\\{{hello}}"
+    ];
+    for i in s_not_escape.iter() {
+        assert_not_rule!(Rule::raw_text, i);
     }
 }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,4 +1,4 @@
-//const _GRAMMAR: &'static str = include_str!("grammar.pest");
+const _GRAMMAR: &'static str = include_str!("grammar.pest");
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
@@ -25,13 +25,13 @@ macro_rules! assert_rule {
 #[cfg(test)]
 macro_rules! assert_not_rule {
     ($rule:expr, $in:expr) => {
-        assert!(!
+        assert!(
             HandlebarsParser::parse($rule, $in)
                 .unwrap()
                 .last()
                 .unwrap()
                 .into_span()
-                .end() ==
+                .end() !=
             $in.len()
         );
     };
@@ -48,9 +48,9 @@ macro_rules! assert_rule_match {
 fn test_raw_text() {
     let s = vec![
         "<h1> helloworld </h1>    ",
-        r"hello\{{world}}",
-        r"hello\{{#if world}}nice\{{/if}}",
-        r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
+        // r"hello\{{world}}",
+        // r"hello\{{#if world}}nice\{{/if}}",
+        // r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
     ];
     for i in s.iter() {
         assert_rule!(Rule::raw_text, i);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,4 +1,4 @@
-const _GRAMMAR: &'static str = include_str!("grammar.pest");
+// const _GRAMMAR: &'static str = include_str!("grammar.pest");
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -483,6 +483,11 @@ mod test {
 
         assert_eq!(
             "{{hello}}",
+            r.render_template(r"\{{hello}}", &data).unwrap()
+        );
+
+        assert_eq!(
+            r"\world",
             r.render_template(r"\\{{hello}}", &data).unwrap()
         );
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -487,6 +487,11 @@ mod test {
         );
 
         assert_eq!(
+            " {{hello}}",
+            r.render_template(r" \{{hello}}", &data).unwrap()
+        );
+
+        assert_eq!(
             r"\world",
             r.render_template(r"\\{{hello}}", &data).unwrap()
         );

--- a/src/template.rs
+++ b/src/template.rs
@@ -705,6 +705,17 @@ fn test_parse_escaped_tag_raw_string() {
 }
 
 #[test]
+fn test_pure_backslash_raw_string() {
+    let source = r"\\\\";
+    let t = Template::compile(source).ok().unwrap();
+    assert_eq!(t.elements.len(), 1);
+    assert_eq!(
+        *t.elements.get(0).unwrap(),
+        RawString(source.to_string())
+    );
+}
+
+#[test]
 fn test_parse_escaped_block_raw_string() {
     let source = r"\{{{{foo}}}} bar";
     let t = Template::compile(source.to_string()).ok().unwrap();

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -1,0 +1,21 @@
+extern crate handlebars;
+
+#[macro_use]
+extern crate serde_json;
+
+use handlebars::Handlebars;
+
+#[test]
+fn test_escape_216() {
+    let hbs = Handlebars::new();
+
+    let data = json!({
+        "FOO": "foo",
+        "BAR": "bar"
+    });
+
+    assert_eq!(
+        hbs.render_template(r"\\\\ {{FOO}} {{BAR}} {{FOO}}{{BAR}} {{FOO}}#{{BAR}} {{FOO}}//{{BAR}} {{FOO}}\\{{FOO}} {{FOO}}\\\\{{FOO}}\\\{{FOO}} \\\{{FOO}} \{{FOO}} \{{FOO}}", &data).unwrap(),
+        r"\\\\ foo bar foobar foo#bar foo//bar foo\foo foo\\\foo\\foo \\foo {{FOO}} {{FOO}}"
+    );
+}


### PR DESCRIPTION
Fixes #216 

There are issues with current backslash escape implementation. This patch changed both parser and template processing to ensure backslash was correctly treated. 