### PR TITLE
update some debs for minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ path = "src/lib.rs"
 log = "0.4.0"
 quick-error = "1.0.0"
 pest = "1.0.0"
-pest_derive = "1.0.7"
+pest_derive = "1.0.8"
 serde = "1.0.0"
 serde_json = "1.0.0"
-regex = "1.0.0"
+regex = "1.0.3"
 lazy_static = "1.0.0"
-walkdir = { version = "2.1.4", optional = true }
+walkdir = { version = "2.2.3", optional = true }
 
 [dev-dependencies]
-env_logger = "0.5.0"
+env_logger = "0.5.13"
 maplit = "1.0.0"
-serde_derive = "1.0.0"
+serde_derive = "1.0.75"
 tempfile = "3.0.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ path = "src/lib.rs"
 
 [dependencies]
 
-log = "^0.4.0"
-quick-error = "^1.0.0"
-pest = "^1.0.0"
-pest_derive = "^1.0.7"
-serde = "^1.0.0"
-serde_json = "^1.0.0"
-regex = "^1.0.0"
-lazy_static = "^1.0.0"
-walkdir = { version = "^2.1.4", optional = true }
+log = "0.4.0"
+quick-error = "1.0.0"
+pest = "1.0.0"
+pest_derive = "1.0.7"
+serde = "1.0.0"
+serde_json = "1.0.0"
+regex = "1.0.0"
+lazy_static = "1.0.0"
+walkdir = { version = "2.1.4", optional = true }
 
 [dev-dependencies]
-env_logger = "^0.5.0"
-maplit = "^1.0.0"
-serde_derive = "^1.0.0"
-tempfile = "^3.0.0"
+env_logger = "0.5.0"
+maplit = "1.0.0"
+serde_derive = "1.0.0"
+tempfile = "3.0.0"
 
 [features]
 dir_source = ["walkdir"]


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.

Also cargo defaults to interpreting version requirements as `^`. So this switched to the shorter form.