### PR TITLE
Support singular and plural block params for each helper

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -56,16 +56,22 @@ impl HelperDef for EachHelper {
                                 local_rc.set_path(new_path);
                             }
 
-                            if let Some(block_param) = h.block_param() {
+                            if let Some(bp_val) = h.block_param() {
                                 let mut params = BlockParams::new();
-                                params.add_path(block_param, local_rc.get_path())?;
+                                params.add_path(bp_val, local_rc.get_path())?;
+
+                                local_rc.push_block_context(params)?;
+                            } else if let Some((bp_val, bp_index)) = h.block_param_pair() {
+                                let mut params = BlockParams::new();
+                                params.add_path(bp_val, local_rc.get_path())?;
+                                params.add_value(bp_index, to_json(i))?;
 
                                 local_rc.push_block_context(params)?;
                             }
 
                             t.render(r, ctx, &mut local_rc, out)?;
 
-                            if h.block_param().is_some() {
+                            if h.has_block_param() {
                                 local_rc.pop_block_context();
                             }
 
@@ -97,7 +103,12 @@ impl HelperDef for EachHelper {
                                 local_rc.set_path(new_path);
                             }
 
-                            if let Some((bp_val, bp_key)) = h.block_param_pair() {
+                            if let Some(bp_val) = h.block_param() {
+                                let mut params = BlockParams::new();
+                                params.add_path(bp_val, local_rc.get_path())?;
+
+                                local_rc.push_block_context(params)?;
+                            } else if let Some((bp_val, bp_key)) = h.block_param_pair() {
                                 let mut params = BlockParams::new();
                                 params.add_path(bp_val, local_rc.get_path())?;
                                 params.add_value(bp_key, to_json(&k))?;
@@ -107,7 +118,7 @@ impl HelperDef for EachHelper {
 
                             t.render(r, ctx, &mut local_rc, out)?;
 
-                            if h.block_param().is_some() {
+                            if h.has_block_param() {
                                 local_rc.pop_block_context();
                             }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -394,6 +394,11 @@ impl<'reg: 'rc, 'rc> Helper<'reg, 'rc> {
         self.block
     }
 
+    /// Returns if the helper has either a block param or block param pair
+    pub fn has_block_param(&self) -> bool {
+        self.block_param.is_some()
+    }
+
     /// Returns block param if any
     pub fn block_param(&self) -> Option<&str> {
         if let Some(&BlockParam::Single(Parameter::Name(ref s))) = self.block_param {

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -32,3 +32,17 @@ fn test_root_with_blocks() {
         "{{#*inline \"test\"}}{{b}}:{{@root.b}};{{/inline}}{{#each a}}{{> test}}{{/each}}";
     assert_eq!(hbs.render_template(template, &data).unwrap(), "1:3;2:3;");
 }
+
+#[test]
+fn test_singular_and_pair_block_params() {
+    let hbs = Handlebars::new();
+
+    let data = json!([
+        {"value": 11},
+        {"value": 22},
+    ]);
+
+    let template =
+        "{{#each this as |b index|}}{{b.value}}{{#each this as |value key|}}:{{key}},{{/each}}{{/each}}";
+    assert_eq!(hbs.render_template(template, &data).unwrap(), "11:value,22:value,");
+}


### PR DESCRIPTION
With a single block param, `each` should set it as the value of the container being iterated over.

With two block param, `each` should set the first as the value of the container being iterated over, and the second as the key/index.