### PR TITLE
fixes #284

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Handlebars-rust is the template engine renders Rust official website
 book](https://doc.rust-lang.org/book/).
 
 [![Build Status](https://travis-ci.org/sunng87/handlebars-rust.svg?branch=master)](https://travis-ci.org/sunng87/handlebars-rust)
-[![](http://meritbadge.herokuapp.com/handlebars)](https://crates.io/crates/handlebars)
+[![](https://meritbadge.herokuapp.com/handlebars)](https://crates.io/crates/handlebars)
 [![](https://img.shields.io/crates/d/handlebars.svg)](https://crates.io/crates/handlebars)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Docs](https://docs.rs/handlebars/badge.svg)](https://docs.rs/crate/handlebars/)


### PR DESCRIPTION
the crates.io badge is served via https now