### PR TITLE
Split Context and RenderContext for better mutable granularity 

### DIFF
--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -61,13 +61,13 @@ fn rank_helper(
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)?
+    let total = h.param(1)?
         .as_ref()
         .and_then(|v| v.value().as_array())
+        .map(|arr| arr.len())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",
         ))?;
-    let total = teams.len();
     if rank == 0 {
         out.write("champion")?;
     } else if rank >= total - 2 {

--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -7,18 +7,19 @@ use std::error::Error;
 
 use serde_json::value::{Map, Value as Json};
 
-use handlebars::{to_json, Decorator, Handlebars, Helper, JsonRender, Output, RenderContext,
+use handlebars::{to_json, Context, Decorator, Handlebars, Helper, JsonRender, Output, RenderContext,
                  RenderError};
 
 // default format helper
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = h.param(0)?
+    let param = h.param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -28,17 +29,18 @@ fn format_helper(
 fn format_decorator(
     d: &Decorator,
     _: &Handlebars,
-    rc: &RenderContext,
+    _: &Context,
+    rc: &mut RenderContext,
 ) -> Result<(), RenderError> {
-    let suffix = d.param(0)?
+    let suffix = d.param(0)
         .map(|v| v.value().render())
         .unwrap_or("".to_owned());
-    rc.inner_mut().register_local_helper(
+    rc.register_local_helper(
         "format",
         Box::new(
-            move |h: &Helper, _: &Handlebars, _: &RenderContext, out: &mut Output| {
+            move |h: &Helper, _: &Handlebars, _: &Context, _: &mut RenderContext, out: &mut Output| {
                 // get parameter from helper or throw an error
-                let param = h.param(0)?
+                let param = h.param(0)
                     .ok_or(RenderError::new("Param 0 is required for format helper."))?;
                 let rendered = format!("{} {}", param.value().render(), suffix);
                 out.write(rendered.as_ref())?;
@@ -53,15 +55,16 @@ fn format_decorator(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)?
+    let rank = h.param(0)
         .and_then(|v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let total = h.param(1)?
+    let total = h.param(1)
         .as_ref()
         .and_then(|v| v.value().as_array())
         .map(|arr| arr.len())

--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -14,11 +14,11 @@ use handlebars::{to_json, Decorator, Handlebars, Helper, JsonRender, Output, Ren
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = h.param(0)
+    let param = h.param(0)?
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -28,17 +28,17 @@ fn format_helper(
 fn format_decorator(
     d: &Decorator,
     _: &Handlebars,
-    rc: &mut RenderContext,
+    rc: &RenderContext,
 ) -> Result<(), RenderError> {
-    let suffix = d.param(0)
+    let suffix = d.param(0)?
         .map(|v| v.value().render())
         .unwrap_or("".to_owned());
-    rc.register_local_helper(
+    rc.inner_mut().register_local_helper(
         "format",
         Box::new(
-            move |h: &Helper, _: &Handlebars, _: &mut RenderContext, out: &mut Output| {
+            move |h: &Helper, _: &Handlebars, _: &RenderContext, out: &mut Output| {
                 // get parameter from helper or throw an error
-                let param = h.param(0)
+                let param = h.param(0)?
                     .ok_or(RenderError::new("Param 0 is required for format helper."))?;
                 let rendered = format!("{} {}", param.value().render(), suffix);
                 out.write(rendered.as_ref())?;
@@ -53,15 +53,16 @@ fn format_decorator(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)
+    let rank = h.param(0)?
         .and_then(|v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)
+    let teams = h.param(1)?
+        .as_ref()
         .and_then(|v| v.value().as_array())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -37,13 +37,13 @@ fn rank_helper(
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)?
+    let total = h.param(1)?
         .as_ref()
         .and_then(|v| v.value().as_array())
+        .map(|arr| arr.len())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",
         ))?;
-    let total = teams.len();
     if rank == 0 {
         out.write("champion")?;
     } else if rank >= total - 2 {

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -8,17 +8,18 @@ extern crate serde_json;
 use std::error::Error;
 use serde_json::value::{Map, Value as Json};
 
-use handlebars::{to_json, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError};
+use handlebars::{to_json, Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError};
 
 // define a custom helper
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = h.param(0)?
+    let param = h.param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -29,15 +30,16 @@ fn format_helper(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)?
+    let rank = h.param(0)
         .and_then(|v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let total = h.param(1)?
+    let total = h.param(1)
         .as_ref()
         .and_then(|v| v.value().as_array())
         .map(|arr| arr.len())

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -14,11 +14,11 @@ use handlebars::{to_json, Handlebars, Helper, JsonRender, Output, RenderContext,
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
     // get parameter from helper or throw an error
-    let param = h.param(0)
+    let param = h.param(0)?
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -29,15 +29,16 @@ fn format_helper(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)
+    let rank = h.param(0)?
         .and_then(|v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)
+    let teams = h.param(1)?
+        .as_ref()
         .and_then(|v| v.value().as_array())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -41,13 +41,13 @@ fn rank_helper(
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)?
+    let total = h.param(1)?
         .as_ref()
         .and_then(|v| v.value().as_array())
+        .map(|arr| arr.len())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",
         ))?;
-    let total = teams.len();
     if rank == 0 {
         out.write("champion")?;
     } else if rank >= total - 2 {

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -19,10 +19,11 @@ use handlebars::{to_json, Context, Handlebars, Helper, JsonRender, Output, Rende
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let param = h.param(0)?
+    let param = h.param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -33,15 +34,16 @@ fn format_helper(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &RenderContext,
+    _: &Context,
+    _: &mut RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)?
+    let rank = h.param(0)
         .and_then(|ref v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let total = h.param(1)?
+    let total = h.param(1)
         .as_ref()
         .and_then(|v| v.value().as_array())
         .map(|arr| arr.len())

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -19,10 +19,10 @@ use handlebars::{to_json, Context, Handlebars, Helper, JsonRender, Output, Rende
 fn format_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let param = h.param(0)
+    let param = h.param(0)?
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
     let rendered = format!("{} pts", param.value().render());
     out.write(rendered.as_ref())?;
@@ -33,15 +33,16 @@ fn format_helper(
 fn rank_helper(
     h: &Helper,
     _: &Handlebars,
-    _: &mut RenderContext,
+    _: &RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let rank = h.param(0)
-        .and_then(|v| v.value().as_u64())
+    let rank = h.param(0)?
+        .and_then(|ref v| v.value().as_u64())
         .ok_or(RenderError::new(
             "Param 0 with u64 type is required for rank helper.",
         ))? as usize;
-    let teams = h.param(1)
+    let teams = h.param(1)?
+        .as_ref()
         .and_then(|v| v.value().as_array())
         .ok_or(RenderError::new(
             "Param 1 with array type is required for rank helper",

--- a/src/context.rs
+++ b/src/context.rs
@@ -168,74 +168,12 @@ impl Context {
     }
 }
 
-/// Render Json data with default format
-pub trait JsonRender {
-    fn render(&self) -> String;
-}
-
-pub trait JsonTruthy {
-    fn is_truthy(&self) -> bool;
-}
-
-impl JsonRender for Json {
-    fn render(&self) -> String {
-        match *self {
-            Json::String(ref s) => s.to_string(),
-            Json::Bool(i) => i.to_string(),
-            Json::Number(ref n) => n.to_string(),
-            Json::Null => "".to_owned(),
-            Json::Array(ref a) => {
-                let mut buf = String::new();
-                buf.push('[');
-                for i in a.iter() {
-                    buf.push_str(i.render().as_ref());
-                    buf.push_str(", ");
-                }
-                buf.push(']');
-                buf
-            }
-            Json::Object(_) => "[object]".to_owned(),
-        }
-    }
-}
-
-pub fn to_json<T>(src: &T) -> Json
-where
-    T: Serialize,
-{
-    to_value(src).unwrap_or_default()
-}
-
-pub fn as_string(src: &Json) -> Option<&str> {
-    src.as_str()
-}
-
-impl JsonTruthy for Json {
-    fn is_truthy(&self) -> bool {
-        match *self {
-            Json::Bool(ref i) => *i,
-            Json::Number(ref n) => n.as_f64().map(|f| f.is_normal()).unwrap_or(false),
-            Json::Null => false,
-            Json::String(ref i) => i.len() > 0,
-            Json::Array(ref i) => i.len() > 0,
-            Json::Object(ref i) => i.len() > 0,
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use context::{self, Context, JsonRender};
+    use context::{self, Context};
+    use value::{self, JsonRender};
     use std::collections::VecDeque;
     use serde_json::value::{Map, Value as Json};
-
-    #[test]
-    fn test_json_render() {
-        let raw = "<p>Hello world</p>\n<p thing=\"hello\"</p>";
-        let thing = Json::String(raw.to_string());
-
-        assert_eq!(raw, thing.render());
-    }
 
     #[derive(Serialize)]
     struct Address {
@@ -331,12 +269,12 @@ mod test {
     #[test]
     fn test_this() {
         let mut map_with_this = Map::new();
-        map_with_this.insert("this".to_string(), context::to_json(&"hello"));
-        map_with_this.insert("age".to_string(), context::to_json(&5usize));
+        map_with_this.insert("this".to_string(), value::to_json(&"hello"));
+        map_with_this.insert("age".to_string(), value::to_json(&5usize));
         let ctx1 = Context::wraps(&map_with_this).unwrap();
 
         let mut map_without_this = Map::new();
-        map_without_this.insert("age".to_string(), context::to_json(&4usize));
+        map_without_this.insert("age".to_string(), value::to_json(&4usize));
         let ctx2 = Context::wraps(&map_without_this).unwrap();
 
         assert_eq!(
@@ -360,7 +298,7 @@ mod test {
         let map = json!({ "age": 4 });
         let s = "hello".to_owned();
         let hash = btreemap!{
-            "tag".to_owned() => context::to_json(&"h1")
+            "tag".to_owned() => value::to_json(&"h1")
         };
 
         let ctx_a1 = Context::wraps(&context::merge_json(&map, &hash)).unwrap();
@@ -381,7 +319,7 @@ mod test {
             "h1".to_owned()
         );
 
-        let ctx_a2 = Context::wraps(&context::merge_json(&context::to_json(&s), &hash)).unwrap();
+        let ctx_a2 = Context::wraps(&context::merge_json(&value::to_json(&s), &hash)).unwrap();
         assert_eq!(
             ctx_a2
                 .navigate(".", &VecDeque::new(), "this")

--- a/src/context.rs
+++ b/src/context.rs
@@ -173,7 +173,7 @@ mod test {
     use context::{self, Context};
     use value::{self, JsonRender};
     use std::collections::VecDeque;
-    use serde_json::value::{Map, Value as Json};
+    use serde_json::value::Map;
 
     #[derive(Serialize)]
     struct Address {

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -49,9 +49,9 @@ mod test {
         let hbs = Registry::new();
 
         let ctx = Context::null();
-        let mut rc = RenderContext::new(ctx, None);
-        t0.elements[0].eval(&hbs, &mut rc).unwrap();
+        let mut rc = RenderContext::new(None);
+        t0.elements[0].eval(&hbs, &ctx, &mut rc).unwrap();
 
-        assert!(rc.inner_mut().get_partial(&"hello".to_owned()).is_some());
+        assert!(rc.get_partial(&"hello".to_owned()).is_some());
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -8,7 +8,7 @@ use error::RenderError;
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<String, RenderError> {
+fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<String, RenderError> {
     d.param(0, registry, render_context)?
         .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
         .and_then(|v| {
@@ -20,13 +20,13 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, r
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<(), RenderError> {
         let name = get_name(d, registry, render_context)?;
 
         let template = d.template()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;
 
-        render_context.set_partial(name, Rc::new(template.clone()));
+        render_context.inner_mut().set_partial(name, Rc::new(template.clone()));
         Ok(())
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -1,32 +1,36 @@
 use std::rc::Rc;
 
+use template::DirectiveTemplate;
 use directives::{DirectiveDef, DirectiveResult};
 use registry::Registry;
-use render::{Directive, RenderContext};
+use render::RenderContext;
 use error::RenderError;
 
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc mut Directive<'reg, 'rc>) -> Result<String, RenderError> {
-    d.param(0)?
-        .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
-        .and_then(|v| {
-            v.value()
-                .as_str()
-                .map(|s| s.to_owned())
-                .ok_or_else(|| RenderError::new("inline name must be string"))
-        })
+fn get_name<'reg: 'rc, 'rc>(d: &'reg DirectiveTemplate, reg: &'reg Registry, rc: &'rc mut RenderContext) -> Result<String, RenderError> {
+    if let Some(p) = d.params.get(0) {
+        p.expand(reg, rc)
+            .and_then(|v| {
+                v.value()
+                    .as_str()
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| RenderError::new("inline name must be string"))
+            })
+    } else {
+        Err(RenderError::new("Param required for directive \"inline\""))
+    }
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult {
-        let name = get_name(d)?;
+    fn call<'reg: 'rc, 'rc>(&self, d: &'reg DirectiveTemplate, r: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult {
+        let name = get_name(d, r, rc)?;
 
-        let template = d.template()
+        let template = d.template.as_ref()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;
 
-        d.render_context().set_partial(name, Rc::new(template.clone()));
+        rc.set_partial(name, Rc::new(template.clone()));
         Ok(())
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -51,11 +51,9 @@ mod test {
         let hbs = Registry::new();
 
         let ctx = Context::null();
-        let mut hlps = HashMap::new();
-
-        let mut rc = RenderContext::new(ctx, &mut hlps, None);
+        let mut rc = RenderContext::new(ctx, None);
         t0.elements[0].eval(&hbs, &mut rc).unwrap();
 
-        assert!(rc.get_partial(&"hello".to_owned()).is_some());
+        assert!(rc.inner_mut().get_partial(&"hello".to_owned()).is_some());
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -8,8 +8,8 @@ use error::RenderError;
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, RenderError> {
-    d.param(0)
+fn get_name<'reg: 'rc, 'rc>(d: &'rc mut Directive<'reg, 'rc>) -> Result<String, RenderError> {
+    d.param(0)?
         .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
         .and_then(|v| {
             v.value()
@@ -20,15 +20,14 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, Rend
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: Directive<'reg, 'rc>) -> DirectiveResult {
-        let name = get_name(&d)?;
+    fn call<'reg: 'rc, 'rc>(&self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult {
+        let name = get_name(d)?;
 
         let template = d.template()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;
 
-        let mut render_context = d.into_render_context();
-        render_context.set_partial(name, Rc::new(template.clone()));
-        Ok(render_context)
+        d.render_context().set_partial(name, Rc::new(template.clone()));
+        Ok(())
     }
 }
 

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use template::DirectiveTemplate;
+use context::Context;
 use directives::{DirectiveDef, DirectiveResult};
 use registry::Registry;
 use render::RenderContext;
@@ -9,9 +10,9 @@ use error::RenderError;
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'reg DirectiveTemplate, reg: &'reg Registry, rc: &'rc mut RenderContext) -> Result<String, RenderError> {
+fn get_name<'reg: 'rc, 'rc>(d: &'reg DirectiveTemplate, reg: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> Result<String, RenderError> {
     if let Some(p) = d.params.get(0) {
-        p.expand(reg, rc)
+        p.expand(reg, ctx, rc)
             .and_then(|v| {
                 v.value()
                     .as_str()
@@ -24,8 +25,8 @@ fn get_name<'reg: 'rc, 'rc>(d: &'reg DirectiveTemplate, reg: &'reg Registry, rc:
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'reg DirectiveTemplate, r: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult {
-        let name = get_name(d, r, rc)?;
+    fn call<'reg: 'rc, 'rc>(&self, d: &'reg DirectiveTemplate, r: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> DirectiveResult {
+        let name = get_name(d, r, ctx, rc)?;
 
         let template = d.template.as_ref()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -8,8 +8,8 @@ use error::RenderError;
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, RenderError> {
-    d.param(0)?
+fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<String, RenderError> {
+    d.param(0, registry, render_context)?
         .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
         .and_then(|v| {
             v.value()
@@ -20,13 +20,13 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, Rend
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg, 'rc>, _: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
-        let name = get_name(d)?;
+    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
+        let name = get_name(d, registry, render_context)?;
 
         let template = d.template()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;
 
-        rc.set_partial(name, Rc::new(template.clone()));
+        render_context.set_partial(name, Rc::new(template.clone()));
         Ok(())
     }
 }

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -39,7 +39,6 @@ mod test {
     use registry::Registry;
     use context::Context;
     use render::{Evaluable, RenderContext};
-    use std::collections::HashMap;
 
     #[test]
     fn test_inline() {

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -20,7 +20,7 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, Rend
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg, 'rc>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg, 'rc>, _: &'reg Registry, render_context: &'rc RenderContext) -> Result<(), RenderError> {
         let name = get_name(d)?;
 
         let template = d.template()

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -8,8 +8,8 @@ use error::RenderError;
 #[derive(Clone, Copy)]
 pub struct InlineDirective;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<String, RenderError> {
-    d.param(0, registry, render_context)?
+fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<String, RenderError> {
+    d.param(0)?
         .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
         .and_then(|v| {
             v.value()
@@ -20,8 +20,8 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg>, registry: &'reg Registry, r
 }
 
 impl DirectiveDef for InlineDirective {
-    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<(), RenderError> {
-        let name = get_name(d, registry, render_context)?;
+    fn call<'reg: 'rc, 'rc>(&self, d: &'rc Directive<'reg, 'rc>, registry: &'reg Registry, render_context: &'rc RenderContext) -> Result<(), RenderError> {
+        let name = get_name(d)?;
 
         let template = d.template()
             .ok_or_else(|| RenderError::new("inline should have a block"))?;

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -4,6 +4,8 @@ use error::RenderError;
 
 pub use self::inline::INLINE_DIRECTIVE;
 
+pub type DirectiveResult = Result<RenderContext, RenderError>;
+
 /// Decorator Definition
 ///
 /// Implement this trait to define your own decorators or directives. Currently
@@ -50,19 +52,19 @@ pub use self::inline::INLINE_DIRECTIVE;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError>;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: Directive<'reg, 'rc>) -> DirectiveResult;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc Directive<'reg, 'rc>, &'reg Registry, &'rc RenderContext)
-        -> Result<(), RenderError>,
+        + for<'reg, 'rc> Fn(Directive<'reg, 'rc>)
+        -> DirectiveResult,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError> {
-        (*self)(d, r, rc)
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: Directive<'reg, 'rc>) -> DirectiveResult {
+        (*self)(d)
     }
 }
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -1,4 +1,5 @@
 use template::DirectiveTemplate;
+use context::Context;
 use render::RenderContext;
 use registry::Registry;
 use error::RenderError;
@@ -53,19 +54,19 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, r: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, r: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> DirectiveResult;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'reg DirectiveTemplate, &'reg Registry, &'rc mut RenderContext)
+        + for<'reg, 'rc> Fn(&'reg DirectiveTemplate, &'reg Registry, &'rc Context, &'rc mut RenderContext)
         -> DirectiveResult,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, reg: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult {
-        (*self)(d, reg, rc)
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, reg: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> DirectiveResult {
+        (*self)(d, reg, ctx, rc)
     }
 }
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -50,18 +50,18 @@ use error::RenderError;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call(&self, d: &Directive, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError>;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError>;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'b, 'c, 'd, 'e> Fn(&'b Directive, &'c Registry, &'d mut RenderContext)
+        + for<'reg, 'rc> Fn(&'rc Directive<'reg, 'rc>, &'reg Registry, &'rc mut RenderContext<'rc>)
         -> Result<(), RenderError>,
 > DirectiveDef for F
 {
-    fn call(&self, d: &Directive, r: &Registry, rc: &mut RenderContext) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
         (*self)(d, r, rc)
     }
 }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -50,18 +50,18 @@ use error::RenderError;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError>;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError>;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc Directive<'reg>, &'reg Registry, &'rc RenderContext)
+        + for<'reg, 'rc> Fn(&'rc Directive<'reg, 'rc>, &'reg Registry, &'rc RenderContext)
         -> Result<(), RenderError>,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError> {
         (*self)(d, r, rc)
     }
 }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -21,13 +21,13 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// ```
 /// use handlebars::*;
 ///
-/// fn update_data(_: &Decorator, _: &Handlebars, rc: &mut RenderContext)
+/// fn update_data<'reg: 'rc, 'rc>(_: &Decorator, _: &Handlebars, _: &Context, rc: &mut RenderContext)
 ///         -> Result<(), RenderError> {
 ///     // modify json object
-///     let mut data = rc.context_mut().data_mut();
-///     if let Some(ref mut m) = data.as_object_mut() {
-///         m.insert("hello".to_string(), to_json(&"world".to_owned()));
-///     }
+///     // let mut data = rc.context_mut().data_mut();
+///     // if let Some(ref mut m) = data.as_object_mut() {
+///     //    m.insert("hello".to_string(), to_json(&"world".to_owned()));
+///     // }
 ///     Ok(())
 /// }
 ///
@@ -40,9 +40,9 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// ```
 /// use handlebars::*;
 ///
-/// fn override_helper(_: &Decorator, _: &Handlebars, rc: &mut RenderContext)
+/// fn override_helper(_: &Decorator, _: &Handlebars, _: &Context, rc: &mut RenderContext)
 ///         -> Result<(), RenderError> {
-///     let new_helper = |h: &Helper, _: &Handlebars, rc: &mut RenderContext, out: &mut Output|
+///     let new_helper = |h: &Helper, _: &Handlebars, _: &Context, rc: &mut RenderContext, out: &mut Output|
 ///             -> Result<(), RenderError> {
 ///         // your helper logic
 ///         Ok(())

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -50,18 +50,18 @@ use error::RenderError;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError>;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError>;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc Directive<'reg, 'rc>, &'reg Registry, &'rc mut RenderContext<'rc>)
+        + for<'reg, 'rc> Fn(&'rc Directive<'reg>, &'reg Registry, &'rc mut RenderContext<'rc>)
         -> Result<(), RenderError>,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg, 'rc>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
         (*self)(d, r, rc)
     }
 }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -1,6 +1,5 @@
-use template::DirectiveTemplate;
 use context::Context;
-use render::RenderContext;
+use render::{Directive, RenderContext};
 use registry::Registry;
 use error::RenderError;
 
@@ -54,18 +53,18 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, r: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> DirectiveResult;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &Directive<'reg, 'rc>, r: &'reg Registry, ctx: &'rc Context, rc: &mut RenderContext) -> DirectiveResult;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'reg DirectiveTemplate, &'reg Registry, &'rc Context, &'rc mut RenderContext)
+        + for<'reg, 'rc> Fn(&Directive<'reg, 'rc>, &'reg Registry, &'rc Context, &mut RenderContext)
         -> DirectiveResult,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, reg: &'reg Registry, ctx: &'rc Context, rc: &'rc mut RenderContext) -> DirectiveResult {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &Directive<'reg, 'rc>, reg: &'reg Registry, ctx: &'rc Context, rc: &mut RenderContext) -> DirectiveResult {
         (*self)(d, reg, ctx, rc)
     }
 }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -71,7 +71,8 @@ mod inline;
 #[cfg(test)]
 mod test {
     use registry::Registry;
-    use context::{self, as_string, Context};
+    use context::{Context};
+    use value::{to_json, as_string};
     use render::{Directive, Helper, RenderContext};
     use output::Output;
     use error::RenderError;
@@ -92,7 +93,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Directive, _: &Registry, _: &mut RenderContext| -> Result<(), RenderError> {
+                |_: &Directive, _: &Registry, _: &RenderContext| -> Result<(), RenderError> {
                     Ok(())
                 },
             ),
@@ -114,13 +115,13 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Directive, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError> {
+                |_: &Directive, _: &Registry, rc: &RenderContext| -> Result<(), RenderError> {
                     // modify json object
                     let ctx_ref = rc.context_mut();
                     let data = ctx_ref.data_mut();
 
                     if let Some(ref mut m) = data.as_object_mut().as_mut() {
-                        m.insert("hello".to_string(), context::to_json(&"war".to_owned()));
+                        m.insert("hello".to_string(), to_json(&"war".to_owned()));
                     }
 
                     Ok(())
@@ -137,9 +138,9 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |d: &Directive, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError> {
+                |d: &Directive, _: &Registry, rc: &RenderContext| -> Result<(), RenderError> {
                     // modify value
-                    let v = d.param(0)
+                    let v = d.param(0)?
                         .and_then(|v| Context::wraps(v.value()).ok())
                         .unwrap_or(Context::null());
                     *rc.context_mut() = v;
@@ -191,14 +192,14 @@ mod test {
             Box::new(
                 |h: &Helper,
                  _: &Registry,
-                 _: &mut RenderContext,
+                 _: &RenderContext,
                  out: &mut Output|
                  -> Result<(), RenderError> {
                     let s = format!(
                         "{}m",
-                        h.param(0,)
+                        h.param(0)?
                             .map(|v| v.value(),)
-                            .unwrap_or(&context::to_json(&0),)
+                            .unwrap_or(&to_json(&0),)
                     );
                     out.write(s.as_ref())?;
                     Ok(())
@@ -208,28 +209,28 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |d: &Directive, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError> {
-                    let new_unit = d.param(0)
+                |d: &Directive, _: &Registry, rc: &RenderContext| -> Result<(), RenderError> {
+                    let new_unit = d.param(0)?
                         .and_then(|v| as_string(v.value()))
                         .unwrap_or("")
                         .to_owned();
                     let new_helper = move |h: &Helper,
                                            _: &Registry,
-                                           _: &mut RenderContext,
+                                           _: &RenderContext,
                                            out: &mut Output|
                           -> Result<(), RenderError> {
                         let s = format!(
                             "{}{}",
-                            h.param(0,)
+                            h.param(0)?
                                 .map(|v| v.value(),)
-                                .unwrap_or(&context::to_json(&0),),
+                                .unwrap_or(&to_json(&0),),
                             new_unit
                         );
                         out.write(s.as_ref())?;
                         Ok(())
                     };
 
-                    rc.register_local_helper("distance", Box::new(new_helper));
+                    rc.inner_mut().register_local_helper("distance", Box::new(new_helper));
                     Ok(())
                 },
             ),
@@ -237,8 +238,8 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |_: &Directive, _: &Registry, rc: &mut RenderContext| -> Result<(), RenderError> {
-                    rc.unregister_local_helper("distance");
+                |_: &Directive, _: &Registry, rc: &RenderContext| -> Result<(), RenderError> {
+                    rc.inner_mut().unregister_local_helper("distance");
                     Ok(())
                 },
             ),

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -1,4 +1,5 @@
-use render::{Directive, RenderContext};
+use template::DirectiveTemplate;
+use render::RenderContext;
 use registry::Registry;
 use error::RenderError;
 
@@ -52,19 +53,19 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, r: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc mut Directive<'reg, 'rc>)
+        + for<'reg, 'rc> Fn(&'reg DirectiveTemplate, &'reg Registry, &'rc mut RenderContext)
         -> DirectiveResult,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult {
-        (*self)(d)
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'reg DirectiveTemplate, reg: &'reg Registry, rc: &'rc mut RenderContext) -> DirectiveResult {
+        (*self)(d, reg, rc)
     }
 }
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -2,7 +2,7 @@ use render::{Directive, RenderContext};
 use registry::Registry;
 use error::RenderError;
 
-// pub use self::inline::INLINE_DIRECTIVE;
+pub use self::inline::INLINE_DIRECTIVE;
 
 /// Decorator Definition
 ///

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -2,7 +2,7 @@ use render::{Directive, RenderContext};
 use registry::Registry;
 use error::RenderError;
 
-pub use self::inline::INLINE_DIRECTIVE;
+// pub use self::inline::INLINE_DIRECTIVE;
 
 /// Decorator Definition
 ///

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -4,7 +4,7 @@ use error::RenderError;
 
 pub use self::inline::INLINE_DIRECTIVE;
 
-pub type DirectiveResult = Result<RenderContext, RenderError>;
+pub type DirectiveResult = Result<(), RenderError>;
 
 /// Decorator Definition
 ///
@@ -52,18 +52,18 @@ pub type DirectiveResult = Result<RenderContext, RenderError>;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: Directive<'reg, 'rc>) -> DirectiveResult;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(Directive<'reg, 'rc>)
+        + for<'reg, 'rc> Fn(&'rc mut Directive<'reg, 'rc>)
         -> DirectiveResult,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: Directive<'reg, 'rc>) -> DirectiveResult {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc mut Directive<'reg, 'rc>) -> DirectiveResult {
         (*self)(d)
     }
 }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -50,18 +50,18 @@ use error::RenderError;
 /// ```
 ///
 pub trait DirectiveDef: Send + Sync {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError>;
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError>;
 }
 
 /// implement DirectiveDef for bare function so we can use function as directive
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc Directive<'reg>, &'reg Registry, &'rc mut RenderContext<'rc>)
+        + for<'reg, 'rc> Fn(&'rc Directive<'reg>, &'reg Registry, &'rc RenderContext)
         -> Result<(), RenderError>,
 > DirectiveDef for F
 {
-    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
+    fn call<'reg: 'rc, 'rc>(&'reg self, d: &'rc Directive<'reg>, r: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError> {
         (*self)(d, r, rc)
     }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -144,7 +144,7 @@ pub static EACH_HELPER: EachHelper = EachHelper;
 #[cfg(test)]
 mod test {
     use registry::Registry;
-    use context::to_json;
+    use value::to_json;
 
     use std::collections::BTreeMap;
     use std::str::FromStr;

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -1,5 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
+use context::Context;
 use value::JsonTruthy;
 use render::{Helper, RenderContext, Renderable};
 use error::RenderError;
@@ -15,10 +16,11 @@ impl HelperDef for IfHelper {
         &self,
         h: &Helper,
         r: &Registry,
-        rc: &RenderContext,
+        ctx: &Context,
+        rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let param = h.param(0)?
+        let param = h.param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"if\""))?;
 
         let mut value = param.value().is_truthy();
@@ -30,7 +32,7 @@ impl HelperDef for IfHelper {
         let tmpl =
             if value { h.template() } else { h.inverse() };
         match tmpl {
-            Some(ref t) => t.render(r, rc, out),
+            Some(ref t) => t.render(r, ctx, rc, out),
             None => Ok(()),
         }
     }

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -1,6 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
-use context::JsonTruthy;
+use value::JsonTruthy;
 use render::{Helper, RenderContext, Renderable};
 use error::RenderError;
 use output::Output;
@@ -11,14 +11,14 @@ pub struct IfHelper {
 }
 
 impl HelperDef for IfHelper {
-    fn call(
+    fn call<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         r: &Registry,
-        rc: &mut RenderContext,
+        rc: &RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let param = h.param(0)
+        let param = h.param(0)?
             .ok_or_else(|| RenderError::new("Param not found for helper \"if\""))?;
 
         let mut value = param.value().is_truthy();

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,5 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
+use context::Context;
 use value::JsonRender;
 use render::{Helper, RenderContext};
 use error::RenderError;
@@ -13,10 +14,11 @@ impl HelperDef for LogHelper {
         &self,
         h: &Helper,
         _: &Registry,
-        _: &RenderContext,
+        _: &Context,
+        _: &mut RenderContext,
         _: &mut Output,
     ) -> HelperResult {
-        let param = h.param(0)?
+        let param = h.param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"log\""))?;
 
         info!(

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -1,6 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
-use context::JsonRender;
+use value::JsonRender;
 use render::{Helper, RenderContext};
 use error::RenderError;
 use output::Output;
@@ -9,14 +9,14 @@ use output::Output;
 pub struct LogHelper;
 
 impl HelperDef for LogHelper {
-    fn call(
+    fn call<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         _: &Registry,
-        _: &mut RenderContext,
+        _: &RenderContext,
         _: &mut Output,
     ) -> HelperResult {
-        let param = h.param(0)
+        let param = h.param(0)?
             .ok_or_else(|| RenderError::new("Param not found for helper \"log\""))?;
 
         info!(

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -2,6 +2,7 @@ use serde_json::value::Value as Json;
 
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
+use context::Context;
 use value::JsonRender;
 use render::{Helper, RenderContext};
 use error::RenderError;
@@ -15,12 +16,13 @@ impl HelperDef for LookupHelper {
         &self,
         h: &Helper,
         _: &Registry,
-        _: &RenderContext,
+        _: &Context,
+        _: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let collection_value = h.param(0)?
+        let collection_value = h.param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"lookup\""))?;
-        let index = h.param(1)?
+        let index = h.param(1)
             .ok_or_else(|| RenderError::new("Insufficient params for helper \"lookup\""))?;
 
         let null = Json::Null;

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -2,7 +2,7 @@ use serde_json::value::Value as Json;
 
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
-use context::JsonRender;
+use value::JsonRender;
 use render::{Helper, RenderContext};
 use error::RenderError;
 use output::Output;
@@ -11,16 +11,16 @@ use output::Output;
 pub struct LookupHelper;
 
 impl HelperDef for LookupHelper {
-    fn call(
+    fn call<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         _: &Registry,
-        _: &mut RenderContext,
+        _: &RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let collection_value = h.param(0)
+        let collection_value = h.param(0)?
             .ok_or_else(|| RenderError::new("Param not found for helper \"lookup\""))?;
-        let index = h.param(1)
+        let index = h.param(1)?
             .ok_or_else(|| RenderError::new("Insufficient params for helper \"lookup\""))?;
 
         let null = Json::Null;

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -7,11 +7,11 @@ use output::Output;
 pub struct RawHelper;
 
 impl HelperDef for RawHelper {
-    fn call(
+    fn call<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         r: &Registry,
-        rc: &mut RenderContext,
+        rc: &RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         let tpl = h.template();

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -1,5 +1,6 @@
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
+use context::Context;
 use render::{Helper, RenderContext, Renderable};
 use output::Output;
 
@@ -11,12 +12,13 @@ impl HelperDef for RawHelper {
         &self,
         h: &Helper,
         r: &Registry,
-        rc: &RenderContext,
+        ctx: &Context,
+        rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         let tpl = h.template();
         if let Some(t) = tpl {
-            t.render(r, rc, out)
+            t.render(r, ctx, rc, out)
         } else {
             Ok(())
         }

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -78,7 +78,7 @@ pub static WITH_HELPER: WithHelper = WithHelper;
 #[cfg(test)]
 mod test {
     use registry::Registry;
-    use context::to_json;
+    use value::to_json;
 
     #[derive(Serialize)]
     struct Address {

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use helpers::{HelperDef, HelperResult};
 use registry::Registry;
-use context::{to_json, JsonTruthy};
+use value::{to_json, JsonTruthy};
 use render::{Helper, RenderContext, Renderable};
 use error::RenderError;
 use output::Output;
@@ -11,20 +11,22 @@ use output::Output;
 pub struct WithHelper;
 
 impl HelperDef for WithHelper {
-    fn call(
+    fn call<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         r: &Registry,
-        rc: &mut RenderContext,
+        rc: &RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        let param = h.param(0)
+        let param = h.param(0)?
             .ok_or_else(|| RenderError::new("Param not found for helper \"with\""))?;
 
-        rc.promote_local_vars();
+        rc.inner_mut().promote_local_vars();
 
         let result = {
-            let mut local_rc = rc.derive();
+            let local_rc = rc.derive();
+            // let mut inner_rc = local_rc.inner_mut();
+            let mut block_rc = local_rc.block_mut();
 
             let not_empty = param.value().is_truthy();
             let template = if not_empty {
@@ -34,39 +36,39 @@ impl HelperDef for WithHelper {
             };
 
             if let Some(path_root) = param.path_root() {
-                let local_path_root = format!("{}/{}", local_rc.get_path(), path_root);
-                local_rc.push_local_path_root(local_path_root);
+                let local_path_root = format!("{}/{}", block_rc.get_path(), path_root);
+                block_rc.push_local_path_root(local_path_root);
             }
             if not_empty {
                 if let Some(inner_path) = param.path() {
-                    let new_path = format!("{}/{}", local_rc.get_path(), inner_path);
-                    local_rc.set_path(new_path);
+                    let new_path = format!("{}/{}", block_rc.get_path(), inner_path);
+                    block_rc.set_path(new_path);
                 }
 
                 if let Some(block_param) = h.block_param() {
                     let mut map = BTreeMap::new();
                     map.insert(block_param.to_string(), to_json(param.value()));
-                    local_rc.push_block_context(&map)?;
+                    block_rc.push_block_context(&map)?;
                 }
             }
 
             let result = match template {
-                Some(t) => t.render(r, &mut local_rc, out),
+                Some(t) => t.render(r, &local_rc, out),
                 None => Ok(()),
             };
 
             if h.block_param().is_some() {
-                local_rc.pop_block_context();
+                block_rc.pop_block_context();
             }
 
             if param.path_root().is_some() {
-                local_rc.pop_local_path_root();
+                block_rc.pop_local_path_root();
             }
 
             result
         };
 
-        rc.demote_local_vars();
+        rc.inner_mut().demote_local_vars();
         result
     }
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,4 @@
-use template::HelperTemplate;
-use render::RenderContext;
+use render::{Helper, RenderContext};
 use context::Context;
 use registry::Registry;
 use error::RenderError;
@@ -56,20 +55,20 @@ pub type HelperResult = Result<(), RenderError>;
 pub trait HelperDef: Send + Sync {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        _: &'reg HelperTemplate,
+        _: &Helper<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
-        _: &'rc mut RenderContext,
+        _: &mut RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         Ok(None)
     }
 
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &'reg HelperTemplate,
+        h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &'rc mut RenderContext,
+        rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         if let Some(result) = self.call_inner(h, r, ctx, rc)? {
@@ -84,16 +83,16 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'reg HelperTemplate, &'reg Registry, &'rc Context, &'rc RenderContext, &mut Output)
+        + for<'reg, 'rc> Fn(&Helper<'reg, 'rc>, &'reg Registry, &'rc Context, &RenderContext, &mut Output)
         -> HelperResult,
 > HelperDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &'reg HelperTemplate,
+        h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &'rc mut RenderContext,
+        rc: &mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         (*self)(h, r, ctx, rc, out)

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -54,7 +54,7 @@ pub type HelperResult = Result<(), RenderError>;
 ///
 
 pub trait HelperDef: Send + Sync {
-    fn call_inner<'reg, 'rc>(
+    fn call_inner<'reg: 'rc, 'rc>(
         &self,
         _: &Helper,
         _: &'reg Registry,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,6 @@
 use template::HelperTemplate;
-use render::{RenderContext};
+use render::RenderContext;
+use context::Context;
 use registry::Registry;
 use error::RenderError;
 use output::Output;
@@ -57,6 +58,7 @@ pub trait HelperDef: Send + Sync {
         &self,
         _: &'reg HelperTemplate,
         _: &'reg Registry,
+        _: &'rc Context,
         _: &'rc mut RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         Ok(None)
@@ -66,10 +68,11 @@ pub trait HelperDef: Send + Sync {
         &self,
         h: &'reg HelperTemplate,
         r: &'reg Registry,
+        ctx: &'rc Context,
         rc: &'rc mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        if let Some(result) = self.call_inner(h, r, rc)? {
+        if let Some(result) = self.call_inner(h, r, ctx, rc)? {
             out.write(result.render().as_ref())?;
         }
 
@@ -81,7 +84,7 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'reg HelperTemplate, &'reg Registry, &'rc RenderContext, &mut Output)
+        + for<'reg, 'rc> Fn(&'reg HelperTemplate, &'reg Registry, &'rc Context, &'rc RenderContext, &mut Output)
         -> HelperResult,
 > HelperDef for F
 {
@@ -89,10 +92,11 @@ impl<
         &self,
         h: &'reg HelperTemplate,
         r: &'reg Registry,
+        ctx: &'rc Context,
         rc: &'rc mut RenderContext,
         out: &mut Output,
     ) -> HelperResult {
-        (*self)(h, r, rc, out)
+        (*self)(h, r, ctx, rc, out)
     }
 }
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -5,12 +5,12 @@ use error::RenderError;
 use output::Output;
 use value::ScopedJson;
 
-// pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
-// pub use self::helper_each::EACH_HELPER;
-// pub use self::helper_with::WITH_HELPER;
-// pub use self::helper_lookup::LOOKUP_HELPER;
-// pub use self::helper_raw::RAW_HELPER;
-// pub use self::helper_log::LOG_HELPER;
+pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
+pub use self::helper_each::EACH_HELPER;
+pub use self::helper_with::WITH_HELPER;
+pub use self::helper_lookup::LOOKUP_HELPER;
+pub use self::helper_raw::RAW_HELPER;
+pub use self::helper_log::LOG_HELPER;
 
 pub type HelperResult = Result<(), RenderError>;
 
@@ -99,12 +99,12 @@ impl<
     }
 }
 
-// mod helper_if;
-// mod helper_each;
-// mod helper_with;
-// mod helper_lookup;
-// mod helper_raw;
-// mod helper_log;
+mod helper_if;
+mod helper_each;
+mod helper_with;
+mod helper_lookup;
+mod helper_raw;
+mod helper_log;
 
 // pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;
 //

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -58,16 +58,16 @@ pub trait HelperDef: Send + Sync {
         &self,
         _: &Helper,
         _: &'reg Registry,
-        _: &'rc mut RenderContext,
+        _: &'rc RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         Ok(None)
     }
 
-    fn call(
-        &self,
-        h: &Helper,
-        r: &Registry,
-        rc: &mut RenderContext,
+    fn call<'reg: 'rc, 'rc>(
+        &'reg self,
+        h: &'rc Helper<'reg>,
+        r: &'reg Registry,
+        rc: &'rc RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         if let Some(result) = self.call_inner(h, r, rc)? {
@@ -82,15 +82,15 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'b, 'c, 'd, 'e> Fn(&'b Helper, &'c Registry, &'d mut RenderContext, &'e mut Output)
+        + for<'reg, 'rc> Fn(&'rc Helper<'reg>, &'reg Registry, &'rc RenderContext, &mut Output)
         -> HelperResult,
 > HelperDef for F
 {
-    fn call(
-        &self,
-        h: &Helper,
-        r: &Registry,
-        rc: &mut RenderContext,
+    fn call<'reg: 'rc, 'rc>(
+        &'reg self,
+        h: &'rc Helper<'reg>,
+        r: &'reg Registry,
+        rc: &'rc RenderContext,
         out: &mut Output,
     ) -> HelperResult {
         (*self)(h, r, rc, out)

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -56,7 +56,7 @@ pub type HelperResult = Result<(), RenderError>;
 pub trait HelperDef: Send + Sync {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        _: &Helper,
+        _: &Helper<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
@@ -65,7 +65,7 @@ pub trait HelperDef: Send + Sync {
 
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        h: &'rc Helper<'reg>,
+        h: &'rc Helper<'reg, 'rc>,
         r: &'reg Registry,
         rc: &'rc RenderContext,
         out: &mut Output,
@@ -82,13 +82,13 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&'rc Helper<'reg>, &'reg Registry, &'rc RenderContext, &mut Output)
+        + for<'reg, 'rc> Fn(&'rc Helper<'reg, 'rc>, &'reg Registry, &'rc RenderContext, &mut Output)
         -> HelperResult,
 > HelperDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        h: &'rc Helper<'reg>,
+        h: &'rc Helper<'reg, 'rc>,
         r: &'reg Registry,
         rc: &'rc RenderContext,
         out: &mut Output,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,16 +1,17 @@
 use render::{Helper, RenderContext};
-use context::JsonRender;
 use registry::Registry;
 use error::RenderError;
 use output::Output;
+use value::{JsonRender, ScopedJson};
+
 use serde_json::Value as Json;
 
-pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
-pub use self::helper_each::EACH_HELPER;
-pub use self::helper_with::WITH_HELPER;
-pub use self::helper_lookup::LOOKUP_HELPER;
-pub use self::helper_raw::RAW_HELPER;
-pub use self::helper_log::LOG_HELPER;
+// pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
+// pub use self::helper_each::EACH_HELPER;
+// pub use self::helper_with::WITH_HELPER;
+// pub use self::helper_lookup::LOOKUP_HELPER;
+// pub use self::helper_raw::RAW_HELPER;
+// pub use self::helper_log::LOG_HELPER;
 
 pub type HelperResult = Result<(), RenderError>;
 
@@ -53,12 +54,12 @@ pub type HelperResult = Result<(), RenderError>;
 ///
 
 pub trait HelperDef: Send + Sync {
-    fn call_inner(
+    fn call_inner<'reg, 'rc>(
         &self,
         _: &Helper,
-        _: &Registry,
-        _: &mut RenderContext,
-    ) -> Result<Option<Json>, RenderError> {
+        _: &'reg Registry,
+        _: &'rc mut RenderContext,
+    ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         Ok(None)
     }
 
@@ -96,12 +97,12 @@ impl<
     }
 }
 
-mod helper_if;
-mod helper_each;
-mod helper_with;
-mod helper_lookup;
-mod helper_raw;
-mod helper_log;
+// mod helper_if;
+// mod helper_each;
+// mod helper_with;
+// mod helper_lookup;
+// mod helper_raw;
+// mod helper_log;
 
 // pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;
 //
@@ -114,7 +115,7 @@ mod helper_log;
 mod test {
     use std::collections::BTreeMap;
 
-    use context::JsonRender;
+    use value::JsonRender;
     use helpers::HelperDef;
     use registry::Registry;
     use render::{Helper, RenderContext, Renderable};

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -126,14 +126,14 @@ mod test {
     struct MetaHelper;
 
     impl HelperDef for MetaHelper {
-        fn call(
+        fn call<'reg: 'rc, 'rc>(
             &self,
             h: &Helper,
             r: &Registry,
-            rc: &mut RenderContext,
+            rc: &RenderContext,
             out: &mut Output,
         ) -> Result<(), RenderError> {
-            let v = h.param(0).unwrap();
+            let v = h.param(0)?.unwrap();
 
             if !h.is_block() {
                 let output = format!("{}:{}", h.name(), v.value().render());
@@ -187,10 +187,10 @@ mod test {
             Box::new(
                 |h: &Helper,
                  _: &Registry,
-                 _: &mut RenderContext,
+                 _: &RenderContext,
                  out: &mut Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}{}", h.name(), h.param(0).unwrap().value());
+                    let output = format!("{}{}", h.name(), h.param(0)?.unwrap().value());
                     out.write(output.as_ref())?;
                     Ok(())
                 },
@@ -201,10 +201,10 @@ mod test {
             Box::new(
                 |h: &Helper,
                  _: &Registry,
-                 _: &mut RenderContext,
+                 _: &RenderContext,
                  out: &mut Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}", h.hash_get("value").unwrap().value().render());
+                    let output = format!("{}", h.hash_get("value")?.unwrap().value().render());
                     out.write(output.as_ref())?;
                     Ok(())
                 },

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -2,9 +2,7 @@ use render::{Helper, RenderContext};
 use registry::Registry;
 use error::RenderError;
 use output::Output;
-use value::{JsonRender, ScopedJson};
-
-use serde_json::Value as Json;
+use value::ScopedJson;
 
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
 pub use self::helper_each::EACH_HELPER;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -83,7 +83,7 @@ pub trait HelperDef: Send + Sync {
 impl<
     F: Send
         + Sync
-        + for<'reg, 'rc> Fn(&Helper<'reg, 'rc>, &'reg Registry, &'rc Context, &RenderContext, &mut Output)
+        + for<'reg, 'rc> Fn(&Helper<'reg, 'rc>, &'reg Registry, &'rc Context, &mut RenderContext, &mut Output)
         -> HelperResult,
 > HelperDef for F
 {
@@ -119,6 +119,7 @@ mod test {
 
     use value::JsonRender;
     use helpers::HelperDef;
+    use context::Context;
     use registry::Registry;
     use render::{Helper, RenderContext, Renderable};
     use error::RenderError;
@@ -132,10 +133,11 @@ mod test {
             &self,
             h: &Helper,
             r: &Registry,
-            rc: &RenderContext,
+            ctx: &Context,
+            rc: &mut RenderContext,
             out: &mut Output,
         ) -> Result<(), RenderError> {
-            let v = h.param(0)?.unwrap();
+            let v = h.param(0).unwrap();
 
             if !h.is_block() {
                 let output = format!("{}:{}", h.name(), v.value().render());
@@ -144,7 +146,7 @@ mod test {
                 let output = format!("{}:{}", h.name(), v.value().render());
                 out.write(output.as_ref())?;
                 out.write("->")?;
-                h.template().unwrap().render(r, rc, out)?;
+                h.template().unwrap().render(r, ctx, rc, out)?;
             };
             Ok(())
         }
@@ -189,10 +191,11 @@ mod test {
             Box::new(
                 |h: &Helper,
                  _: &Registry,
-                 _: &RenderContext,
+                 _: &Context,
+                 _: &mut RenderContext,
                  out: &mut Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}{}", h.name(), h.param(0)?.unwrap().value());
+                    let output = format!("{}{}", h.name(), h.param(0).unwrap().value());
                     out.write(output.as_ref())?;
                     Ok(())
                 },
@@ -203,10 +206,11 @@ mod test {
             Box::new(
                 |h: &Helper,
                  _: &Registry,
-                 _: &RenderContext,
+                 _: &Context,
+                 _: &mut RenderContext,
                  out: &mut Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}", h.hash_get("value")?.unwrap().value().render());
+                    let output = format!("{}", h.hash_get("value").unwrap().value().render());
                     out.write(output.as_ref())?;
                     Ok(())
                 },

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -6,12 +6,12 @@ use value::{JsonRender, ScopedJson};
 
 use serde_json::Value as Json;
 
-// pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
-// pub use self::helper_each::EACH_HELPER;
-// pub use self::helper_with::WITH_HELPER;
-// pub use self::helper_lookup::LOOKUP_HELPER;
-// pub use self::helper_raw::RAW_HELPER;
-// pub use self::helper_log::LOG_HELPER;
+pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
+pub use self::helper_each::EACH_HELPER;
+pub use self::helper_with::WITH_HELPER;
+pub use self::helper_lookup::LOOKUP_HELPER;
+pub use self::helper_raw::RAW_HELPER;
+pub use self::helper_log::LOG_HELPER;
 
 pub type HelperResult = Result<(), RenderError>;
 
@@ -64,7 +64,7 @@ pub trait HelperDef: Send + Sync {
     }
 
     fn call<'reg: 'rc, 'rc>(
-        &'reg self,
+        &self,
         h: &'rc Helper<'reg, 'rc>,
         r: &'reg Registry,
         rc: &'rc RenderContext,
@@ -87,7 +87,7 @@ impl<
 > HelperDef for F
 {
     fn call<'reg: 'rc, 'rc>(
-        &'reg self,
+        &self,
         h: &'rc Helper<'reg, 'rc>,
         r: &'reg Registry,
         rc: &'rc RenderContext,
@@ -97,12 +97,12 @@ impl<
     }
 }
 
-// mod helper_if;
-// mod helper_each;
-// mod helper_with;
-// mod helper_lookup;
-// mod helper_raw;
-// mod helper_log;
+mod helper_if;
+mod helper_each;
+mod helper_with;
+mod helper_lookup;
+mod helper_raw;
+mod helper_log;
 
 // pub type HelperDef = for <'a, 'b, 'c> Fn<(&'a Context, &'b Helper, &'b Registry, &'c mut RenderContext), Result<String, RenderError>>;
 //

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -29,7 +29,7 @@ pub type HelperResult = Result<(), RenderError>;
 /// ```
 /// use handlebars::*;
 ///
-/// fn upper(h: &Helper, _: &Handlebars, rc: &mut RenderContext, out: &mut Output)
+/// fn upper(h: &Helper, _: &Handlebars, _: &Context, rc: &mut RenderContext, out: &mut Output)
 ///     -> HelperResult {
 ///    // get parameter from helper or throw an error
 ///    let param = h.param(0).and_then(|v| v.value().as_str()).unwrap_or("");
@@ -45,8 +45,8 @@ pub type HelperResult = Result<(), RenderError>;
 /// ```
 /// use handlebars::*;
 ///
-/// fn dummy_block(h: &Helper, r: &Handlebars, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
-///     h.template().map(|t| t.render(r, rc, out)).unwrap_or(Ok(()))
+/// fn dummy_block(h: &Helper, r: &Handlebars, ctx: &Context, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
+///     h.template().map(|t| t.render(r, ctx, rc, out)).unwrap_or(Ok(()))
 /// }
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@
 //! struct SimpleHelper;
 //!
 //! impl HelperDef for SimpleHelper {
-//!   fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
+//!   fn call<'reg: 'rc, 'rc>(&self, h: &Helper, _: &Handlebars, _: &Context, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
 //!     let param = h.param(0).unwrap();
 //!
 //!     out.write("1st helper: ")?;
@@ -259,7 +259,7 @@
 //! }
 //!
 //! // implement via bare function
-//! fn another_simple_helper (h: &Helper, _: &Handlebars, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
+//! fn another_simple_helper (h: &Helper, _: &Handlebars, _: &Context, rc: &mut RenderContext, out: &mut Output) -> HelperResult {
 //!     let param = h.param(0).unwrap();
 //!
 //!     out.write("2nd helper: ")?;
@@ -274,7 +274,7 @@
 //!   handlebars.register_helper("another-simple-helper", Box::new(another_simple_helper));
 //!   // via closure
 //!   handlebars.register_helper("closure-helper",
-//!       Box::new(|h: &Helper, r: &Handlebars, rc: &mut RenderContext, out: &mut Output| -> HelperResult {
+//!       Box::new(|h: &Helper, r: &Handlebars, _: &Context, rc: &mut RenderContext, out: &mut Output| -> HelperResult {
 //!           let param = h.param(0).ok_or(RenderError::new("param not found"))?;
 //!
 //!           out.write("3rd helper: ")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,6 @@
 
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
 extern crate log;
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,8 +341,7 @@ extern crate serde_json;
 pub use self::template::Template;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
-pub use self::render::{Directive as Decorator, Evaluable, Helper, RenderContext,
-                       Renderable};
+pub use self::render::{Evaluable, RenderContext, Renderable};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,7 @@
 
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
 extern crate log;
 #[cfg(test)]
 #[macro_use]
@@ -340,7 +341,7 @@ extern crate serde_json;
 pub use self::template::Template;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
-pub use self::render::{Evaluable, RenderContext, Renderable};
+pub use self::render::{Directive as Decorator, Helper, Evaluable, RenderContext, Renderable};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,13 +341,14 @@ extern crate serde_json;
 pub use self::template::Template;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
-pub use self::render::{ContextJson, Directive as Decorator, Evaluable, Helper, RenderContext,
+pub use self::render::{Directive as Decorator, Evaluable, Helper, RenderContext,
                        Renderable};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::directives::DirectiveDef as DecoratorDef;
-pub use self::context::{to_json, Context, JsonRender};
+pub use self::context::Context;
 pub use self::support::str::StringWriter;
 pub use self::output::Output;
+pub use self::value::{ScopedJson, PathAndJson, to_json, JsonRender};
 
 mod grammar;
 mod template;
@@ -360,3 +361,4 @@ mod support;
 mod directives;
 mod partial;
 mod output;
+mod value;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -32,6 +32,7 @@ fn render_partial<'reg: 'rc, 'rc>(
 
     // @partial-block
     if let Some(t) = d.template() {
+        // FIXME: avoid clone here possibly
         local_rc.inner_mut().set_partial("@partial-block".to_string(), Rc::new(t.clone()));
     }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -34,16 +34,14 @@ fn render_partial<'reg: 'rc, 'rc>(
     }
 
     if d.hash().is_empty() {
-        t.render(r, ctx, local_rc, out)?;
-        Ok(())
+        t.render(r, ctx, local_rc, out)
     } else {
         let hash_ctx =
             BTreeMap::from_iter(d.hash().iter().map(|(k, v)| (k.clone(), v.value().clone())));
         let partial_context = merge_json(local_rc.evaluate(ctx, ".", r.strict_mode())?, &hash_ctx);
         let ctx = Context::wraps(&partial_context)?;
-//        let mut partial_rc = local_rc.with_context(Context::wraps(&partial_context)?);
-        t.render(r, &ctx, local_rc, out)?;
-        Ok(())
+        let mut partial_rc = local_rc.new_for_block();
+        t.render(r, &ctx, &mut partial_rc, out)
     }
 }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -10,14 +10,14 @@ use render::{Directive, Evaluable, RenderContext, Renderable};
 use error::RenderError;
 use output::Output;
 
-fn render_partial(
-    t: &Template,
-    d: &Directive,
-    r: &Registry,
-    local_rc: &mut RenderContext,
-    out: &mut Output,
+fn render_partial<'reg: 'rc, 'rc>(
+    t: &'reg Template,
+    d: &'rc Directive<'reg, 'rc>,
+    r: &'reg Registry,
+    local_rc: &'rc mut RenderContext<'rc>,
+    out: &'rc mut Output,
 ) -> Result<(), RenderError> {
-    let context_param = d.params().get(0).and_then(|p| p.path());
+    let context_param = d.param(0)?.and_then(|p| p.path());
     if let Some(p) = context_param {
         let old_path = local_rc.get_path().clone();
         local_rc.promote_local_vars();
@@ -30,42 +30,42 @@ fn render_partial(
         local_rc.set_partial("@partial-block".to_string(), Rc::new(t.clone()));
     }
 
-    let hash = d.hash();
+    let hash = d.hash()?;
     if hash.is_empty() {
         t.render(r, local_rc, out)
     } else {
         let hash_ctx =
-            BTreeMap::from_iter(d.hash().iter().map(|(k, v)| (k.clone(), v.value().clone())));
+            BTreeMap::from_iter(hash.iter().map(|(k, v)| (k.clone(), v.value().clone())));
         let partial_context = merge_json(local_rc.evaluate(".", r.strict_mode())?, &hash_ctx);
         let mut partial_rc = local_rc.with_context(Context::wraps(&partial_context)?);
         t.render(r, &mut partial_rc, out)
     }
 }
 
-pub fn expand_partial(
-    d: &Directive,
-    r: &Registry,
-    rc: &mut RenderContext,
-    out: &mut Output,
+pub fn expand_partial<'reg: 'rc, 'rc>(
+    d: &'rc Directive<'reg, 'rc>,
+    r: &'reg Registry,
+    rc: &'rc mut RenderContext<'rc>,
+    out: &'rc mut Output,
 ) -> Result<(), RenderError> {
     // try eval inline partials first
     if let Some(t) = d.template() {
         t.eval(r, rc)?;
     }
 
-    if rc.is_current_template(d.name()) {
+    let tname = d.name()?;
+    if rc.is_current_template(tname.as_ref()) {
         return Err(RenderError::new("Cannot include self in >"));
     }
 
-    let tname = d.name();
-    let partial = rc.get_partial(tname);
+    let partial = rc.get_partial(tname.as_ref());
 
     match partial {
         Some(t) => {
             let mut local_rc = rc.derive();
             render_partial(t.borrow(), d, r, &mut local_rc, out)
         }
-        None => if let Some(t) = r.get_template(tname).or(d.template()) {
+        None => if let Some(t) = r.get_template(tname.as_ref()).or(d.template()) {
             let mut local_rc = rc.derive();
             render_partial(t, d, r, &mut local_rc, out)
         } else {

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -12,12 +12,12 @@ use output::Output;
 
 fn render_partial<'reg: 'rc, 'rc>(
     t: &'reg Template,
-    d: &'rc Directive<'reg>,
+    d: &'rc Directive<'reg, 'rc>,
     r: &'reg Registry,
     local_rc: &'rc RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let context_param = d.param(0, r, local_rc)?.and_then(|p| p.path());
+    let context_param = d.param(0)?.and_then(|p| p.path());
     if let Some(p) = context_param {
         let block = local_rc.block_mut();
         let inner = local_rc.inner_mut();
@@ -30,10 +30,10 @@ fn render_partial<'reg: 'rc, 'rc>(
 
     // @partial-block
     if let Some(t) = d.template() {
-        local_rc.inner().set_partial("@partial-block".to_string(), Rc::new(t.clone()));
+        local_rc.inner_mut().set_partial("@partial-block".to_string(), Rc::new(t.clone()));
     }
 
-    let hash = d.hash(r, local_rc)?;
+    let hash = d.hash()?;
     if hash.is_empty() {
         t.render(r, local_rc, out)
     } else {
@@ -46,7 +46,7 @@ fn render_partial<'reg: 'rc, 'rc>(
 }
 
 pub fn expand_partial<'reg: 'rc, 'rc>(
-    d: &'rc Directive<'reg>,
+    d: &'rc Directive<'reg, 'rc>,
     r: &'reg Registry,
     rc: &'rc RenderContext,
     out: &mut Output,
@@ -56,7 +56,7 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
         t.eval(r, rc)?;
     }
 
-    let tname = d.name(r, rc)?;
+    let tname = d.name()?;
     let rc_inner = rc.inner();
     if rc_inner.is_current_template(tname.as_ref()) {
         return Err(RenderError::new("Cannot include self in >"));

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -17,15 +17,17 @@ fn render_partial<'reg: 'rc, 'rc>(
     local_rc: &'rc RenderContext,
     out: &mut Output,
 ) -> Result<(), RenderError> {
-    let context_param = d.param(0)?.and_then(|p| p.path());
+    let context_param = d.param(0)?;
     if let Some(p) = context_param {
-        let block = local_rc.block_mut();
-        let inner = local_rc.inner_mut();
+        if let Some(ref param_path) = p.path() {
+            let mut block = local_rc.block_mut();
+            let mut inner = local_rc.inner_mut();
 
-        let old_path = block.get_path();
-        inner.promote_local_vars();
-        let new_path = format!("{}/{}", old_path, p);
-        block.set_path(new_path);
+            let old_path = block.get_path().clone();
+            inner.promote_local_vars();
+            let new_path = format!("{}/{}", old_path, param_path);
+            block.set_path(new_path);
+        }
     };
 
     // @partial-block

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -88,13 +88,13 @@ impl Registry {
     }
 
     fn setup_builtins(mut self) -> Registry {
-        // self.register_helper("if", Box::new(helpers::IF_HELPER));
-        // self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
-        // self.register_helper("each", Box::new(helpers::EACH_HELPER));
-        // self.register_helper("with", Box::new(helpers::WITH_HELPER));
-        // self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
-        // self.register_helper("raw", Box::new(helpers::RAW_HELPER));
-        // self.register_helper("log", Box::new(helpers::LOG_HELPER));
+        self.register_helper("if", Box::new(helpers::IF_HELPER));
+        self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
+        self.register_helper("each", Box::new(helpers::EACH_HELPER));
+        self.register_helper("with", Box::new(helpers::WITH_HELPER));
+        self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
+        self.register_helper("raw", Box::new(helpers::RAW_HELPER));
+        self.register_helper("log", Box::new(helpers::LOG_HELPER));
 
         self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
         self

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -88,13 +88,13 @@ impl Registry {
     }
 
     fn setup_builtins(mut self) -> Registry {
-        self.register_helper("if", Box::new(helpers::IF_HELPER));
-        self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
-        self.register_helper("each", Box::new(helpers::EACH_HELPER));
-        self.register_helper("with", Box::new(helpers::WITH_HELPER));
-        self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
-        self.register_helper("raw", Box::new(helpers::RAW_HELPER));
-        self.register_helper("log", Box::new(helpers::LOG_HELPER));
+        // self.register_helper("if", Box::new(helpers::IF_HELPER));
+        // self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
+        // self.register_helper("each", Box::new(helpers::EACH_HELPER));
+        // self.register_helper("with", Box::new(helpers::WITH_HELPER));
+        // self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
+        // self.register_helper("raw", Box::new(helpers::RAW_HELPER));
+        // self.register_helper("log", Box::new(helpers::LOG_HELPER));
 
         self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
         self
@@ -267,8 +267,9 @@ impl Registry {
             .and_then(|t| {
                 let ctx = Context::wraps(data)?;
                 let render_context = RenderContext::new(ctx, t.name.clone());
-                t.render(self, &render_context, output)
+                t.render(self, render_context, output)
             })
+            .map(|_| ())
     }
 
     /// Render a registered template with some data into a string
@@ -330,7 +331,8 @@ impl Registry {
         let ctx = Context::wraps(data)?;
         let render_context = RenderContext::new(ctx, None);
         let mut out = WriteOutput::new(writer);
-        tpl.render(self, &render_context, &mut out)
+        tpl.render(self, render_context, &mut out)
+            .map(|_| ())
             .map_err(TemplateRenderError::from)
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -88,15 +88,15 @@ impl Registry {
     }
 
     fn setup_builtins(mut self) -> Registry {
-        // self.register_helper("if", Box::new(helpers::IF_HELPER));
-        // self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
-        // self.register_helper("each", Box::new(helpers::EACH_HELPER));
-        // self.register_helper("with", Box::new(helpers::WITH_HELPER));
-        // self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
-        // self.register_helper("raw", Box::new(helpers::RAW_HELPER));
-        // self.register_helper("log", Box::new(helpers::LOG_HELPER));
+        self.register_helper("if", Box::new(helpers::IF_HELPER));
+        self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
+        self.register_helper("each", Box::new(helpers::EACH_HELPER));
+        self.register_helper("with", Box::new(helpers::WITH_HELPER));
+        self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
+        self.register_helper("raw", Box::new(helpers::RAW_HELPER));
+        self.register_helper("log", Box::new(helpers::LOG_HELPER));
 
-        // self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
+        self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
         self
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -266,8 +266,8 @@ impl Registry {
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
                 let ctx = Context::wraps(data)?;
-                let render_context = RenderContext::new(ctx, t.name.clone());
-                t.render(self, render_context, output)
+                let mut render_context = RenderContext::new(ctx, t.name.clone());
+                t.render(self, &mut render_context, output)
             })
             .map(|_| ())
     }
@@ -329,9 +329,9 @@ impl Registry {
     {
         let tpl = Template::compile2(template_string, self.source_map)?;
         let ctx = Context::wraps(data)?;
-        let render_context = RenderContext::new(ctx, None);
+        let mut render_context = RenderContext::new(ctx, None);
         let mut out = WriteOutput::new(writer);
-        tpl.render(self, render_context, &mut out)
+        tpl.render(self, &mut render_context, &mut out)
             .map(|_| ())
             .map_err(TemplateRenderError::from)
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -413,11 +413,11 @@ mod test {
     struct DummyHelper;
 
     impl HelperDef for DummyHelper {
-        fn call(
+        fn call<'reg: 'rc, 'rc>(
             &self,
             h: &Helper,
             r: &Registry,
-            rc: &mut RenderContext,
+            rc: &RenderContext,
             out: &mut Output,
         ) -> Result<(), RenderError> {
             h.template().unwrap().render(r, rc, out)?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -266,10 +266,8 @@ impl Registry {
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
                 let ctx = Context::wraps(data)?;
-                let mut local_helpers = HashMap::new();
-                let mut render_context =
-                    RenderContext::new(ctx, &mut local_helpers, t.name.clone());
-                t.render(self, &mut render_context, output)
+                let render_context = RenderContext::new(ctx, t.name.clone());
+                t.render(self, &render_context, output)
             })
     }
 
@@ -330,10 +328,9 @@ impl Registry {
     {
         let tpl = Template::compile2(template_string, self.source_map)?;
         let ctx = Context::wraps(data)?;
-        let mut local_helpers = HashMap::new();
-        let mut render_context = RenderContext::new(ctx, &mut local_helpers, None);
+        let render_context = RenderContext::new(ctx, None);
         let mut out = WriteOutput::new(writer);
-        tpl.render(self, &mut render_context, &mut out)
+        tpl.render(self, &render_context, &mut out)
             .map_err(TemplateRenderError::from)
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -266,8 +266,8 @@ impl Registry {
             .ok_or(RenderError::new(format!("Template not found: {}", name)))
             .and_then(|t| {
                 let ctx = Context::wraps(data)?;
-                let mut render_context = RenderContext::new(ctx, t.name.clone());
-                t.render(self, &mut render_context, output)
+                let mut render_context = RenderContext::new(t.name.clone());
+                t.render(self, &ctx, &mut render_context, output)
             })
             .map(|_| ())
     }
@@ -329,9 +329,9 @@ impl Registry {
     {
         let tpl = Template::compile2(template_string, self.source_map)?;
         let ctx = Context::wraps(data)?;
-        let mut render_context = RenderContext::new(ctx, None);
+        let mut render_context = RenderContext::new(None);
         let mut out = WriteOutput::new(writer);
-        tpl.render(self, &mut render_context, &mut out)
+        tpl.render(self, &ctx, &mut render_context, &mut out)
             .map(|_| ())
             .map_err(TemplateRenderError::from)
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -405,6 +405,7 @@ impl Registry {
 #[cfg(test)]
 mod test {
     use registry::Registry;
+    use context::Context;
     use render::{Helper, RenderContext, Renderable};
     use helpers::HelperDef;
     use support::str::StringWriter;
@@ -419,11 +420,11 @@ mod test {
             &self,
             h: &Helper,
             r: &Registry,
-            rc: &RenderContext,
+            ctx: &Context,
+            rc: &mut RenderContext,
             out: &mut Output,
         ) -> Result<(), RenderError> {
-            h.template().unwrap().render(r, rc, out)?;
-            Ok(())
+            h.template().unwrap().render(r, ctx, rc, out)
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -88,15 +88,15 @@ impl Registry {
     }
 
     fn setup_builtins(mut self) -> Registry {
-        self.register_helper("if", Box::new(helpers::IF_HELPER));
-        self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
-        self.register_helper("each", Box::new(helpers::EACH_HELPER));
-        self.register_helper("with", Box::new(helpers::WITH_HELPER));
-        self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
-        self.register_helper("raw", Box::new(helpers::RAW_HELPER));
-        self.register_helper("log", Box::new(helpers::LOG_HELPER));
+        // self.register_helper("if", Box::new(helpers::IF_HELPER));
+        // self.register_helper("unless", Box::new(helpers::UNLESS_HELPER));
+        // self.register_helper("each", Box::new(helpers::EACH_HELPER));
+        // self.register_helper("with", Box::new(helpers::WITH_HELPER));
+        // self.register_helper("lookup", Box::new(helpers::LOOKUP_HELPER));
+        // self.register_helper("raw", Box::new(helpers::RAW_HELPER));
+        // self.register_helper("log", Box::new(helpers::LOG_HELPER));
 
-        self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
+        // self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
         self
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -81,7 +81,7 @@ impl RenderContext {
 
     pub fn derive(&self) -> RenderContext {
         let inner = self.inner.clone();
-        let block = Rc::new(BlockRenderContext::default());
+        let block = self.block.clone();
 
         RenderContext { inner, block }
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::rc::Rc;
@@ -745,8 +745,6 @@ impl Evaluable for TemplateElement {
     fn eval<'reg: 'rc, 'rc>(&'reg self, registry: &'reg Registry, rc: &'rc RenderContext) -> Result<(), RenderError> {
         match *self {
             DirectiveExpression(ref dt) | DirectiveBlock(ref dt) => {
-                let inner = rc.inner_mut();
-                let block = rc.block();
                 let di = Directive::from_template(dt, registry, rc);
                 match registry.get_decorator(di.name()?.as_ref()) {
                     Some(d) => (**d).call(&di, registry, rc),

--- a/src/render.rs
+++ b/src/render.rs
@@ -86,12 +86,12 @@ impl RenderContext {
         RenderContext { inner, block }
     }
 
-    // pub fn with_context(&self, context: Context) -> RenderContext {
-    //     let inner = self.inner.clone();
-    //     let block = Rc::new(BlockRenderContext::default());
+    pub fn new_for_block(&self) -> RenderContext {
+        let inner = self.inner.clone();
+        let block = Rc::new(BlockRenderContext::default());
 
-    //     RenderContext { inner, block }
-    // }
+        RenderContext { inner, block }
+    }
 
     fn inner(&self) -> &RenderContextInner {
         self.inner.borrow()

--- a/src/render.rs
+++ b/src/render.rs
@@ -765,7 +765,7 @@ fn test_raw_string() {
     let mut out = StringOutput::new();
     let ctx = Context::null();
     {
-        let mut rc = RenderContext::new(ctx, None);
+        let rc = RenderContext::new(ctx, None);
         let raw_string = RawString("<h1>hello world</h1>".to_string());
 
         raw_string.render(&r, &rc, &mut out).ok().unwrap();
@@ -782,7 +782,7 @@ fn test_expression() {
     m.insert("hello".to_string(), value);
     let ctx = Context::wraps(&m).unwrap();
     {
-        let mut rc = RenderContext::new(ctx, None);
+        let rc = RenderContext::new(ctx, None);
         let element = Expression(Parameter::Name("hello".into()));
 
         element.render(&r, &rc, &mut out).ok().unwrap();
@@ -800,7 +800,7 @@ fn test_html_expression() {
     m.insert("hello".to_string(), value.to_string());
     let ctx = Context::wraps(&m).unwrap();
     {
-        let mut rc = RenderContext::new(ctx, None);
+        let rc = RenderContext::new(ctx, None);
         let element = HTMLExpression(Parameter::Name("hello".into()));
         element.render(&r, &rc, &mut out).ok().unwrap();
     }
@@ -818,7 +818,7 @@ fn test_template() {
     let ctx = Context::wraps(&m).unwrap();
 
     {
-        let mut rc = RenderContext::new(ctx, None);
+        let rc = RenderContext::new(ctx, None);
         let mut elements: Vec<TemplateElement> = Vec::new();
 
         let e1 = RawString("<h1>".to_string());
@@ -849,7 +849,7 @@ fn test_render_context_promotion_and_demotion() {
     use value::to_json;
     let ctx = Context::null();
 
-    let mut render_context = RenderContext::new(ctx, None);
+    let render_context = RenderContext::new(ctx, None);
 
     render_context.inner_mut().set_local_var("@index".to_string(), to_json(&0));
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -14,7 +14,7 @@ use partial;
 use registry::Registry;
 use template::TemplateElement::*;
 use template::{
-    BlockParam, Directive as DirectiveTemplate, HelperTemplate, Parameter, Template,
+    BlockParam, DirectiveTemplate, HelperTemplate, Parameter, Template,
     TemplateElement, TemplateMapping,
 };
 use value::{ScopedJson, PathAndJson, JsonRender};
@@ -306,245 +306,245 @@ impl fmt::Debug for RenderContextInner {
 }
 
 /// Render-time Helper data when using in a helper definition
-#[derive(Debug)]
-pub struct Helper<'reg: 'rc, 'rc> {
-    // name: &'reg String,
-    // params: Vec<PathAndJson<'reg, 'rc>>,
-    // hash: BTreeMap<String, PathAndJson<'reg, 'rc>>,
-    // template: Option<&'reg Template>,
-    // inverse: Option<&'reg Template>,
-    // block_param: Option<&'reg BlockParam>,
-    // block: bool,
+// #[derive(Debug)]
+// pub struct Helper<'reg: 'rc, 'rc> {
+//     // name: &'reg String,
+//     // params: Vec<PathAndJson<'reg, 'rc>>,
+//     // hash: BTreeMap<String, PathAndJson<'reg, 'rc>>,
+//     // template: Option<&'reg Template>,
+//     // inverse: Option<&'reg Template>,
+//     // block_param: Option<&'reg BlockParam>,
+//     // block: bool,
 
-    helper_template: &'reg HelperTemplate,
-    render_context: &'rc mut RenderContext,
-    registry: &'reg Registry,
-}
+//     helper_template: &'reg HelperTemplate,
+//     render_context: &'rc mut RenderContext,
+//     registry: &'reg Registry,
+// }
 
-impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
-    fn new(
-        ht: &'reg HelperTemplate,
-        registry: &'reg Registry,
-        render_context: &'rc mut RenderContext,
-    ) -> Helper<'reg, 'rc> {
-        Helper {
-            helper_template: ht,
-            render_context,
-            registry,
-        }
-    }
+// impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
+//     fn new(
+//         ht: &'reg HelperTemplate,
+//         registry: &'reg Registry,
+//         render_context: &'rc mut RenderContext,
+//     ) -> Helper<'reg, 'rc> {
+//         Helper {
+//             helper_template: ht,
+//             render_context,
+//             registry,
+//         }
+//     }
 
-    /// Returns helper name
-    pub fn name(&self) -> &'reg str {
-        &self.helper_template.name
-    }
+//     /// Returns helper name
+//     pub fn name(&self) -> &'reg str {
+//         &self.helper_template.name
+//     }
 
-    /// Returns all helper params, resolved within the context
-    pub fn params(&'rc mut self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
-        let mut pv = Vec::new();
-        for p in self.helper_template.params.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
-            pv.push(r);
-        }
-        Ok(pv)
-    }
+//     /// Returns all helper params, resolved within the context
+//     pub fn params(&'rc mut self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
+//         let mut pv = Vec::new();
+//         for p in self.helper_template.params.iter() {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             pv.push(r);
+//         }
+//         Ok(pv)
+//     }
 
-    /// Returns nth helper param, resolved within the context.
-    ///
-    /// ## Example
-    ///
-    /// To get the first param in `{{my_helper abc}}` or `{{my_helper 2}}`,
-    /// use `h.param(0)` in helper definition.
-    /// Variable `abc` is auto resolved in current context.
-    ///
-    /// ```
-    /// use handlebars::*;
-    ///
-    /// fn my_helper(h: &Helper, rc: &mut RenderContext) -> Result<(), RenderError> {
-    ///     let v = h.param(0).map(|v| v.value())
-    ///         .ok_or(RenderError::new("param not found"));
-    ///     // ..
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn param(&'rc mut self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
-        if let Some(p) = self.helper_template.params.get(idx) {
-            let r = p.expand(self.registry, self.render_context)?;
-            Ok(Some(r))
-        } else {
-            Ok(None)
-        }
-    }
+//     /// Returns nth helper param, resolved within the context.
+//     ///
+//     /// ## Example
+//     ///
+//     /// To get the first param in `{{my_helper abc}}` or `{{my_helper 2}}`,
+//     /// use `h.param(0)` in helper definition.
+//     /// Variable `abc` is auto resolved in current context.
+//     ///
+//     /// ```
+//     /// use handlebars::*;
+//     ///
+//     /// fn my_helper(h: &Helper, rc: &mut RenderContext) -> Result<(), RenderError> {
+//     ///     let v = h.param(0).map(|v| v.value())
+//     ///         .ok_or(RenderError::new("param not found"));
+//     ///     // ..
+//     ///     Ok(())
+//     /// }
+//     /// ```
+//     pub fn param(&'rc mut self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+//         if let Some(p) = self.helper_template.params.get(idx) {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             Ok(Some(r))
+//         } else {
+//             Ok(None)
+//         }
+//     }
 
-    /// Returns hash, resolved within the context
-    pub fn hash(&'rc mut self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
-        let mut hm = BTreeMap::new();
-        for (k, p) in self.helper_template.hash.iter() {
-            let r = try!(p.expand(self.registry, self.render_context));
-            hm.insert(k.clone(), r);
-        }
-        Ok(hm)
-    }
+//     /// Returns hash, resolved within the context
+//     pub fn hash(&'rc mut self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
+//         let mut hm = BTreeMap::new();
+//         for (k, p) in self.helper_template.hash.iter() {
+//             let r = try!(p.expand(self.registry, self.render_context));
+//             hm.insert(k.clone(), r);
+//         }
+//         Ok(hm)
+//     }
 
-    /// Return hash value of a given key, resolved within the context
-    ///
-    /// ## Example
-    ///
-    /// To get the first param in `{{my_helper v=abc}}` or `{{my_helper v=2}}`,
-    /// use `h.hash_get("v")` in helper definition.
-    /// Variable `abc` is auto resolved in current context.
-    ///
-    /// ```
-    /// use handlebars::*;
-    ///
-    /// fn my_helper(h: &Helper, rc: &mut RenderContext) -> Result<(), RenderError> {
-    ///     let v = h.hash_get("v").map(|v| v.value())
-    ///         .ok_or(RenderError::new("param not found"));
-    ///     // ..
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn hash_get(&'rc mut self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
-        if let Some(p) = self.helper_template.hash.get(key) {
-            let r = p.expand(self.registry, self.render_context)?;
-            Ok(Some(r))
-        } else {
-            Ok(None)
-        }
-    }
+//     /// Return hash value of a given key, resolved within the context
+//     ///
+//     /// ## Example
+//     ///
+//     /// To get the first param in `{{my_helper v=abc}}` or `{{my_helper v=2}}`,
+//     /// use `h.hash_get("v")` in helper definition.
+//     /// Variable `abc` is auto resolved in current context.
+//     ///
+//     /// ```
+//     /// use handlebars::*;
+//     ///
+//     /// fn my_helper(h: &Helper, rc: &mut RenderContext) -> Result<(), RenderError> {
+//     ///     let v = h.hash_get("v").map(|v| v.value())
+//     ///         .ok_or(RenderError::new("param not found"));
+//     ///     // ..
+//     ///     Ok(())
+//     /// }
+//     /// ```
+//     pub fn hash_get(&'rc mut self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+//         if let Some(p) = self.helper_template.hash.get(key) {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             Ok(Some(r))
+//         } else {
+//             Ok(None)
+//         }
+//     }
 
-    /// Returns the default inner template if the helper is a block helper.
-    ///
-    /// Typically you will render the template via: `template.render(registry, render_context)`
-    ///
-    pub fn template(&self) -> Option<&'reg Template> {
-        self.helper_template.template.as_ref()
-    }
+//     /// Returns the default inner template if the helper is a block helper.
+//     ///
+//     /// Typically you will render the template via: `template.render(registry, render_context)`
+//     ///
+//     pub fn template(&self) -> Option<&'reg Template> {
+//         self.helper_template.template.as_ref()
+//     }
 
-    /// Returns the template of `else` branch if any
-    pub fn inverse(&self) -> Option<&'reg Template> {
-        self.helper_template.inverse.as_ref()
-    }
+//     /// Returns the template of `else` branch if any
+//     pub fn inverse(&self) -> Option<&'reg Template> {
+//         self.helper_template.inverse.as_ref()
+//     }
 
-    /// Returns if the helper is a block one `{{#helper}}{{/helper}}` or not `{{helper 123}}`
-    pub fn is_block(&self) -> bool {
-        self.helper_template.block
-    }
+//     /// Returns if the helper is a block one `{{#helper}}{{/helper}}` or not `{{helper 123}}`
+//     pub fn is_block(&self) -> bool {
+//         self.helper_template.block
+//     }
 
-    /// Returns block param if any
-    pub fn block_param(&self) -> Option<&str> {
-        if let Some(BlockParam::Single(Parameter::Name(ref s))) = self.helper_template.block_param {
-            Some(s)
-        } else {
-            None
-        }
-    }
+//     /// Returns block param if any
+//     pub fn block_param(&self) -> Option<&str> {
+//         if let Some(BlockParam::Single(Parameter::Name(ref s))) = self.helper_template.block_param {
+//             Some(s)
+//         } else {
+//             None
+//         }
+//     }
 
-    /// Return block param pair (for example |key, val|) if any
-    pub fn block_param_pair(&self) -> Option<(&str, &str)> {
-        if let Some(BlockParam::Pair((Parameter::Name(ref s1), Parameter::Name(ref s2)))) =
-            self.helper_template.block_param
-        {
-            Some((s1, s2))
-        } else {
-            None
-        }
-    }
+//     /// Return block param pair (for example |key, val|) if any
+//     pub fn block_param_pair(&self) -> Option<(&str, &str)> {
+//         if let Some(BlockParam::Pair((Parameter::Name(ref s1), Parameter::Name(ref s2)))) =
+//             self.helper_template.block_param
+//         {
+//             Some((s1, s2))
+//         } else {
+//             None
+//         }
+//     }
 
-    pub fn render_context(&mut self) -> &mut RenderContext {
-        self.render_context
-    }
+//     pub fn render_context(&mut self) -> &mut RenderContext {
+//         self.render_context
+//     }
 
-    pub fn registry(&self) -> &Registry {
-        self.registry
-    }
-}
+//     pub fn registry(&self) -> &Registry {
+//         self.registry
+//     }
+// }
 
 /// Render-time Decorator data when using in a decorator definition
-#[derive(Debug)]
-pub struct Directive<'reg: 'rc, 'rc> {
-    name: String,
-    directive_template: &'reg DirectiveTemplate,
-    render_context: &'rc mut RenderContext,
-    registry: &'reg Registry,
-}
+// #[derive(Debug)]
+// pub struct Directive<'reg: 'rc, 'rc> {
+//     name: String,
+//     directive_template: &'reg DirectiveTemplate,
+//     render_context: &'rc mut RenderContext,
+//     registry: &'reg Registry,
+// }
 
-impl<'reg: 'rc, 'rc> Directive<'reg, 'rc> {
-    fn try_from_template(
-        dt: &'reg DirectiveTemplate,
-        registry: &'reg Registry,
-        render_context: &'rc mut RenderContext,
-    ) -> Result<Directive<'reg, 'rc>, RenderError> {
-        let name = try!(dt.name.expand_as_name(registry, render_context));
+// impl<'reg: 'rc, 'rc> Directive<'reg, 'rc> {
+//     fn try_from_template(
+//         dt: &'reg DirectiveTemplate,
+//         registry: &'reg Registry,
+//         render_context: &'rc mut RenderContext,
+//     ) -> Result<Directive<'reg, 'rc>, RenderError> {
+//         let name = try!(dt.name.expand_as_name(registry, render_context));
 
 
-        Ok(Directive {
-            name: name,
-            directive_template: dt,
-            render_context,
-            registry,
-        })
-    }
+//         Ok(Directive {
+//             name: name,
+//             directive_template: dt,
+//             render_context,
+//             registry,
+//         })
+//     }
 
-    /// Returns helper name
-    pub fn name(&self) -> &String {
-        &self.name
-    }
+//     /// Returns helper name
+//     pub fn name(&self) -> &String {
+//         &self.name
+//     }
 
-    /// Returns all helper params, resolved within the context
-    pub fn params(&'rc mut self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
-        let mut evaluated_params = Vec::new();
-        for p in self.directive_template.params.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
-            evaluated_params.push(r);
-        }
-        Ok(evaluated_params)
-    }
+//     /// Returns all helper params, resolved within the context
+//     pub fn params(&'rc mut self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
+//         let mut evaluated_params = Vec::new();
+//         for p in self.directive_template.params.iter() {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             evaluated_params.push(r);
+//         }
+//         Ok(evaluated_params)
+//     }
 
-    /// Returns nth helper param, resolved within the context
-    pub fn param(&'rc mut self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
-        if let Some(ref p) = self.directive_template.params.get(idx) {
-            let r = p.expand(self.registry, self.render_context)?;
-            Ok(Some(r))
-        } else {
-            Ok(None)
-        }
-    }
+//     /// Returns nth helper param, resolved within the context
+//     pub fn param(&'rc mut self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+//         if let Some(ref p) = self.directive_template.params.get(idx) {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             Ok(Some(r))
+//         } else {
+//             Ok(None)
+//         }
+//     }
 
-    /// Returns hash, resolved within the context
-    pub fn hash(&'rc mut self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
-        let mut evaluated_hash = BTreeMap::new();
-        for (k, p) in self.directive_template.hash.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
-            evaluated_hash.insert(k.clone(), r);
-        }
+//     /// Returns hash, resolved within the context
+//     pub fn hash(&'rc mut self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
+//         let mut evaluated_hash = BTreeMap::new();
+//         for (k, p) in self.directive_template.hash.iter() {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             evaluated_hash.insert(k.clone(), r);
+//         }
 
-        Ok(evaluated_hash)
-    }
+//         Ok(evaluated_hash)
+//     }
 
-    /// Return hash value of a given key, resolved within the context
-    pub fn hash_get(&'rc mut self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
-        if let Some(ref p) = self.directive_template.hash.get(key) {
-            let r = p.expand(self.registry, self.render_context)?;
-            Ok(Some(r))
-        } else {
-            Ok(None)
-        }
-    }
+//     /// Return hash value of a given key, resolved within the context
+//     pub fn hash_get(&'rc mut self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+//         if let Some(ref p) = self.directive_template.hash.get(key) {
+//             let r = p.expand(self.registry, self.render_context)?;
+//             Ok(Some(r))
+//         } else {
+//             Ok(None)
+//         }
+//     }
 
-    /// Returns the default inner template if any
-    pub fn template(&self) -> Option<&'reg Template> {
-        self.directive_template.template.as_ref()
-    }
+//     /// Returns the default inner template if any
+//     pub fn template(&self) -> Option<&'reg Template> {
+//         self.directive_template.template.as_ref()
+//     }
 
-    pub fn render_context(&mut self) -> &mut RenderContext {
-        self.render_context
-    }
+//     pub fn render_context(&mut self) -> &mut RenderContext {
+//         self.render_context
+//     }
 
-    pub fn registry(&self) -> &Registry {
-        self.registry
-    }
-}
+//     pub fn registry(&self) -> &Registry {
+//         self.registry
+//     }
+// }
 
 /// Render trait
 pub trait Renderable {
@@ -571,21 +571,20 @@ pub trait Evaluable {
 
 fn call_helper_for_value<'reg: 'rc, 'rc>(
     hd: &Box<HelperDef>,
-    mut ht: &'rc mut Helper<'reg, 'rc>,
+    ht: &'reg HelperTemplate,
+    r: &'reg Registry,
+    rc: &'rc mut RenderContext,
 ) -> Result<PathAndJson<'reg, 'rc>, RenderError> {
-    // test if helperDef has json result
-    let call_inner_result = hd.call_inner(ht)?;
-
-    if call_inner_result.is_some() {
-        Ok(PathAndJson::new(None, call_inner_result.unwrap()))
+    if let Some(result) = hd.call_inner(ht, r, rc)? {
+        Ok(PathAndJson::new(None, result))
     } else {
         // parse value from output
         let mut so = StringOutput::new();
-        let disable_escape = ht.render_context().is_disable_escape();
+        let disable_escape = rc.is_disable_escape();
 
-        ht.render_context().set_disable_escape(true);
-        hd.call(ht, &mut so)?;
-        ht.render_context().set_disable_escape(disable_escape);
+        rc.set_disable_escape(true);
+        hd.call(ht, r, rc, &mut so)?;
+        rc.set_disable_escape(disable_escape);
         let string = so.to_string().map_err(RenderError::from)?;
         Ok(PathAndJson::new(None, ScopedJson::Derived(Json::String(string))))
     }
@@ -636,10 +635,9 @@ impl Parameter {
             &Parameter::Subexpression(ref t) => match t.as_element() {
                 Expression(ref expr) => expr.expand(registry, rc),
                 HelperExpression(ref ht) => {
-                    let mut helper = Helper::new(ht, registry, rc);
                     if let Some(ref d) = rc.get_local_helper(&ht.name) {
                         let helper_def = d.borrow();
-                        call_helper_for_value(helper_def, &mut helper)
+                        call_helper_for_value(helper_def, ht, registry, rc)
                     } else {
                         registry
                             .get_helper(&ht.name)
@@ -652,7 +650,7 @@ impl Parameter {
                                 "Helper not defined: {:?}",
                                 ht.name
                             )))
-                            .and_then(move |d| call_helper_for_value(d, &mut helper))
+                            .and_then(move |d| call_helper_for_value(d, ht, registry, rc))
                     }
                 }
                 _ => unreachable!(),
@@ -700,7 +698,6 @@ impl Evaluable for Template {
     fn eval<'reg:'rc, 'rc>(&'reg self, registry: &'reg Registry, rc: &'rc mut RenderContext) -> Result<(), RenderError> {
         let iter = self.elements.iter();
         let mut idx = 0;
-        let mut rc = rc;
         for t in iter {
             t.eval(registry, rc).map_err(|mut e| {
                 if e.line_no.is_none() {
@@ -752,9 +749,8 @@ impl Renderable for TemplateElement {
                 Ok(())
             }
             HelperExpression(ref ht) | HelperBlock(ref ht) => {
-                let mut helper = Helper::new(ht, registry, rc);
                 if let Some(ref d) = rc.get_local_helper(&ht.name) {
-                    d.call(&mut helper, out)
+                    d.call(ht, registry, rc, out)
                 } else {
                     registry
                         .get_helper(&ht.name)
@@ -767,13 +763,12 @@ impl Renderable for TemplateElement {
                             "Helper not defined: {:?}",
                             ht.name
                         )))
-                        .and_then(move |d| d.call(&mut helper, out))
+                        .and_then(move |d| d.call(ht, registry, rc, out))
                 }
             }
             DirectiveExpression(_) | DirectiveBlock(_) => self.eval(registry, rc),
             PartialExpression(ref dt) | PartialBlock(ref dt) => {
-                let di = Directive::try_from_template(dt, registry, rc)?;
-                partial::expand_partial(di, out)
+                partial::expand_partial(dt, registry, rc, out)
             }
             _ => Ok(()),
         }
@@ -784,9 +779,9 @@ impl Evaluable for TemplateElement {
     fn eval<'reg:'rc, 'rc>(&'reg self, registry: &'reg Registry, rc: &'rc mut RenderContext) -> Result<(), RenderError> {
         match *self {
             DirectiveExpression(ref dt) | DirectiveBlock(ref dt) => {
-                let mut di = Directive::try_from_template(dt, registry, rc)?;
-                match registry.get_decorator(di.name().as_ref()) {
-                    Some(d) => (**d).call(&mut di),
+                let name = dt.name.expand_as_name(registry, rc)?;
+                match registry.get_decorator(&name) {
+                    Some(d) => (**d).call(dt, registry, rc),
                     None => Err(RenderError::new(format!(
                         "Directive not defined: {:?}",
                         dt.name

--- a/src/render.rs
+++ b/src/render.rs
@@ -277,19 +277,15 @@ impl<'a> fmt::Debug for RenderContext<'a> {
 
 /// Render-time Helper data when using in a helper definition
 #[derive(Debug)]
-pub struct Helper<'reg: 'rc, 'rc> {
+pub struct Helper<'reg> {
     template: &'reg HelperTemplate,
-    registry: &'reg Registry,
-    render_context: &'rc mut RenderContext<'rc>,
 }
 
-impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
+impl<'reg: 'rc, 'rc> Helper<'reg> {
     fn from_template(
         template: &'reg HelperTemplate,
-        registry: &'reg Registry,
-        render_context: &'rc mut RenderContext<'rc>,
-    ) -> Helper<'reg, 'rc> {
-        Helper { template, registry, render_context }
+    ) -> Helper<'reg> {
+        Helper { template }
     }
 
     /// Returns helper name
@@ -298,10 +294,10 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
     }
 
     /// Returns all helper params, resolved within the context
-    pub fn params(&'rc self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn params(&'rc self, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
         let mut evaluated_params = Vec::new();
         for p in self.template.params.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             evaluated_params.push(r);
         }
         Ok(evaluated_params)
@@ -325,9 +321,9 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn param(&'rc self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn param(&'rc self, idx: usize, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
         if let Some(p) = self.template.params.get(idx) {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             Ok(Some(r))
         } else {
             Ok(None)
@@ -335,10 +331,10 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
     }
 
     /// Returns hash, resolved within the context
-    pub fn hash(&'rc self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn hash(&'rc self, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
         let mut evaluated_hash = BTreeMap::new();
         for (k, p) in self.template.hash.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             evaluated_hash.insert(k.clone(), r);
         }
         Ok(evaluated_hash)
@@ -362,9 +358,9 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn hash_get(&'rc self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn hash_get(&'rc self, key: &str, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
         if let Some(p) = self.template.hash.get(key) {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             Ok(Some(r))
         } else {
             Ok(None)
@@ -412,40 +408,36 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
 
 /// Render-time Decorator data when using in a decorator definition
 #[derive(Debug)]
-pub struct Directive<'reg: 'rc, 'rc> {
+pub struct Directive<'reg> {
     template: &'reg DirectiveTemplate,
-    registry: &'reg Registry,
-    render_context: &'rc mut RenderContext<'rc>,
 }
 
-impl<'reg: 'rc, 'rc> Directive<'reg, 'rc> {
+impl<'reg: 'rc, 'rc> Directive<'reg> {
     fn from_template(
         template: &'reg DirectiveTemplate,
-        registry: &'reg Registry,
-        render_context: &'rc mut RenderContext<'rc>,
-    ) -> Directive<'reg, 'rc> {
-        Directive { template, registry, render_context }
+    ) -> Directive<'reg> {
+        Directive { template }
     }
 
     /// Returns helper name
-    pub fn name(&'rc self) -> Result<String, RenderError> {
-        self.template.name.expand_as_name(self.registry, self.render_context)
+    pub fn name(&'rc self, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<String, RenderError> {
+        self.template.name.expand_as_name(registry, render_context)
     }
 
     /// Returns all helper params, resolved within the context
-    pub fn params(&'rc self) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn params(&'rc self, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Vec<PathAndJson<'reg, 'rc>>, RenderError> {
         let mut evaluated_params = Vec::new();
         for p in self.template.params.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             evaluated_params.push(r);
         }
         Ok(evaluated_params)
     }
 
     /// Returns nth helper param, resolved within the context
-    pub fn param(&'rc self, idx: usize) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn param(&'rc self, idx: usize, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
         if let Some(p) = self.template.params.get(idx) {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             Ok(Some(r))
         } else {
             Ok(None)
@@ -453,19 +445,19 @@ impl<'reg: 'rc, 'rc> Directive<'reg, 'rc> {
     }
 
     /// Returns hash, resolved within the context
-    pub fn hash(&'rc self) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn hash(&'rc self, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<BTreeMap<String, PathAndJson<'reg, 'rc>>, RenderError> {
         let mut evaluated_hash = BTreeMap::new();
         for (k, p) in self.template.hash.iter() {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             evaluated_hash.insert(k.clone(), r);
         }
         Ok(evaluated_hash)
     }
 
     /// Return hash value of a given key, resolved within the context
-    pub fn hash_get(&'rc self, key: &str) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
+    pub fn hash_get(&'rc self, key: &str, registry: &'reg Registry, render_context: &'rc mut RenderContext<'rc>) -> Result<Option<PathAndJson<'reg, 'rc>>, RenderError> {
         if let Some(p) = self.template.hash.get(key) {
-            let r = p.expand(self.registry, self.render_context)?;
+            let r = p.expand(registry, render_context)?;
             Ok(Some(r))
         } else {
             Ok(None)
@@ -485,7 +477,7 @@ pub trait Renderable {
         &'reg self,
         registry: &'reg Registry,
         rc: &'rc mut RenderContext<'rc>,
-        out: &'rc mut Output,
+        out: &mut Output,
     ) -> Result<(), RenderError>;
 
     /// render into string
@@ -564,7 +556,7 @@ impl Parameter {
             &Parameter::Subexpression(ref t) => match t.into_element() {
                 Expression(ref expr) => expr.expand(registry, rc),
                 HelperExpression(ref ht) => {
-                    let helper = Helper::from_template(ht, registry, rc);
+                    let helper = Helper::from_template(ht);
                     if let Some(ref d) = rc.get_local_helper(&ht.name) {
                         call_helper_for_value(
                             d.borrow(), &helper, registry, rc)
@@ -594,7 +586,7 @@ impl Renderable for Template {
         &'reg self,
         registry: &'reg Registry,
         rc: &'rc mut RenderContext<'rc>,
-        out: &'rc mut Output,
+        out: &mut Output,
     ) -> Result<(), RenderError> {
         rc.set_current_template_name(self.name.as_ref().map(|s| s.clone()));
         let iter = self.elements.iter();
@@ -652,7 +644,7 @@ impl Renderable for TemplateElement {
         &'reg self,
         registry: &'reg Registry,
         rc: &'rc mut RenderContext<'rc>,
-        out: &'rc mut Output,
+        out: &mut Output,
     ) -> Result<(), RenderError> {
         match *self {
             RawString(ref v) => {
@@ -678,7 +670,7 @@ impl Renderable for TemplateElement {
                 Ok(())
             }
             HelperExpression(ref ht) | HelperBlock(ref ht) => {
-                let helper = Helper::from_template(ht, registry, rc);
+                let helper = Helper::from_template(ht);
                 if let Some(ref d) = rc.get_local_helper(&ht.name) {
                     d.call(&helper, registry, rc, out)
                 } else {
@@ -698,7 +690,7 @@ impl Renderable for TemplateElement {
             }
             DirectiveExpression(_) | DirectiveBlock(_) => self.eval(registry, rc),
             PartialExpression(ref dt) | PartialBlock(ref dt) => {
-                let di = Directive::from_template(dt, registry, rc);
+                let di = Directive::from_template(dt);
                 partial::expand_partial(&di, registry, rc, out)
             }
             _ => Ok(()),
@@ -710,8 +702,8 @@ impl Evaluable for TemplateElement {
     fn eval<'reg: 'rc, 'rc>(&'reg self, registry: &'reg Registry, rc: &'rc mut RenderContext<'rc>) -> Result<(), RenderError> {
         match *self {
             DirectiveExpression(ref dt) | DirectiveBlock(ref dt) => {
-                let di = Directive::from_template(dt, registry, rc);
-                match registry.get_decorator(di.name()?.as_ref()) {
+                let di = Directive::from_template(dt);
+                match registry.get_decorator(di.name(registry, rc)?.as_ref()) {
                     Some(d) => (**d).call(&di, registry, rc),
                     None => Err(RenderError::new(format!(
                         "Directive not defined: {:?}",

--- a/src/render.rs
+++ b/src/render.rs
@@ -630,8 +630,7 @@ impl Renderable for Template {
         out: &mut Output,
     ) -> Result<(), RenderError> {
         let template_name = self.name.clone();
-        let mut inner = rc.inner_mut();
-        (*inner).set_current_template_name(template_name);
+        rc.inner_mut().set_current_template_name(template_name);
         let iter = self.elements.iter();
         let mut idx = 0;
         for t in iter {

--- a/src/support.rs
+++ b/src/support.rs
@@ -52,3 +52,22 @@ pub mod str {
         }
     }
 }
+
+use std::cell::Ref;
+use std::ops::Deref;
+
+pub enum RefWrapper<'a, T: 'a + ?Sized> {
+    CellRef(Ref<'a, T>),
+    Ref(&'a T)
+}
+
+impl<'a, T: 'a + ?Sized> Deref for RefWrapper<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            RefWrapper::CellRef(cell_ref) => cell_ref.deref(),
+            RefWrapper::Ref(normal_ref) => normal_ref.deref()
+        }
+    }
+}

--- a/src/support.rs
+++ b/src/support.rs
@@ -71,3 +71,15 @@ impl<'a, T: 'a + ?Sized> Deref for RefWrapper<'a, T> {
         }
     }
 }
+
+impl<'a, T: 'a + ?Sized> From<Ref<'a, T>> for RefWrapper<'a, T> {
+    fn from(cell_ref: Ref<'a, T>) -> RefWrapper<'a, T> {
+        RefWrapper::CellRef(cell_ref)
+    }
+}
+
+impl<'a, T: 'a + ?Sized> From<&'a T> for RefWrapper<'a, T> {
+    fn from(normal_ref: &'a T) -> RefWrapper<'a, T> {
+        RefWrapper::Ref(normal_ref)
+    }
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -127,7 +127,7 @@ pub struct HelperTemplate {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct Directive {
+pub struct DirectiveTemplate {
     pub name: Parameter,
     pub params: Vec<Parameter>,
     pub hash: BTreeMap<String, Parameter>,
@@ -414,7 +414,7 @@ impl Template {
     pub fn compile2<S: AsRef<str>>(source: S, mapping: bool) -> Result<Template, TemplateError> {
         let source = source.as_ref();
         let mut helper_stack: VecDeque<HelperTemplate> = VecDeque::new();
-        let mut directive_stack: VecDeque<Directive> = VecDeque::new();
+        let mut directive_stack: VecDeque<DirectiveTemplate> = VecDeque::new();
         let mut template_stack: VecDeque<Template> = VecDeque::new();
 
         let mut omit_pro_ws = false;
@@ -525,7 +525,7 @@ impl Template {
                                 helper_stack.push_front(helper_template);
                             }
                             Rule::directive_block_start | Rule::partial_block_start => {
-                                let directive = Directive {
+                                let directive = DirectiveTemplate {
                                     name: exp.name,
                                     params: exp.params,
                                     hash: exp.hash,
@@ -611,7 +611,7 @@ impl Template {
                                 t.push_element(el, line_no, col_no);
                             }
                             Rule::directive_expression | Rule::partial_expression => {
-                                let directive = Directive {
+                                let directive = DirectiveTemplate {
                                     name: exp.name,
                                     params: exp.params,
                                     hash: exp.hash,
@@ -726,10 +726,10 @@ pub enum TemplateElement {
     HTMLExpression(Parameter),
     HelperExpression(HelperTemplate),
     HelperBlock(HelperTemplate),
-    DirectiveExpression(Directive),
-    DirectiveBlock(Directive),
-    PartialExpression(Directive),
-    PartialBlock(Directive),
+    DirectiveExpression(DirectiveTemplate),
+    DirectiveBlock(DirectiveTemplate),
+    PartialExpression(DirectiveTemplate),
+    PartialBlock(DirectiveTemplate),
     Comment(String),
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -37,7 +37,7 @@ impl Subexpression {
         !(self.params.is_empty() && self.hash.is_empty())
     }
 
-    pub fn into_element(&self) -> TemplateElement {
+    pub fn as_element(&self) -> TemplateElement {
         if self.is_helper() {
             HelperExpression(HelperTemplate::from(self))
         } else {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,14 +1,14 @@
 use serde::Serialize;
-use serde_json::value::{to_value, Map, Value as Json};
+use serde_json::value::{to_value, Value as Json};
 
 #[derive(Debug)]
-pub enum ScopedJson<'reg, 'rc> {
+pub enum ScopedJson<'reg: 'rc, 'rc> {
     Constant(&'reg Json),
     Derived(Json),
     Context(&'rc Json),
 }
 
-impl<'reg, 'rc> ScopedJson<'reg, 'rc> {
+impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
     pub fn as_ref(&self) -> &Json {
         match self {
             ScopedJson::Constant(j) => j,
@@ -25,12 +25,12 @@ impl<'reg, 'rc> ScopedJson<'reg, 'rc> {
 /// Json wrapper that holds the Json value and reference path information
 ///
 #[derive(Debug)]
-pub struct PathAndJson<'reg, 'rc> {
+pub struct PathAndJson<'reg: 'rc, 'rc> {
     path: Option<String>,
     value: ScopedJson<'reg, 'rc>,
 }
 
-impl<'reg, 'rc> PathAndJson<'reg, 'rc> {
+impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
     pub fn new(path: Option<String>, value: ScopedJson<'reg, 'rc>) -> PathAndJson<'reg, 'rc> {
         PathAndJson { path, value }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,119 @@
+use serde::Serialize;
+use serde_json::value::{to_value, Map, Value as Json};
+
+#[derive(Debug)]
+pub enum ScopedJson<'reg, 'rc> {
+    Constant(&'reg Json),
+    Derived(Json),
+    Context(&'rc Json),
+}
+
+impl<'reg, 'rc> ScopedJson<'reg, 'rc> {
+    pub fn as_ref(&self) -> &Json {
+        match self {
+            ScopedJson::Constant(j) => j,
+            ScopedJson::Derived(ref j) => j,
+            ScopedJson::Context(j) => j,
+        }
+    }
+
+    pub fn render(&self) -> String {
+        self.as_ref().render()
+    }
+}
+
+/// Json wrapper that holds the Json value and reference path information
+///
+#[derive(Debug)]
+pub struct PathAndJson<'reg, 'rc> {
+    path: Option<String>,
+    value: ScopedJson<'reg, 'rc>,
+}
+
+impl<'reg, 'rc> PathAndJson<'reg, 'rc> {
+    pub fn new(path: Option<String>, value: ScopedJson<'reg, 'rc>) -> PathAndJson<'reg, 'rc> {
+        PathAndJson { path, value }
+    }
+
+    /// Returns relative path when the value is referenced
+    /// If the value is from a literal, the path is `None`
+    pub fn path(&self) -> Option<&String> {
+        self.path.as_ref()
+    }
+
+    /// Return root level of this path if any
+    pub fn path_root(&self) -> Option<&str> {
+        self.path
+            .as_ref()
+            .and_then(|p| p.split(|c| c == '.' || c == '/').nth(0))
+    }
+
+    /// Returns the value
+    #[inline]
+    pub fn value(&self) -> &Json {
+        self.value.as_ref()
+    }
+}
+
+/// Render Json data with default format
+pub trait JsonRender {
+    fn render(&self) -> String;
+}
+
+pub trait JsonTruthy {
+    fn is_truthy(&self) -> bool;
+}
+
+impl JsonRender for Json {
+    fn render(&self) -> String {
+        match *self {
+            Json::String(ref s) => s.to_string(),
+            Json::Bool(i) => i.to_string(),
+            Json::Number(ref n) => n.to_string(),
+            Json::Null => "".to_owned(),
+            Json::Array(ref a) => {
+                let mut buf = String::new();
+                buf.push('[');
+                for i in a.iter() {
+                    buf.push_str(i.render().as_ref());
+                    buf.push_str(", ");
+                }
+                buf.push(']');
+                buf
+            }
+            Json::Object(_) => "[object]".to_owned(),
+        }
+    }
+}
+
+pub fn to_json<T>(src: &T) -> Json
+where
+    T: Serialize,
+{
+    to_value(src).unwrap_or_default()
+}
+
+pub fn as_string(src: &Json) -> Option<&str> {
+    src.as_str()
+}
+
+impl JsonTruthy for Json {
+    fn is_truthy(&self) -> bool {
+        match *self {
+            Json::Bool(ref i) => *i,
+            Json::Number(ref n) => n.as_f64().map(|f| f.is_normal()).unwrap_or(false),
+            Json::Null => false,
+            Json::String(ref i) => i.len() > 0,
+            Json::Array(ref i) => i.len() > 0,
+            Json::Object(ref i) => i.len() > 0,
+        }
+    }
+}
+
+#[test]
+fn test_json_render() {
+    let raw = "<p>Hello world</p>\n<p thing=\"hello\"</p>";
+    let thing = Json::String(raw.to_string());
+
+    assert_eq!(raw, thing.render());
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,7 +9,7 @@ pub enum ScopedJson<'reg: 'rc, 'rc> {
 }
 
 impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
-    pub fn as_ref(&self) -> &Json {
+    pub fn as_json(&self) -> &Json {
         match self {
             ScopedJson::Constant(j) => j,
             ScopedJson::Derived(ref j) => j,
@@ -18,7 +18,13 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
     }
 
     pub fn render(&self) -> String {
-        self.as_ref().render()
+        self.as_json().render()
+    }
+}
+
+impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'reg, 'rc> {
+    fn from(v: Json) -> ScopedJson<'reg, 'rc> {
+        ScopedJson::Derived(v)
     }
 }
 
@@ -49,9 +55,8 @@ impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
     }
 
     /// Returns the value
-    #[inline]
     pub fn value(&self) -> &Json {
-        self.value.as_ref()
+        self.value.as_json()
     }
 }
 

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -2,49 +2,49 @@ extern crate handlebars;
 #[macro_use]
 extern crate serde_json;
 
-use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError};
+use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError, ScopedJson};
 use serde_json::Value;
 
 struct GtHelper;
 
 impl HelperDef for GtHelper {
-    fn call_inner(
+    fn call_inner<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         _: &Handlebars,
-        _: &mut RenderContext,
-    ) -> Result<Option<Value>, RenderError> {
-        let p1 = h.param(0)
+        _: &RenderContext,
+    ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
+        let p1 = h.param(0)?
             .and_then(|v| v.value().as_i64())
             .ok_or(RenderError::new(
                 "Param 0 with i64 type is required for gt helper.",
             ))?;
-        let p2 = h.param(1)
+        let p2 = h.param(1)?
             .and_then(|v| v.value().as_i64())
             .ok_or(RenderError::new(
                 "Param 1 with i64 type is required for gt helper.",
             ))?;
 
-        Ok(Some(Value::Bool(p1 > p2)))
+        Ok(Some(Value::Bool(p1 > p2).into()))
     }
 }
 
 struct NotHelper;
 
 impl HelperDef for NotHelper {
-    fn call_inner(
+    fn call_inner<'reg: 'rc, 'rc>(
         &self,
         h: &Helper,
         _: &Handlebars,
-        _: &mut RenderContext,
-    ) -> Result<Option<Value>, RenderError> {
-        let p1 = h.param(0)
+        _: &RenderContext,
+    ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
+        let p1 = h.param(0)?
             .and_then(|v| v.value().as_bool())
             .ok_or(RenderError::new(
                 "Param 0 with bool type is required for not helper.",
             ))?;
 
-        Ok(Some(Value::Bool(!p1)))
+        Ok(Some(Value::Bool(!p1).into()))
     }
 }
 

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -2,7 +2,7 @@ extern crate handlebars;
 #[macro_use]
 extern crate serde_json;
 
-use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError, ScopedJson};
+use handlebars::{Context, Handlebars, Helper, HelperDef, RenderContext, RenderError, ScopedJson};
 use serde_json::Value;
 
 struct GtHelper;
@@ -12,14 +12,15 @@ impl HelperDef for GtHelper {
         &self,
         h: &Helper,
         _: &Handlebars,
-        _: &RenderContext,
+        _: &Context,
+        _: &mut RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
-        let p1 = h.param(0)?
+        let p1 = h.param(0)
             .and_then(|v| v.value().as_i64())
             .ok_or(RenderError::new(
                 "Param 0 with i64 type is required for gt helper.",
             ))?;
-        let p2 = h.param(1)?
+        let p2 = h.param(1)
             .and_then(|v| v.value().as_i64())
             .ok_or(RenderError::new(
                 "Param 1 with i64 type is required for gt helper.",
@@ -36,9 +37,10 @@ impl HelperDef for NotHelper {
         &self,
         h: &Helper,
         _: &Handlebars,
-        _: &RenderContext,
+        _: &Context,
+        _: &mut RenderContext,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
-        let p1 = h.param(0)?
+        let p1 = h.param(0)
             .and_then(|v| v.value().as_bool())
             .ok_or(RenderError::new(
                 "Param 0 with bool type is required for not helper.",


### PR DESCRIPTION
Another attempt to fix #206 

In order to use reference from Context, we have to ensure it's immutable across the render process. However, that's conflict with how we use RenderContext. So we have to split `Context` and `RenderContext` for better mutable granularity.