### PR TITLE
(feat) switch back to std hashmap [#279]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ serde_json = "1.0.39"
 regex = "1.0.3"
 lazy_static = "1.0.0"
 walkdir = { version = "2.2.3", optional = true }
-hashbrown = { version = "0.5.0", features = ["serde"] }
 
 [dev-dependencies]
 env_logger = "0.6.0"

--- a/release.toml
+++ b/release.toml
@@ -5,4 +5,3 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
   {file="src/lib.rs", search="https://docs.rs/handlebars/[a-z0-9\\.-]+", replace="https://docs.rs/handlebars/{{version}}"},
 ]
-

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,5 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
-use hashbrown::HashMap;
 use pest::iterators::Pair;
 use pest::Parser;
 use serde::Serialize;
@@ -300,9 +299,8 @@ fn join(segs: &VecDeque<&str>, sep: &str) -> String {
 mod test {
     use crate::context::{self, BlockParams, Context};
     use crate::value::{self};
-    use hashbrown::HashMap;
     use serde_json::value::Map;
-    use std::collections::VecDeque;
+    use std::collections::{HashMap, VecDeque};
 
     #[derive(Serialize)]
     struct Address {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,8 +349,6 @@ extern crate serde_json;
 #[cfg(not(feature = "no_dir_source"))]
 extern crate walkdir;
 
-extern crate hashbrown;
-
 pub use self::context::{BlockParams, Context};
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use std::collections::HashMap;
 
 use serde_json::value::Value as Json;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-use hashbrown::HashMap;
 use serde::Serialize;
 
 use regex::{Captures, Regex};

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,10 +1,9 @@
 use std::borrow::Borrow;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 
-use hashbrown::HashMap;
 use serde_json::value::Value as Json;
 
 use crate::context::{self, BlockParamHolder, BlockParams, Context};

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::convert::From;
 use std::iter::Peekable;
 
@@ -7,7 +7,6 @@ use pest::error::LineColLocation;
 use pest::iterators::Pair;
 use pest::{Parser, Position};
 
-use hashbrown::HashMap;
 use serde_json::value::Value as Json;
 use std::str::FromStr;
 


### PR DESCRIPTION
Fixes #279

Benchmark shows std hashmap now shares same performance with hashbrown. So we'd better swtich back in next major release.