### PR TITLE
Implement register_template_directory to Registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = "^1.0.0"
 serde_json = "^1.0.0"
 regex = "^1.0.0"
 lazy_static = "^1.0.0"
+walkdir = "^1.0.0"
 
 [dev-dependencies]
 env_logger = "^0.4.0"

--- a/examples/render-cli.rs
+++ b/examples/render-cli.rs
@@ -41,9 +41,10 @@ fn main() {
     let mut handlebars = Handlebars::new();
 
     handlebars
-        .register_template_file(&filename, &filename)
+        .register_templates_directory()
         .ok()
         .unwrap();
+
     match handlebars.render(&filename, &data) {
         Ok(data) => {
             println!("{}", data);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::From;
 use std::io::Error as IOError;
 use std::error::Error;
 use std::fmt;
@@ -242,3 +243,4 @@ impl TemplateRenderError {
         }
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ extern crate serde;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
+extern crate walkdir;
 
 pub use self::template::Template;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};


### PR DESCRIPTION
Allow a caller to specify a directory path and an extension, then
register all files in that directory.

Closes #11