### PR TITLE
Hashbrown map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.0"
 regex = "1.0.3"
 lazy_static = "1.0.0"
 walkdir = { version = "2.2.3", optional = true }
+hashbrown = "0.1.8"
 
 [dev-dependencies]
 env_logger = "0.5.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,8 @@ extern crate serde_json;
 #[cfg(not(feature = "no_dir_source"))]
 extern crate walkdir;
 
+extern crate hashbrown;
+
 pub use self::context::Context;
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};


### PR DESCRIPTION
Replace std collections with Hashbrown/Swiss map. Speeds benchmark up for 10% at most.