### PR TITLE
Fix a few typos in the docs

### DIFF
--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -12,7 +12,7 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// Implement this trait to define your own decorators or directives. Currently
 /// decorator shares same definition with helper.
 ///
-/// In handlebars, it is recommanded to use decorator to change context data and update helper
+/// In handlebars, it is recommended to use decorator to change context data and update helper
 /// definition.
 /// ## Updating context data
 ///

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -20,7 +20,7 @@ pub type HelperResult = Result<(), RenderError>;
 ///
 /// * `&Helper`: current helper template information, contains name, params, hashes and nested template
 /// * `&Registry`: the global registry, you can find templates by name from registry
-/// * `&mut RenderContext`: you can access data or modify variables (starts with @)/patials in render context, for example, @index of #each. See its document for detail.
+/// * `&mut RenderContext`: you can access data or modify variables (starts with @)/partials in render context, for example, @index of #each. See its document for detail.
 ///
 /// By default, you can use bare function as helper definition because we have supported unboxed_closure. If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! generates empty string for such case. However, in Rust we want a
 //! little bit strict sometime.
 //!
-//! By enabling `strcit_mode` on handlebars:
+//! By enabling `strict_mode` on handlebars:
 //!
 //! ```
 //! # use handlebars::Handlebars;
@@ -133,12 +133,12 @@
 //! # }
 //! ```
 //!
-//! On registeration, the template is parsed, compiled and cached in the registry. So further
-//! usage will benifite from the one-time work. Also features like include, inheritance
+//! On registration, the template is parsed, compiled and cached in the registry. So further
+//! usage will benefit from the one-time work. Also features like include, inheritance
 //! that involves template reference requires you to register those template first with
 //! a name so the registry can find it.
 //!
-//! If you template is small or just to expirement, you can use `render_template` API
+//! If you template is small or just to experiment, you can use `render_template` API
 //! without registration.
 //!
 //! ```
@@ -299,16 +299,16 @@
 //! * `{{{{#raw}}}} ... {{{{/raw}}}}` escape handlebars expression within the block
 //! * `{{#if ...}} ... {{else}} ... {{/if}}` if-else block
 //! * `{{#unless ...}} ... {{else}} .. {{/unless}}` if-not-else block
-//! * `{{#each ...}} ... {{/each}}` iterates over an array or object. Handlebar-rust doesn't support mustach iteration syntax so use this instead.
-//! * `{{#with ...}} ... {{/with}}` change current context. Similar to {{#each}}, used for replace corresponding mustach syntax.
+//! * `{{#each ...}} ... {{/each}}` iterates over an array or object. Handlebar-rust doesn't support mustache iteration syntax so use this instead.
+//! * `{{#with ...}} ... {{/with}}` change current context. Similar to {{#each}}, used for replace corresponding mustache syntax.
 //! * `{{lookup ... ...}}` get value from array by `@index` or `@key`
 //! * `{{> ...}}` include template with name
 //! * `{{log ...}}` log value with rust logger, default level: INFO. Currently you cannot change the level.
 //!
 //! ### Template inheritance
 //!
-//! Handlebarsjs partial system is fully supported in this implementation.
-//! Check [example](https://github.com/sunng87/handlebars-rust/blob/master/examples/partials.rs#L49) for detail.
+//! Handlebars.js' partial system is fully supported in this implementation.
+//! Check [example](https://github.com/sunng87/handlebars-rust/blob/master/examples/partials.rs#L49) for details.
 //!
 //!
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,7 +396,7 @@ impl Registry {
         let mut tpl_str = String::new();
         template_source
             .read_to_string(&mut tpl_str)
-            .map_err(|e| TemplateRenderError::IOError(e, "Unamed template source".to_owned()))?;
+            .map_err(|e| TemplateRenderError::IOError(e, "Unnamed template source".to_owned()))?;
         self.render_template_to_write(&tpl_str, data, writer)
     }
 }


### PR DESCRIPTION
All credit goes to https://github.com/Jason-Rev/vscode-spell-checker