### PR TITLE
Swap order of block parameters in each helper

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -215,7 +215,7 @@ fn test_helper_start() {
         "{{#if}}",
         "{{~#if hello~}}",
         "{{#each people as |person|}}",
-        "{{#each-obj obj as |key val|}}",
+        "{{#each-obj obj as |val key|}}",
         "{{#each assets}}",
     ];
     for i in s.iter() {
@@ -263,7 +263,7 @@ fn test_raw_block() {
 
 #[test]
 fn test_block_param() {
-    let s = vec!["as |person|", "as |key val|"];
+    let s = vec!["as |person|", "as |val key|"];
     for i in s.iter() {
         assert_rule!(Rule::block_param, i);
     }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -94,7 +94,7 @@ impl HelperDef for EachHelper {
                                 local_rc.set_path(new_path);
                             }
 
-                            if let Some((bp_key, bp_val)) = h.block_param_pair() {
+                            if let Some((bp_val, bp_key)) = h.block_param_pair() {
                                 let mut map = HashMap::new();
                                 map.insert(bp_key.to_string(), to_json(k));
                                 map.insert(bp_val.to_string(), to_json(v));
@@ -305,7 +305,7 @@ mod test {
     #[test]
     fn test_each_object_block_param() {
         let mut handlebars = Registry::new();
-        let template = "{{#each this as |k v|}}\
+        let template = "{{#each this as |v k|}}\
                         {{#with k as |inner_k|}}{{inner_k}}{{/with}}:{{v}}|\
                         {{/each}}";
         assert!(handlebars.register_template_string("t0", template).is_ok());

--- a/src/template.rs
+++ b/src/template.rs
@@ -1043,14 +1043,14 @@ fn test_block_param() {
         Err(e) => panic!("{}", e),
     }
 
-    match Template::compile("{{#each people as |key val|}}{{person}}{{/each}}") {
+    match Template::compile("{{#each people as |val key|}}{{person}}{{/each}}") {
         Ok(t) => {
             if let HelperBlock(ref ht) = t.elements[0] {
                 if let Some(BlockParam::Pair((Parameter::Name(ref n1), Parameter::Name(ref n2)))) =
                     ht.block_param
                 {
-                    assert_eq!(n1, "key");
-                    assert_eq!(n2, "val");
+                    assert_eq!(n1, "val");
+                    assert_eq!(n2, "key");
                 } else {
                     panic!("helper block param expected.");
                 }


### PR DESCRIPTION
As per https://handlebarsjs.com/builtin_helpers.html#iteration, the order of block parameters is `value` first, `key` second.