### PR TITLE
Implement register_template_directory to Registry 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ serde = "^1.0.0"
 serde_json = "^1.0.0"
 regex = "^1.0.0"
 lazy_static = "^1.0.0"
-walkdir = "^1.0.0"
+walkdir = "^2.1.4"
 
 [dev-dependencies]
 env_logger = "^0.4.0"
 maplit = "^1.0.0"
 serde_derive = "^1.0.0"
+tempfile = "^3.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = "^1.0.0"
 serde_json = "^1.0.0"
 regex = "^1.0.0"
 lazy_static = "^1.0.0"
+walkdir = "^1.0.0"
 
 [dev-dependencies]
 env_logger = "^0.4.0"

--- a/examples/render-cli.rs
+++ b/examples/render-cli.rs
@@ -44,7 +44,6 @@ fn main() {
         .register_template_file(&filename, &filename)
         .ok()
         .unwrap();
-
     match handlebars.render(&filename, &data) {
         Ok(data) => {
             println!("{}", data);

--- a/examples/render-cli.rs
+++ b/examples/render-cli.rs
@@ -41,9 +41,10 @@ fn main() {
     let mut handlebars = Handlebars::new();
 
     handlebars
-        .register_template_file(&filename, &filename)
+        .register_templates_directory()
         .ok()
         .unwrap();
+
     match handlebars.render(&filename, &data) {
         Ok(data) => {
             println!("{}", data);

--- a/examples/render-cli.rs
+++ b/examples/render-cli.rs
@@ -41,7 +41,7 @@ fn main() {
     let mut handlebars = Handlebars::new();
 
     handlebars
-        .register_templates_directory()
+        .register_template_file(&filename, &filename)
         .ok()
         .unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::From;
 use std::io::Error as IOError;
 use std::error::Error;
 use std::fmt;
@@ -242,3 +243,4 @@ impl TemplateRenderError {
         }
     }
 }
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use std::convert::From;
 use std::io::Error as IOError;
 use std::error::Error;
 use std::fmt;

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fmt;
 
 use serde_json::error::Error as SerdeError;
+use walkdir::Error as WalkdirError;
 
 use template::Parameter;
 
@@ -207,6 +208,13 @@ quick_error! {
             description(err.description())
             display("Template \"{}\": {}", name, err)
         }
+    }
+}
+
+impl From<WalkdirError> for TemplateFileError {
+    fn from(error: WalkdirError) -> TemplateFileError {
+        let path_string: String = error.path().map(|p| p.to_string_lossy().to_string()).unwrap_or_default();
+        TemplateFileError::IOError(IOError::from(error), path_string)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ extern crate serde;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
+extern crate walkdir;
 
 pub use self::template::Template;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,8 @@ extern crate quick_error;
 #[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
+#[cfg(test)]
+extern crate tempfile;
 
 extern crate regex;
 extern crate serde;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -209,7 +209,7 @@ impl Registry {
                     self.register_template_file(&tpl_canonical_name, &tpl_path)?;
                 }
 
-                 Ok(())
+                Ok(())
             },
         }
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::io;
-use std::fs::{File, read_dir};
+use std::fs::File;
 use std::path::Path;
 use std::fmt::{self, Debug, Formatter};
 
@@ -17,7 +17,7 @@ use directives::{self, DirectiveDef};
 use support::str::StringWriter;
 use error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 
-use walkdir::{WalkDir, DirEntry};
+use walkdir::WalkDir;
 
 lazy_static!{
     static ref DEFAULT_REPLACE: Regex = Regex::new(">|<|\"|&").unwrap();


### PR DESCRIPTION
Allow a caller to specify a directory path and an extension, then
register all files in that directory.

Closes #11