### PR TITLE
Parse path during template parse phase

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -257,6 +257,7 @@ fn join(segs: &VecDeque<&str>, sep: &str) -> String {
 mod test {
     use crate::context::{self, BlockParams, Context};
     use crate::error::RenderError;
+    use crate::json::path::parse_json_path;
     use crate::json::value::{self, ScopedJson};
     use serde_json::value::Map;
     use std::collections::{HashMap, VecDeque};
@@ -265,7 +266,13 @@ mod test {
         ctx: &'rc Context,
         path: &str,
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
-        ctx.navigate(&Vec::new(), &VecDeque::new(), path, &VecDeque::new())
+        let relative_path = parse_json_path(path).unwrap();
+        ctx.navigate(
+            &Vec::new(),
+            &VecDeque::new(),
+            &relative_path,
+            &VecDeque::new(),
+        )
     }
 
     #[derive(Serialize)]
@@ -432,7 +439,7 @@ mod test {
             ctx.navigate(
                 &["a".to_owned(), "b".to_owned()],
                 &VecDeque::new(),
-                "@root/b",
+                &parse_json_path("@root/b").unwrap(),
                 &VecDeque::new()
             )
             .unwrap()
@@ -460,15 +467,25 @@ mod test {
         block_params.push_front(block_param);
 
         assert_eq!(
-            ctx.navigate(&Vec::new(), &VecDeque::new(), "z.[1]", &block_params)
-                .unwrap()
-                .render(),
+            ctx.navigate(
+                &Vec::new(),
+                &VecDeque::new(),
+                &parse_json_path("z.[1]").unwrap(),
+                &block_params
+            )
+            .unwrap()
+            .render(),
             "2".to_string()
         );
         assert_eq!(
-            ctx.navigate(&Vec::new(), &VecDeque::new(), "t", &block_params)
-                .unwrap()
-                .render(),
+            ctx.navigate(
+                &Vec::new(),
+                &VecDeque::new(),
+                &parse_json_path("t").unwrap(),
+                &block_params
+            )
+            .unwrap()
+            .render(),
             "good".to_string()
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,8 +7,6 @@ use serde_json::error::Error as SerdeError;
 #[cfg(feature = "dir_source")]
 use walkdir::Error as WalkdirError;
 
-use crate::template::Parameter;
-
 /// Error when rendering data on template.
 #[derive(Debug)]
 pub struct RenderError {
@@ -104,7 +102,7 @@ quick_error! {
                 open, closed)
             description("wrong name of closing helper")
         }
-        MismatchingClosedDirective(open: Parameter, closed: Parameter) {
+        MismatchingClosedDirective(open: String, closed: String) {
             display("directive {:?} was opened, but {:?} is closing",
                 open, closed)
             description("wrong name of closing directive")

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -25,7 +25,7 @@ symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"@"|"-"|"_"|'\u{80}'..'\u{7ff}'|'\
 path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }
-reference = @{ "@"? ~ path_inline }
+reference = @{ path_inline }
 name = _{ subexpression | reference }
 
 param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
@@ -108,6 +108,6 @@ path_key = _{ "[" ~  path_raw_id ~ "]" }
 path_root = { "@root" }
 path_current = { "this" | "." }
 path_item = _{ path_id|path_current|path_key }
-
-path_inline = _{ (path_root ~ path_sep)? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
+path_local = { "@" }
+path_inline = _{ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
 path = _{ path_inline ~ EOI }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -25,22 +25,24 @@ symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"@"|"-"|"_"|'\u{80}'..'\u{7ff}'|'\
 path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }
-reference = @{ path_inline }
+reference = { path_inline }
+
 name = _{ subexpression | reference }
 
 param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
 hash = { identifier ~ "=" ~ param }
 block_param = { "as" ~ "|" ~ identifier ~ identifier? ~ "|"}
 exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
-partial_exp_line = _{ name ~ (hash|param)* }
+partial_exp_line = _{ (identifier ~ (hash|param)+) | name }
 
-subexpression = { "(" ~ name ~ (hash|param)* ~ ")" }
+subexpression = { "(" ~ ((identifier ~ (hash|param)+) | reference)  ~ ")" }
 
 pre_whitespace_omitter = { "~" }
 pro_whitespace_omitter = { "~" }
 
 expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~
-              name ~ (hash|param)* ~ block_param? ~ pro_whitespace_omitter? ~ "}}" }
+              ((identifier ~ (hash|param)+) | name )
+              ~ pro_whitespace_omitter? ~ "}}" }
 html_expression = { "{{{" ~ pre_whitespace_omitter? ~ name ~
 pro_whitespace_omitter? ~ "}}}" }
 
@@ -53,27 +55,27 @@ invert_tag = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
              ~ pro_whitespace_omitter? ~ "}}"}
 helper_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
                      pro_whitespace_omitter? ~ "}}" }
-helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
                    pro_whitespace_omitter? ~ "}}" }
 helper_block = _{ helper_block_start ~ template ~
                   (invert_tag ~ template)? ~ helper_block_end }
 
 directive_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
                         ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-directive_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+directive_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
                         pro_whitespace_omitter? ~ "}}" }
 directive_block = _{ directive_block_start ~ template ~
                      directive_block_end }
 
 partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
                         ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
-partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
                       pro_whitespace_omitter? ~ "}}" }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
 raw_block_start = { "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
                     pro_whitespace_omitter? ~ "}}}}" }
-raw_block_end = { "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ name ~
+raw_block_end = { "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
                   pro_whitespace_omitter? ~ "}}}}" }
 raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
@@ -99,15 +101,15 @@ handlebars = _{ template ~ EOI }
 // json path visitor
 // Disallowed chars: Whitespace ! " # % & ' ( ) * + , . / ; < = > @ [ \ ] ^ ` { | } ~
 
-path_id = { symbol_char+ }
+path_id = @{ symbol_char+ }
 
 path_raw_id = { (!"]" ~ ANY)* }
 path_sep = _{ "/" | "." }
 path_up = { ".." }
 path_key = _{ "[" ~  path_raw_id ~ "]" }
 path_root = { "@root" }
-path_current = { "this" | "." }
-path_item = _{ path_id|path_current|path_key }
+path_current = _{ "this" ~ path_sep | "./" }
+path_item = _{ path_id|path_key }
 path_local = { "@" }
-path_inline = _{ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
+path_inline = _{ path_current? ~ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
 path = _{ path_inline ~ EOI }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -21,11 +21,11 @@ array_literal = { "[" ~ literal? ~ ("," ~ literal)* ~ "]" }
 object_literal = { "{" ~ (string_literal ~ ":" ~ literal)?
                    ~ ("," ~ string_literal ~ ":" ~ literal)* ~ "}" }
 
-symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"@"|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
+symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
 path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }
-reference = { path_inline }
+reference = ${ path_inline }
 
 name = _{ subexpression | reference }
 
@@ -111,5 +111,5 @@ path_root = { "@root" }
 path_current = _{ "this" ~ path_sep | "./" }
 path_item = _{ path_id|path_key }
 path_local = { "@" }
-path_inline = _{ path_current? ~ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
+path_inline = ${ path_current? ~ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
 path = _{ path_inline ~ EOI }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -277,13 +277,13 @@ fn test_path() {
         "a.[bb c]/b/c/d",
         "a.[0].[#hello]",
         "../a/b.[0].[1]",
-        "./this.[0]/[1]/this/a",
+        "this.[0]/[1]/this/a",
         "./this_name",
         "./goo/[/bar]",
         "a.[你好]",
         "a.[10].[#comment]",
         "a.[]", // empty key
-        "././[/foo]",
+        "./[/foo]",
         "[foo]",
         "@root/a/b",
     ];

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -54,10 +54,8 @@ impl HelperDef for EachHelper {
                             if let Some(ref p) = array_path {
                                 if is_first {
                                     rc.set_path(copy_on_push_vec(p, i.to_string()))
-                                } else {
-                                    if let Some(ptr) = rc.base_path_mut().last_mut() {
-                                        *ptr = i.to_string();
-                                    }
+                                } else if let Some(ptr) = rc.base_path_mut().last_mut() {
+                                    *ptr = i.to_string();
                                 }
                             }
 
@@ -94,10 +92,8 @@ impl HelperDef for EachHelper {
                             if let Some(ref p) = obj_path {
                                 if is_first {
                                     rc.set_path(copy_on_push_vec(p, k.clone()));
-                                } else {
-                                    if let Some(ptr) = rc.base_path_mut().last_mut() {
-                                        *ptr = k.clone();
-                                    }
+                                } else if let Some(ptr) = rc.base_path_mut().last_mut() {
+                                    *ptr = k.clone();
                                 }
                             }
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -29,7 +29,7 @@ impl HelperDef for EachHelper {
 
         match template {
             Some(t) => {
-                let saved_path = rc.get_path().to_vec();
+                let saved_path = rc.base_path().to_vec();
                 rc.promote_local_vars();
                 let local_path_root = value.path_root();
                 if let Some(p) = local_path_root {
@@ -53,7 +53,7 @@ impl HelperDef for EachHelper {
 
                             if let Some(ref p) = array_path {
                                 if is_first {
-                                    rc.set_path(copy_on_push_vec(p, i.to_string()))
+                                    *rc.base_path_mut() = copy_on_push_vec(p, i.to_string());
                                 } else if let Some(ptr) = rc.base_path_mut().last_mut() {
                                     *ptr = i.to_string();
                                 }
@@ -61,12 +61,12 @@ impl HelperDef for EachHelper {
 
                             if let Some(bp_val) = h.block_param() {
                                 let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.get_path().clone())?;
+                                params.add_path(bp_val, rc.base_path().clone())?;
 
                                 rc.push_block_context(params)?;
                             } else if let Some((bp_val, bp_index)) = h.block_param_pair() {
                                 let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.get_path().clone())?;
+                                params.add_path(bp_val, rc.base_path().clone())?;
                                 params.add_value(bp_index, to_json(i))?;
 
                                 rc.push_block_context(params)?;
@@ -91,7 +91,7 @@ impl HelperDef for EachHelper {
 
                             if let Some(ref p) = obj_path {
                                 if is_first {
-                                    rc.set_path(copy_on_push_vec(p, k.clone()));
+                                    *rc.base_path_mut() = copy_on_push_vec(p, k.clone());
                                 } else if let Some(ptr) = rc.base_path_mut().last_mut() {
                                     *ptr = k.clone();
                                 }
@@ -99,12 +99,12 @@ impl HelperDef for EachHelper {
 
                             if let Some(bp_val) = h.block_param() {
                                 let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.get_path().clone())?;
+                                params.add_path(bp_val, rc.base_path().clone())?;
 
                                 rc.push_block_context(params)?;
                             } else if let Some((bp_val, bp_key)) = h.block_param_pair() {
                                 let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.get_path().clone())?;
+                                params.add_path(bp_val, rc.base_path().clone())?;
                                 params.add_value(bp_key, to_json(&k))?;
 
                                 rc.push_block_context(params)?;
@@ -139,7 +139,7 @@ impl HelperDef for EachHelper {
                 }
 
                 rc.demote_local_vars();
-                rc.set_path(saved_path);
+                *rc.base_path_mut() = saved_path;
                 rendered
             }
             None => Ok(()),

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -216,6 +216,7 @@ mod test {
         assert_eq!(r1.ok().unwrap(), "2727".to_string());
 
         let r2 = handlebars.render("t2", &people);
+        dbg!(&r2);
         assert_eq!(r2.ok().unwrap(), "01".to_string());
     }
 

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -216,7 +216,6 @@ mod test {
         assert_eq!(r1.ok().unwrap(), "2727".to_string());
 
         let r2 = handlebars.render("t2", &people);
-        dbg!(&r2);
         assert_eq!(r2.ok().unwrap(), "01".to_string());
     }
 

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -22,7 +22,7 @@ impl HelperDef for WithHelper {
             .param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"with\""))?;
 
-        let saved_base_path = rc.get_path().to_vec();
+        let saved_base_path = rc.base_path().to_vec();
         rc.promote_local_vars();
 
         let not_empty = param.value().is_truthy(false);
@@ -36,13 +36,13 @@ impl HelperDef for WithHelper {
         if not_empty {
             let new_path = param.context_path();
             if let Some(new_path) = new_path {
-                rc.set_path(new_path.clone());
+                *rc.base_path_mut() = new_path.clone();
             }
 
             if let Some(block_param) = h.block_param() {
                 let mut params = BlockParams::new();
                 if new_path.is_some() {
-                    params.add_path(block_param, rc.get_path().clone())?;
+                    params.add_path(block_param, rc.base_path().clone())?;
                 } else {
                     params.add_value(block_param, param.value().clone())?;
                 }
@@ -65,7 +65,7 @@ impl HelperDef for WithHelper {
         }
 
         rc.demote_local_vars();
-        rc.set_path(saved_base_path);
+        *rc.base_path_mut() = saved_base_path;
         result
     }
 }

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -37,8 +37,8 @@ impl Path {
     /// for test only
     pub(crate) fn with_named_paths(name_segs: &[&str]) -> Path {
         let segs = name_segs
-            .into_iter()
-            .map(|n| PathSeg::Named(n.to_string()))
+            .iter()
+            .map(|n| PathSeg::Named((*n).to_string()))
             .collect();
         Path::Relative((segs, name_segs.join("/")))
     }
@@ -104,10 +104,10 @@ where
         it.next();
     }
 
-    return path_stack;
+    path_stack
 }
 
-pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<String>, relative_path: &[PathSeg]) {
+pub(crate) fn merge_json_path(path_stack: &mut Vec<String>, relative_path: &[PathSeg]) {
     for seg in relative_path {
         match seg {
             PathSeg::Named(s) => {

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -14,16 +14,23 @@ pub enum PathSeg {
 
 #[derive(PartialEq, Clone, Debug)]
 pub enum Path {
-    Relative(Vec<PathSeg>),
-    Local((usize, String)),
+    Relative((Vec<PathSeg>, String)),
+    Local((usize, String, String)),
 }
 
 impl Path {
-    pub(crate) fn new(segs: Vec<PathSeg>) -> Path {
+    pub(crate) fn new(raw: &str, segs: Vec<PathSeg>) -> Path {
         if let Some((level, name)) = get_local_path_and_level(&segs) {
-            Path::Local((level, name))
+            Path::Local((level, name, raw.to_owned()))
         } else {
-            Path::Relative(segs)
+            Path::Relative((segs, raw.to_owned()))
+        }
+    }
+
+    pub(crate) fn raw(&self) -> &str {
+        match self {
+            Path::Relative((_, ref raw)) => raw,
+            Path::Local((_, _, ref raw)) => raw,
         }
     }
 
@@ -33,7 +40,7 @@ impl Path {
             .into_iter()
             .map(|n| PathSeg::Named(n.to_string()))
             .collect();
-        Path::Relative(segs)
+        Path::Relative((segs, name_segs.join("/")))
     }
 }
 

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -26,6 +26,15 @@ impl Path {
             Path::Relative(segs)
         }
     }
+
+    /// for test only
+    pub(crate) fn with_named_paths(name_segs: &[&str]) -> Path {
+        let segs = name_segs
+            .into_iter()
+            .map(|n| PathSeg::Named(n.to_string()))
+            .collect();
+        Path::Relative(segs)
+    }
 }
 
 // from json path to a deque of
@@ -82,9 +91,7 @@ where
             Rule::path_id | Rule::path_raw_id => {
                 path_stack.push(PathSeg::Named(n.as_str().to_string()));
             }
-            _ => {
-                continue;
-            }
+            _ => {}
         }
 
         it.next();

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -1,16 +1,119 @@
-use crate::grammar::Rule;
+use std::iter::Peekable;
 
-#[derive(Debug)]
-pub(crate) enum PathSeg<'a> {
-    Named(&'a str),
+use pest::iterators::Pair;
+use pest::Parser;
+
+use crate::error::RenderError;
+use crate::grammar::{HandlebarsParser, Rule};
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum PathSeg {
+    Named(String),
     Ruled(Rule),
 }
 
-pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<String>, relative_path: &[PathSeg<'a>]) {
+#[derive(PartialEq, Clone, Debug)]
+pub enum Path {
+    Relative(Vec<PathSeg>),
+    Local((usize, String)),
+}
+
+impl Path {
+    pub(crate) fn new(segs: Vec<PathSeg>) -> Path {
+        if let Some((level, name)) = get_local_path_and_level(&segs) {
+            Path::Local((level, name))
+        } else {
+            Path::Relative(segs)
+        }
+    }
+}
+
+// from json path to a deque of
+pub(crate) fn parse_json_path(path: &str) -> Result<Vec<PathSeg>, RenderError> {
+    let parsed_path = HandlebarsParser::parse(Rule::path, path)
+        .map(|p| p.flatten())
+        .map_err(|_| RenderError::new("Invalid JSON path"))?;
+
+    let mut path_stack = Vec::with_capacity(5);
+    for seg in parsed_path {
+        match seg.as_rule() {
+            Rule::path_root => {
+                path_stack.push(PathSeg::Ruled(Rule::path_root));
+            }
+            Rule::path_local => {
+                path_stack.push(PathSeg::Ruled(Rule::path_local));
+            }
+            Rule::path_up => {
+                path_stack.push(PathSeg::Ruled(Rule::path_up));
+            }
+            Rule::path_id | Rule::path_raw_id => {
+                path_stack.push(PathSeg::Named(seg.as_str().to_string()));
+            }
+            _ => {
+                continue;
+            }
+        }
+    }
+
+    Ok(path_stack)
+}
+
+fn get_local_path_and_level(paths: &[PathSeg]) -> Option<(usize, String)> {
+    paths.get(0).and_then(|seg| {
+        if seg == &PathSeg::Ruled(Rule::path_local) {
+            let mut level = 0;
+            while paths[level + 1] == PathSeg::Ruled(Rule::path_up) {
+                level += 1;
+            }
+            if let Some(PathSeg::Named(name)) = paths.get(level + 1) {
+                Some((level, name.clone()))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    })
+}
+
+pub(crate) fn parse_json_path_from_iter<'a, I>(it: &mut Peekable<I>, limit: usize) -> Vec<PathSeg>
+where
+    I: Iterator<Item = Pair<'a, Rule>>,
+{
+    let mut path_stack = Vec::with_capacity(5);
+    while let Some(n) = it.peek() {
+        let span = n.as_span();
+        if span.end() > limit {
+            break;
+        }
+
+        // FIXME: remove duplicate code
+        match n.as_rule() {
+            Rule::path_root => {
+                path_stack.push(PathSeg::Ruled(Rule::path_root));
+            }
+            Rule::path_up => {
+                path_stack.push(PathSeg::Ruled(Rule::path_up));
+            }
+            Rule::path_id | Rule::path_raw_id => {
+                path_stack.push(PathSeg::Named(n.as_str().to_string()));
+            }
+            _ => {
+                continue;
+            }
+        }
+
+        it.next();
+    }
+
+    return path_stack;
+}
+
+pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<String>, relative_path: &[PathSeg]) {
     for seg in relative_path {
         match seg {
             PathSeg::Named(s) => {
-                path_stack.push((*s).to_string());
+                path_stack.push(s.clone());
             }
             PathSeg::Ruled(Rule::path_root) => {}
             PathSeg::Ruled(Rule::path_up) => {

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -38,7 +38,7 @@ fn render_partial<'reg: 'rc, 'rc>(
             .iter()
             .map(|(k, v)| (k.clone(), v.value().clone()))
             .collect::<HashMap<String, Json>>();
-        let partial_context = merge_json(local_rc.evaluate(ctx, ".")?.as_json(), &hash_ctx);
+        let partial_context = merge_json(local_rc.evaluate(ctx, &[])?.as_json(), &hash_ctx);
         let ctx = Context::wraps(&partial_context)?;
         let mut partial_rc = local_rc.new_for_block();
         t.render(r, &ctx, &mut partial_rc, out)

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -21,7 +21,7 @@ fn render_partial<'reg: 'rc, 'rc>(
     if let Some(ref param_ctx) = d.param(0) {
         if let Some(p) = param_ctx.context_path() {
             local_rc.promote_local_vars();
-            local_rc.set_path(p.clone());
+            *local_rc.base_path_mut() = p.clone();
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -670,7 +670,6 @@ mod test {
         );
 
         let data2 = json!([1, 2, 3]);
-        dbg!(r.render_template("accessing valid array index {{this.[2]}}", &data2));
         assert!(r
             .render_template("accessing valid array index {{this.[2]}}", &data2)
             .is_ok());

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -670,6 +670,7 @@ mod test {
         );
 
         let data2 = json!([1, 2, 3]);
+        dbg!(r.render_template("accessing valid array index {{this.[2]}}", &data2));
         assert!(r
             .render_template("accessing valid array index {{this.[2]}}", &data2)
             .is_ok());

--- a/src/render.rs
+++ b/src/render.rs
@@ -124,7 +124,7 @@ impl<'reg> RenderContext<'reg> {
         path: &[PathSeg],
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         context.navigate(
-            self.get_path(),
+            self.base_path(),
             self.get_local_path_root(),
             path,
             &self.block.block_context,
@@ -209,12 +209,8 @@ impl<'reg> RenderContext<'reg> {
         self.inner_mut().disable_escape = disable
     }
 
-    pub fn get_path(&self) -> &Vec<String> {
+    pub fn base_path(&self) -> &Vec<String> {
         &self.block().path
-    }
-
-    pub fn set_path(&mut self, path: Vec<String>) {
-        self.block_mut().path = path;
     }
 
     pub fn base_path_mut(&mut self) -> &mut Vec<String> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -217,6 +217,10 @@ impl<'reg> RenderContext<'reg> {
         self.block_mut().path = path;
     }
 
+    pub fn base_path_mut(&mut self) -> &mut Vec<String> {
+        &mut self.block_mut().path
+    }
+
     pub fn get_local_path_root(&self) -> &VecDeque<Vec<String>> {
         &self.block().local_path_root
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -39,9 +39,9 @@ impl Subexpression {
     ) -> Subexpression {
         Subexpression {
             element: Box::new(Expression(Box::new(HelperTemplate {
-                name: name,
-                params: params,
-                hash: hash,
+                name,
+                params,
+                hash,
                 template: None,
                 inverse: None,
                 block_param: None,
@@ -622,9 +622,9 @@ impl Template {
                                     template: None,
                                 };
                                 let el = if rule == Rule::directive_expression {
-                                    DirectiveExpression(directive)
+                                    DirectiveExpression(Box::new(directive))
                                 } else {
-                                    PartialExpression(directive)
+                                    PartialExpression(Box::new(directive))
                                 };
                                 let t = template_stack.front_mut().unwrap();
                                 t.push_element(el, line_no, col_no);
@@ -659,9 +659,9 @@ impl Template {
                                     d.template = Some(prev_t);
                                     let t = template_stack.front_mut().unwrap();
                                     if rule == Rule::directive_block_end {
-                                        t.elements.push(DirectiveBlock(d));
+                                        t.elements.push(DirectiveBlock(Box::new(d)));
                                     } else {
-                                        t.elements.push(PartialBlock(d));
+                                        t.elements.push(PartialBlock(Box::new(d)));
                                     }
                                 } else {
                                     return Err(TemplateError::of(
@@ -733,10 +733,10 @@ pub enum TemplateElement {
     HTMLExpression(Parameter),
     Expression(Box<HelperTemplate>),
     HelperBlock(Box<HelperTemplate>),
-    DirectiveExpression(DirectiveTemplate),
-    DirectiveBlock(DirectiveTemplate),
-    PartialExpression(DirectiveTemplate),
-    PartialBlock(DirectiveTemplate),
+    DirectiveExpression(Box<DirectiveTemplate>),
+    DirectiveBlock(Box<DirectiveTemplate>),
+    PartialExpression(Box<DirectiveTemplate>),
+    PartialBlock(Box<DirectiveTemplate>),
     Comment(String),
 }
 


### PR DESCRIPTION
One of key issue with handlebars render performance is because the JSON path expression is parsed on rendering, which provides some flexibility for helper developers. However, in performance critical case like large loop, these path expressions are parsed again and again causing huge waste of CPU time. 

This patch changed this behaviour by breaking JSON path to navigable segments during template parsing. 

#294 

![image](https://user-images.githubusercontent.com/221942/71559643-aa14aa80-2a9b-11ea-84db-c272a60b7771.png)
