### PR TITLE
Reorganize feature flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ matrix:
 script:
   - cargo $TASK --verbose
   - cargo $TASK --no-default-features --features no_logging --verbose
-  - cargo $TASK --no-default-features --features no_dir_source --verbose
+  - cargo $TASK --no-default-features --features dir_source --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 
-log = { version = "0.4.0", optional = true }
+log = { version = "0.4.0" }
 quick-error = "1.0.0"
 pest = "2.1.0"
 pest_derive = "2.1.0"
@@ -38,12 +38,8 @@ criterion = "0.2.11"
 
 [features]
 dir_source = ["walkdir"]
-logging = ["log"]
-
-default = ["dir_source", "logging"]
-
-no_dir_source = ["logging"]
-no_logging = ["dir_source"]
+no_logging = []
+default = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::io::Error as IOError;
 use std::string::FromUtf8Error;
 
 use serde_json::error::Error as SerdeError;
-#[cfg(not(feature = "no_dir_source"))]
+#[cfg(feature = "dir_source")]
 use walkdir::Error as WalkdirError;
 
 use crate::template::Parameter;
@@ -227,7 +227,7 @@ quick_error! {
     }
 }
 
-#[cfg(not(feature = "no_dir_source"))]
+#[cfg(feature = "dir_source")]
 impl From<WalkdirError> for TemplateFileError {
     fn from(error: WalkdirError) -> TemplateFileError {
         let path_string: String = error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ extern crate serde;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
-#[cfg(not(feature = "no_dir_source"))]
+#[cfg(feature = "dir_source")]
 extern crate walkdir;
 
 extern crate hashbrown;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,7 +15,7 @@ use crate::render::{RenderContext, Renderable};
 use crate::support::str::{self, StringWriter};
 use crate::template::Template;
 
-#[cfg(not(feature = "no_dir_source"))]
+#[cfg(feature = "dir_source")]
 use walkdir::{DirEntry, WalkDir};
 
 /// This type represents an *escape fn*, that is a function who's purpose it is
@@ -66,7 +66,7 @@ impl Default for Registry {
     }
 }
 
-#[cfg(not(feature = "no_dir_source"))]
+#[cfg(feature = "dir_source")]
 fn filter_file(entry: &DirEntry, suffix: &str) -> bool {
     let path = entry.path();
 
@@ -200,7 +200,7 @@ impl Registry {
     /// will use their relative name as template name. For example, when `dir_path` is
     /// `templates/` and `tpl_extension` is `.hbs`, the file
     /// `templates/some/path/file.hbs` will be registerd as `some/path/file`.
-    #[cfg(not(feature = "no_dir_source"))]
+    #[cfg(feature = "dir_source")]
     pub fn register_templates_directory<P>(
         &mut self,
         tpl_extension: &'static str,
@@ -486,7 +486,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "no_dir_source"))]
+    #[cfg(feature = "dir_source")]
     fn test_register_templates_directory() {
         let mut r = Registry::new();
         {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -433,11 +433,11 @@ mod test {
     use crate::registry::Registry;
     use crate::render::{Helper, RenderContext, Renderable};
     use crate::support::str::StringWriter;
-    #[cfg(not(feature = "no_dir_source"))]
+    #[cfg(feature = "dir_source")]
     use std::fs::{DirBuilder, File};
-    #[cfg(not(feature = "no_dir_source"))]
+    #[cfg(feature = "dir_source")]
     use std::io::Write;
-    #[cfg(not(feature = "no_dir_source"))]
+    #[cfg(feature = "dir_source")]
     use tempfile::tempdir;
 
     #[derive(Clone, Copy)]


### PR DESCRIPTION
As of 2.0, the feature flags of handlebars-rust was a little bit confuse. In this patch, I made:

* `no_dir_source` is now by default, `walkdir` dependency and `register_directory` is only enabled by `dir_source` feature. Webassembly compatibility is now by default.
* `no_logging` feature cleaned up.
