### PR TITLE
CI: add test with minimal versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: rust
-rust:
-  - nightly
-  - beta
-  - stable
-  - 1.31.0
 
 env:
   # - TASK=build
   - TASK=test
 
 matrix:
+  include:
+    - rust: nightly
+    - rust: beta
+    - rust: stable
+    - rust: 1.31.0
+    - rust: nightly
+      name: minimal-versions
+      script:
+        - cargo -Z minimal-versions test --verbose
   exclude:
     - rust: nightly
       env: TASK=build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/lib.rs"
 
 log = { version = "0.4.0", optional = true }
 quick-error = "1.0.0"
-pest = "2.0.2"
-pest_derive = "2.0.1"
+pest = "2.1.0"
+pest_derive = "2.1.0"
 serde = "1.0.0"
 serde_json = "1.0.0"
 regex = "1.0.3"


### PR DESCRIPTION
This ensures our lower bounds in dependencies are accurate