### PR TITLE
Fix/nested block param

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use serde_json::value::{to_value, Map, Value as Json};
 
 use crate::error::RenderError;
 use crate::grammar::{HandlebarsParser, Rule};
-use crate::value::{PathAndJson, ScopedJson};
+use crate::value::ScopedJson;
 
 pub type Object = HashMap<String, Json>;
 
@@ -154,7 +154,7 @@ fn parse_json_visitor<'a, 'b: 'a>(
     }
 
     match used_block_param {
-        Some(BlockParamHolder::Value(ref v)) => {
+        Some(BlockParamHolder::Value(_)) => {
             parse_json_visitor_inner(&mut path_stack, relative_path)?;
             // drop first seg, which is block_param
             path_stack.pop_front();
@@ -249,9 +249,6 @@ impl Context {
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         let (paths, block_param_holder) =
             parse_json_visitor(base_path, path_context, relative_path, block_params)?;
-
-        dbg!(block_param_holder);
-        dbg!(&paths);
 
         if let Some(BlockParamHolder::Value(ref block_param_value)) = block_param_holder {
             let mut data = Some(block_param_value);

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -38,7 +38,13 @@ impl HelperDef for EachHelper {
                     (true, &Json::Array(ref list)) => {
                         let len = list.len();
 
-                        let array_path = value.path().and_then(|p| rc.concat_path(p));
+                        let array_path = value.path().map(|p| {
+                            if value.is_absolute_path() {
+                                p.to_string()
+                            } else {
+                                format!("{}/{}", rc.get_path(), p)
+                            }
+                        });
 
                         for (i, _) in list.iter().enumerate().take(len) {
                             let mut local_rc = rc.derive();
@@ -83,7 +89,13 @@ impl HelperDef for EachHelper {
                     }
                     (true, &Json::Object(ref obj)) => {
                         let mut first: bool = true;
-                        let obj_path = value.path().and_then(|p| rc.concat_path(p));
+                        let obj_path = value.path().map(|p| {
+                            if value.is_absolute_path() {
+                                p.to_string()
+                            } else {
+                                format!("{}/{}", rc.get_path(), p)
+                            }
+                        });
 
                         for (k, _) in obj.iter() {
                             let mut local_rc = rc.derive();

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -35,7 +35,13 @@ impl HelperDef for WithHelper {
                 local_rc.push_local_path_root(local_path_root);
             }
             if not_empty {
-                let new_path = param.path().and_then(|p| local_rc.concat_path(p));
+                let new_path = param.path().map(|p| {
+                    if param.is_absolute_path() {
+                        p.to_string()
+                    } else {
+                        format!("{}/{}", rc.get_path(), p)
+                    }
+                });
                 if let Some(ref new_path) = new_path {
                     local_rc.set_path(new_path.clone());
                 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -18,8 +18,16 @@ fn render_partial<'reg: 'rc, 'rc>(
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     // partial context path
-    if let Some(ref p) = d.param(0) {
-        if let Some(param_path) = p.path().and_then(|p| local_rc.concat_path(p)) {
+    if let Some(ref param_ctx) = d.param(0) {
+        let param_path = param_ctx.path().map(|p| {
+            if param_ctx.is_absolute_path() {
+                p.to_string()
+            } else {
+                format!("{}/{}", local_rc.get_path(), p)
+            }
+        });
+
+        if let Some(param_path) = param_path {
             local_rc.promote_local_vars();
             local_rc.set_path(param_path);
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -241,31 +241,6 @@ impl<'reg> RenderContext<'reg> {
         }
     }
 
-    // pub fn concat_path(&self, path_seg: &str) -> Option<String> {
-    //     dbg!(path_seg);
-    //     // FIXME:  what if path_seg is a complex path
-    //     let (path_parts, value_option) = context::parse_json_visitor(
-    //         self.get_path(),
-    //         self.get_local_path_root(),
-    //         path_seg,
-    //         &self.block.block_context,
-    //     )
-    //     .unwrap();
-    //     dbg!(&path_parts);
-
-    //     if value_option.is_some() {
-    //         None
-    //     } else {
-    //         Some(
-    //             path_parts
-    //                 .into_iter()
-    //                 .map(|v| format!("{}", v))
-    //                 .collect::<Vec<String>>()
-    //                 .join("/"),
-    //         )
-    //     }
-    // }
-
     pub fn get_local_path_root(&self) -> &VecDeque<String> {
         &self.block().local_path_root
     }
@@ -628,7 +603,12 @@ impl Parameter {
                             value,
                         ))
                     } else {
-                        Ok(PathAndJson::new(Some(name.to_owned()), value))
+                        match value {
+                            // when evaluate result is a derived json, it indicates the
+                            // value is a block context value
+                            ScopedJson::Derived(_) => Ok(PathAndJson::new(None, value)),
+                            _ => Ok(PathAndJson::new(Some(name.to_owned()), value)),
+                        }
                     }
                 }
             }

--- a/src/render.rs
+++ b/src/render.rs
@@ -233,10 +233,25 @@ impl<'reg> RenderContext<'reg> {
     }
 
     pub fn concat_path(&self, path_seg: &str) -> Option<String> {
-        match context::get_in_block_params(&self.block.block_context, path_seg) {
-            Some(BlockParamHolder::Path(paths)) => Some(paths.join("/")),
-            Some(BlockParamHolder::Value(_)) => None,
-            None => Some(format!("{}/{}", self.get_path(), path_seg)),
+        // FIXME:  what if path_seg is a complex path
+        let (path_parts, value_option) = context::parse_json_visitor(
+            self.get_path(),
+            self.get_local_path_root(),
+            path_seg,
+            &self.block.block_context,
+        )
+        .unwrap();
+
+        if value_option.is_some() {
+            None
+        } else {
+            Some(
+                path_parts
+                    .into_iter()
+                    .map(|v| format!("{}", v))
+                    .collect::<Vec<String>>()
+                    .join("/"),
+            )
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use serde::Serialize;
 use serde_json::value::{to_value, Value as Json};
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use serde::Serialize;
 use serde_json::value::{to_value, Value as Json};
 
@@ -14,6 +16,9 @@ pub enum ScopedJson<'reg: 'rc, 'rc> {
     Constant(&'reg Json),
     Derived(Json),
     Context(&'rc Json),
+    // represents a block param json with resolve full path
+    // this path is different from `PathAndJson`
+    BlockContext(&'rc Json, String),
     Missing,
 }
 
@@ -24,6 +29,7 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
             ScopedJson::Constant(j) => j,
             ScopedJson::Derived(ref j) => j,
             ScopedJson::Context(j) => j,
+            ScopedJson::BlockContext(j, _) => j,
             _ => &DEFAULT_VALUE,
         }
     }
@@ -33,7 +39,7 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
     }
 
     pub fn is_missing(&self) -> bool {
-        match *self {
+        match self {
             ScopedJson::Missing => true,
             _ => false,
         }
@@ -43,6 +49,13 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
         let v = self.as_json();
         ScopedJson::Derived(v.clone())
     }
+
+    pub fn block_context_path(&self) -> Option<&String> {
+        match self {
+            ScopedJson::BlockContext(_, ref p) => Some(p),
+            _ => None,
+        }
+    }
 }
 
 impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'reg, 'rc> {
@@ -51,30 +64,65 @@ impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'reg, 'rc> {
     }
 }
 
+#[derive(Debug)]
+enum Path {
+    Relative(String),
+    Absolute(String),
+}
+
+impl Path {
+    pub fn get(&self) -> &String {
+        match self {
+            Path::Relative(ref s) => s,
+            Path::Absolute(ref s) => s,
+        }
+    }
+}
+
 /// Json wrapper that holds the Json value and reference path information
 ///
 #[derive(Debug)]
 pub struct PathAndJson<'reg: 'rc, 'rc> {
-    path: Option<String>,
+    path: Option<Path>,
     value: ScopedJson<'reg, 'rc>,
 }
 
 impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
     pub fn new(path: Option<String>, value: ScopedJson<'reg, 'rc>) -> PathAndJson<'reg, 'rc> {
-        PathAndJson { path, value }
+        PathAndJson {
+            path: path.map(|p| Path::Relative(p)),
+            value,
+        }
+    }
+
+    pub fn new_absolute(
+        path: Option<String>,
+        value: ScopedJson<'reg, 'rc>,
+    ) -> PathAndJson<'reg, 'rc> {
+        PathAndJson {
+            path: path.map(|p| Path::Absolute(p)),
+            value,
+        }
     }
 
     /// Returns relative path when the value is referenced
     /// If the value is from a literal, the path is `None`
     pub fn path(&self) -> Option<&String> {
-        self.path.as_ref()
+        self.path.as_ref().map(|p| p.get())
     }
 
     /// Return root level of this path if any
     pub fn path_root(&self) -> Option<&str> {
         self.path
             .as_ref()
-            .and_then(|p| p.split(|c| c == '.' || c == '/').nth(0))
+            .and_then(|p| p.get().split(|c| c == '.' || c == '/').nth(0))
+    }
+
+    pub fn is_absolute_path(&self) -> bool {
+        match self.path {
+            Some(Path::Absolute(_)) => true,
+            _ => false,
+        }
     }
 
     /// Returns the value
@@ -85,6 +133,10 @@ impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
     /// Test if value is missing
     pub fn is_value_missing(&self) -> bool {
         self.value.is_missing()
+    }
+
+    pub fn render(&self) -> String {
+        self.value.render()
     }
 }
 

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -44,5 +44,33 @@ fn test_singular_and_pair_block_params() {
 
     let template =
         "{{#each this as |b index|}}{{b.value}}{{#each this as |value key|}}:{{key}},{{/each}}{{/each}}";
-    assert_eq!(hbs.render_template(template, &data).unwrap(), "11:value,22:value,");
+    assert_eq!(
+        hbs.render_template(template, &data).unwrap(),
+        "11:value,22:value,"
+    );
+}
+
+#[test]
+fn test_nested_each() {
+    let hbs = Handlebars::new();
+
+    let data = json!({
+        "classes": [
+            {
+                "methods": [
+                    {"id": 1},
+                    {"id": 2}
+                ]
+            },
+            {
+                "methods": [
+                    {"id": 3},
+                    {"id": 4}
+                ]
+            },
+        ],
+    });
+
+    let template = "{{#each classes as |class|}}{{#each class.methods as |method|}}{{method.id}}{{/each}}{{/each}}";
+    assert_eq!(hbs.render_template(template, &data).unwrap(), "1;2;3;4;");
 }

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -71,6 +71,6 @@ fn test_nested_each() {
         ],
     });
 
-    let template = "{{#each classes as |class|}}{{#each class.methods as |method|}}{{method.id}}{{/each}}{{/each}}";
+    let template = "{{#each classes as |class|}}{{#each class.methods as |method|}}{{method.id}};{{/each}}{{/each}}";
     assert_eq!(hbs.render_template(template, &data).unwrap(), "1;2;3;4;");
 }


### PR DESCRIPTION
Fixes #275 

Finally got a fix on 2.0 API  without ruining benchmark. The downside is we introduced some new APIs in `ScopedJson` and `PathAndJson`, which I think is a little fragile in terms of design.

The path system may receive an revamp in 3.0 but for now it works.