### PR TITLE
helpers: accept any json value for boolean helpers

### DIFF
--- a/src/helpers/helper_boolean.rs
+++ b/src/helpers/helper_boolean.rs
@@ -1,14 +1,16 @@
 //! Helpers for boolean operations
 
+use crate::value::JsonTruthy;
+
 handlebars_helper!(eq: |x: i64, y: i64| x == y);
 handlebars_helper!(ne: |x: i64, y: i64| x != y);
 handlebars_helper!(gt: |x: i64, y: i64| x > y);
 handlebars_helper!(gte: |x: i64, y: i64| x >= y);
 handlebars_helper!(lt: |x: i64, y: i64| x < y);
 handlebars_helper!(lte: |x: i64, y: i64| x <= y);
-handlebars_helper!(and: |x: bool, y: bool| x && y);
-handlebars_helper!(or: |x: bool, y: bool| x || y);
-handlebars_helper!(not: |x: bool| !x);
+handlebars_helper!(and: |x: Json, y: Json| x.is_truthy(false) && y.is_truthy(false));
+handlebars_helper!(or: |x: Json, y: Json| x.is_truthy(false) || y.is_truthy(false));
+handlebars_helper!(not: |x: Json| !x.is_truthy(false));
 
 #[cfg(test)]
 mod test_conditions {
@@ -32,6 +34,8 @@ mod test_conditions {
         test_condition("(gt 5 3)", true);
         test_condition("(gt 3 5)", false);
         test_condition("(or (gt 3 5) (gt 5 3))", true);
+        test_condition("(not [])", true);
+        test_condition("(and null 4)", false);
         test_condition("(eq 5 5)", true);
         test_condition("(eq 5 6)", false);
         test_condition("(ne 5 6)", true);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -70,6 +70,7 @@ macro_rules! handlebars_helper {
     (@as_json_value $x:ident, f64) => { $x.as_f64() };
     (@as_json_value $x:ident, bool) => { $x.as_bool() };
     (@as_json_value $x:ident, null) => { $x.as_null() };
+    (@as_json_value $x:ident, Json) => { Some($x) };
 }
 
 /// This macro is defined if the `logging` feature is set.


### PR DESCRIPTION
Makes thinkgs more consistent with default if behaviour, allows writing

```
{{#if (or a b)}}FOO{{else}}BAR{{/if}}
```

instead of

```
{{#if a}}FOO{{else}}{{#if b}}FOO{{else}}BAR{{/if}}{{/if}}
```

when a or b can be null, for example