### PR TITLE
Block API

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -80,17 +80,18 @@ impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
         &mut self.base_path
     }
 
-    pub fn base_value(&self) -> Option<&'rc Json> {
-        self.base_value
-    }
+    // TODO: disable for lifetime issue
+    // pub fn base_value(&self) -> Option<&'rc Json> {
+    //     self.base_value
+    // }
 
-    pub fn base_value_mut(&mut self) -> &mut Option<&'rc Json> {
-        &mut self.base_value
-    }
+    // pub fn base_value_mut(&mut self) -> &mut Option<&'rc Json> {
+    //     &mut self.base_value
+    // }
 
-    pub fn set_base_value(&mut self, value: &'rc Json) {
-        self.base_value = Some(value);
-    }
+    // pub fn set_base_value(&mut self, value: &'rc Json) {
+    //     self.base_value = Some(value);
+    // }
 
     pub fn get_block_param(&self, block_param_name: &str) -> Option<&BlockParamHolder> {
         self.block_params.get(block_param_name)

--- a/src/block.rs
+++ b/src/block.rs
@@ -76,15 +76,35 @@ impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
         &self.base_path
     }
 
+    pub fn base_path_mut(&mut self) -> &mut Vec<String> {
+        &mut self.base_path
+    }
+
     pub fn base_value(&self) -> Option<&'rc Json> {
         self.base_value
+    }
+
+    pub fn base_value_mut(&mut self) -> &mut Option<&'rc Json> {
+        &mut self.base_value
+    }
+
+    pub fn set_base_value(&mut self, value: &'rc Json) {
+        self.base_value = Some(value);
     }
 
     pub fn get_block_param(&self, block_param_name: &str) -> Option<&BlockParamHolder> {
         self.block_params.get(block_param_name)
     }
 
+    pub fn set_block_params(&mut self, block_params: BlockParams<'reg>) {
+        self.block_params = block_params;
+    }
+
     pub fn local_path_root(&self) -> &Vec<String> {
         &self.local_path_root
+    }
+
+    pub fn set_local_path_root(&mut self, path_root: Vec<String>) {
+        self.local_path_root = path_root;
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use serde_json::value::Value as Json;
+
+use crate::error::RenderError;
+
+#[derive(Clone, Debug)]
+pub enum BlockParamHolder {
+    // a reference to certain context value
+    Path(Vec<String>),
+    // an actual value holder
+    Value(Json),
+}
+
+impl BlockParamHolder {
+    pub fn value(v: Json) -> BlockParamHolder {
+        BlockParamHolder::Value(v)
+    }
+
+    pub fn path(r: Vec<String>) -> BlockParamHolder {
+        BlockParamHolder::Path(r)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BlockParams<'reg> {
+    data: HashMap<&'reg str, BlockParamHolder>,
+}
+
+impl<'reg> BlockParams<'reg> {
+    pub fn new() -> BlockParams<'reg> {
+        BlockParams::default()
+    }
+
+    pub fn add_path(&mut self, k: &'reg str, v: Vec<String>) -> Result<(), RenderError> {
+        self.data.insert(k, BlockParamHolder::path(v));
+        Ok(())
+    }
+
+    pub fn add_value(&mut self, k: &'reg str, v: Json) -> Result<(), RenderError> {
+        self.data.insert(k, BlockParamHolder::value(v));
+        Ok(())
+    }
+
+    #[inline]
+    pub fn get(&self, k: &str) -> Option<&BlockParamHolder> {
+        self.data.get(k)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BlockContext<'reg: 'rc, 'rc> {
+    base_path: Vec<String>,
+    base_value: Option<&'rc Json>,
+    local_path_root: Vec<String>,
+    // current block context variables
+    block_params: BlockParams<'reg>,
+    // local variables in current context
+    local_variables: HashMap<String, Json>,
+}
+
+impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
+    pub(crate) fn new() -> BlockContext<'reg, 'rc> {
+        BlockContext::default()
+    }
+
+    pub fn set_local_var(&mut self, name: String, value: Json) {
+        self.local_variables.insert(name, value);
+    }
+
+    pub fn get_local_var(&self, name: &str) -> Option<&Json> {
+        self.local_variables.get(&format!("@{}", name))
+    }
+
+    pub fn base_path(&self) -> &Vec<String> {
+        &self.base_path
+    }
+
+    pub fn base_value(&self) -> Option<&'rc Json> {
+        self.base_value
+    }
+
+    pub fn get_block_param(&self, block_param_name: &str) -> Option<&BlockParamHolder> {
+        self.block_params.get(block_param_name)
+    }
+
+    pub fn local_path_root(&self) -> &Vec<String> {
+        &self.local_path_root
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -97,17 +97,15 @@ fn parse_json_visitor<'reg: 'rc, 'rc>(
             } else if from_root {
                 merge_json_path(&mut path_stack, relative_path);
                 Ok(ResolvedPath::AbsolutePath(path_stack))
-            } else {
-                if always_for_absolute_path {
-                    if let Some(ref base_path) = block_contexts.front().map(|blk| blk.base_path()) {
-                        path_stack.extend_from_slice(base_path);
-                    }
-                    merge_json_path(&mut path_stack, relative_path);
-                    Ok(ResolvedPath::AbsolutePath(path_stack))
-                } else {
-                    merge_json_path(&mut path_stack, relative_path);
-                    Ok(ResolvedPath::RelativePath(path_stack))
+            } else if always_for_absolute_path {
+                if let Some(ref base_path) = block_contexts.front().map(|blk| blk.base_path()) {
+                    path_stack.extend_from_slice(base_path);
                 }
+                merge_json_path(&mut path_stack, relative_path);
+                Ok(ResolvedPath::AbsolutePath(path_stack))
+            } else {
+                merge_json_path(&mut path_stack, relative_path);
+                Ok(ResolvedPath::RelativePath(path_stack))
             }
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use serde::Serialize;
 use serde_json::value::{to_value, Map, Value as Json};
 
-use crate::block::{BlockContext, BlockParamHolder, BlockParams};
+use crate::block::{BlockContext, BlockParamHolder};
 use crate::error::RenderError;
 use crate::grammar::Rule;
 use crate::json::path::*;

--- a/src/context.rs
+++ b/src/context.rs
@@ -180,7 +180,8 @@ impl Context {
         relative_path: &'rc [PathSeg],
         block_contexts: &VecDeque<BlockContext<'reg, 'rc>>,
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
-        let resolved_visitor = parse_json_visitor(&relative_path, block_contexts, false)?;
+        // always use absolute at the moment until we get base_value lifetime issue fixed
+        let resolved_visitor = parse_json_visitor(&relative_path, block_contexts, true)?;
 
         match resolved_visitor {
             ResolvedPath::AbsolutePath(paths) => {
@@ -200,20 +201,22 @@ impl Context {
                     .unwrap_or_else(|| ScopedJson::Missing))
             }
             ResolvedPath::RelativePath(paths) => {
-                let mut ptr = block_contexts.front().and_then(|blk| blk.base_value());
-                for p in paths.iter() {
-                    ptr = get_data(ptr, p)?;
-                }
+                // relative path is disabled for now
+                unreachable!()
+                // let mut ptr = block_contexts.front().and_then(|blk| blk.base_value());
+                // for p in paths.iter() {
+                //     ptr = get_data(ptr, p)?;
+                // }
 
-                let path_root = if !relative_path.is_empty() {
-                    parse_json_visitor(&relative_path[..1], block_contexts, true)?.full_path()
-                } else {
-                    None
-                };
+                // let path_root = if !relative_path.is_empty() {
+                //     parse_json_visitor(&relative_path[..1], block_contexts, true)?.full_path()
+                // } else {
+                //     None
+                // };
 
-                Ok(ptr
-                    .map(|v| ScopedJson::Context(v, paths, path_root))
-                    .unwrap_or_else(|| ScopedJson::Missing))
+                // Ok(ptr
+                //     .map(|v| ScopedJson::Context(v, paths, path_root))
+                //     .unwrap_or_else(|| ScopedJson::Missing))
             }
             ResolvedPath::BlockParamValue(paths, value) => {
                 let mut ptr = Some(&value);

--- a/src/context.rs
+++ b/src/context.rs
@@ -38,7 +38,7 @@ impl ResolvedPath {
 }
 
 fn parse_json_visitor<'reg: 'rc, 'rc>(
-    relative_path: &'rc [PathSeg],
+    relative_path: &[PathSeg],
     block_contexts: &VecDeque<BlockContext<'reg, 'rc>>,
     always_for_absolute_path: bool,
 ) -> Result<ResolvedPath, RenderError> {
@@ -177,7 +177,7 @@ impl Context {
     /// If you want to navigate from top level, set the base path to `"."`
     pub(crate) fn navigate<'reg, 'rc>(
         &'rc self,
-        relative_path: &'rc [PathSeg],
+        relative_path: &[PathSeg],
         block_contexts: &VecDeque<BlockContext<'reg, 'rc>>,
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         // always use absolute at the moment until we get base_value lifetime issue fixed
@@ -200,7 +200,7 @@ impl Context {
                     .map(|v| ScopedJson::Context(v, paths, path_root))
                     .unwrap_or_else(|| ScopedJson::Missing))
             }
-            ResolvedPath::RelativePath(paths) => {
+            ResolvedPath::RelativePath(_paths) => {
                 // relative path is disabled for now
                 unreachable!()
                 // let mut ptr = block_contexts.front().and_then(|blk| blk.base_value());

--- a/src/directives/inline.rs
+++ b/src/directives/inline.rs
@@ -23,7 +23,7 @@ impl DirectiveDef for InlineDirective {
         d: &Directive<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
     ) -> DirectiveResult {
         let name = get_name(d)?;
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -62,7 +62,7 @@ pub trait DirectiveDef: Send + Sync {
         d: &Directive<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
     ) -> DirectiveResult;
 }
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -34,7 +34,8 @@ impl HelperDef for EachHelper {
 
                 if let Some(path) = value.context_path() {
                     *block_context.base_path_mut() = path.to_vec();
-                    block_context.set_base_value(value.value());
+                    // TODO: disable base value support for now.
+                    // block_context.set_base_value(value.value());
                 }
 
                 let local_path_root = value.path_root();

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -1,6 +1,7 @@
 use serde_json::value::Value as Json;
 
-use crate::context::{BlockParams, Context};
+use crate::block::{BlockContext, BlockParams};
+use crate::context::Context;
 use crate::error::RenderError;
 use crate::helpers::{HelperDef, HelperResult};
 use crate::json::value::{to_json, JsonTruthy};
@@ -29,14 +30,19 @@ impl HelperDef for EachHelper {
 
         match template {
             Some(t) => {
-                let saved_path = rc.base_path().to_vec();
-                rc.promote_local_vars();
-                let local_path_root = value.path_root();
-                if let Some(p) = local_path_root {
-                    rc.push_local_path_root(p.to_vec());
+                let mut block_context = BlockContext::new();
+
+                if let Some(path) = value.context_path() {
+                    *block_context.base_path_mut() = path.to_vec();
+                    block_context.set_base_value(value.value());
                 }
 
-                debug!("each value {:?}", value.value());
+                let local_path_root = value.path_root();
+                if let Some(p) = local_path_root {
+                    block_context.set_local_path_root(p.to_vec());
+                }
+                rc.push_block(block_context);
+
                 let rendered = match (value.value().is_truthy(false), value.value()) {
                     (true, &Json::Array(ref list)) => {
                         let len = list.len();
@@ -44,39 +50,38 @@ impl HelperDef for EachHelper {
                         let array_path = value.context_path();
 
                         for (i, _) in list.iter().enumerate().take(len) {
-                            let is_first = i == 0usize;
-                            let is_last = i == len - 1;
+                            if let Some(ref mut block) = rc.block_mut() {
+                                let is_first = i == 0usize;
+                                let is_last = i == len - 1;
 
-                            rc.set_local_var("@first".to_string(), to_json(is_first));
-                            rc.set_local_var("@last".to_string(), to_json(is_last));
-                            rc.set_local_var("@index".to_string(), to_json(i));
+                                block.set_local_var("@first".to_string(), to_json(is_first));
+                                block.set_local_var("@last".to_string(), to_json(is_last));
+                                block.set_local_var("@index".to_string(), to_json(i));
+                                if let Some(ref p) = array_path {
+                                    if is_first {
+                                        *block.base_path_mut() = copy_on_push_vec(p, i.to_string());
+                                    } else if let Some(ptr) = block.base_path_mut().last_mut() {
+                                        *ptr = i.to_string();
+                                    }
+                                }
 
-                            if let Some(ref p) = array_path {
-                                if is_first {
-                                    *rc.base_path_mut() = copy_on_push_vec(p, i.to_string());
-                                } else if let Some(ptr) = rc.base_path_mut().last_mut() {
-                                    *ptr = i.to_string();
+                                // TODO: base value
+
+                                if let Some(bp_val) = h.block_param() {
+                                    let mut params = BlockParams::new();
+                                    params.add_path(bp_val, block.base_path().clone())?;
+
+                                    block.set_block_params(params);
+                                } else if let Some((bp_val, bp_index)) = h.block_param_pair() {
+                                    let mut params = BlockParams::new();
+                                    params.add_path(bp_val, block.base_path().clone())?;
+                                    params.add_value(bp_index, to_json(i))?;
+
+                                    block.set_block_params(params);
                                 }
                             }
 
-                            if let Some(bp_val) = h.block_param() {
-                                let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.base_path().clone())?;
-
-                                rc.push_block_context(params)?;
-                            } else if let Some((bp_val, bp_index)) = h.block_param_pair() {
-                                let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.base_path().clone())?;
-                                params.add_value(bp_index, to_json(i))?;
-
-                                rc.push_block_context(params)?;
-                            }
-
                             t.render(r, ctx, rc, out)?;
-
-                            if h.has_block_param() {
-                                rc.pop_block_context();
-                            }
                         }
 
                         Ok(())
@@ -86,35 +91,35 @@ impl HelperDef for EachHelper {
                         let obj_path = value.context_path();
 
                         for (k, _) in obj.iter() {
-                            rc.set_local_var("@first".to_string(), to_json(is_first));
-                            rc.set_local_var("@key".to_string(), to_json(k));
+                            if let Some(ref mut block) = rc.block_mut() {
+                                block.set_local_var("@first".to_string(), to_json(is_first));
+                                block.set_local_var("@key".to_string(), to_json(k));
 
-                            if let Some(ref p) = obj_path {
-                                if is_first {
-                                    *rc.base_path_mut() = copy_on_push_vec(p, k.clone());
-                                } else if let Some(ptr) = rc.base_path_mut().last_mut() {
-                                    *ptr = k.clone();
+                                if let Some(ref p) = obj_path {
+                                    if is_first {
+                                        *block.base_path_mut() = copy_on_push_vec(p, k.clone());
+                                    } else if let Some(ptr) = block.base_path_mut().last_mut() {
+                                        *ptr = k.clone();
+                                    }
+                                }
+
+                                // TODO
+
+                                if let Some(bp_val) = h.block_param() {
+                                    let mut params = BlockParams::new();
+                                    params.add_path(bp_val, block.base_path().clone())?;
+
+                                    block.set_block_params(params);
+                                } else if let Some((bp_val, bp_key)) = h.block_param_pair() {
+                                    let mut params = BlockParams::new();
+                                    params.add_path(bp_val, block.base_path().clone())?;
+                                    params.add_value(bp_key, to_json(&k))?;
+
+                                    block.set_block_params(params);
                                 }
                             }
 
-                            if let Some(bp_val) = h.block_param() {
-                                let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.base_path().clone())?;
-
-                                rc.push_block_context(params)?;
-                            } else if let Some((bp_val, bp_key)) = h.block_param_pair() {
-                                let mut params = BlockParams::new();
-                                params.add_path(bp_val, rc.base_path().clone())?;
-                                params.add_value(bp_key, to_json(&k))?;
-
-                                rc.push_block_context(params)?;
-                            }
-
                             t.render(r, ctx, rc, out)?;
-
-                            if h.has_block_param() {
-                                rc.pop_block_context();
-                            }
 
                             if is_first {
                                 is_first = false;
@@ -134,12 +139,7 @@ impl HelperDef for EachHelper {
                     ))),
                 };
 
-                if local_path_root.is_some() {
-                    rc.pop_local_path_root();
-                }
-
-                rc.demote_local_vars();
-                *rc.base_path_mut() = saved_path;
+                rc.pop_block();
                 rendered
             }
             None => Ok(()),

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -17,8 +17,8 @@ impl HelperDef for EachHelper {
         &self,
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
-        ctx: &Context,
-        rc: &mut RenderContext<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let value = h

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -17,7 +17,7 @@ impl HelperDef for IfHelper {
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let param = h

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -22,7 +22,7 @@ impl HelperDef for LogHelper {
         h: &Helper<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
-        _: &mut RenderContext<'reg>,
+        _: &mut RenderContext<'reg, 'rc>,
         _: &mut dyn Output,
     ) -> HelperResult {
         let param = h

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -17,7 +17,7 @@ impl HelperDef for LookupHelper {
         h: &Helper<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
-        _: &mut RenderContext<'reg>,
+        _: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let collection_value = h

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -13,7 +13,7 @@ impl HelperDef for RawHelper {
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let tpl = h.template();

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -15,7 +15,7 @@ impl HelperDef for WithHelper {
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let param = h

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -80,7 +80,7 @@ pub trait HelperDef: Send + Sync {
         _: &Helper<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
-        _: &mut RenderContext<'reg>,
+        _: &mut RenderContext<'reg, 'rc>,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         Ok(None)
     }
@@ -90,7 +90,7 @@ pub trait HelperDef: Send + Sync {
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         if let Some(result) = self.call_inner(h, r, ctx, rc)? {
@@ -113,7 +113,7 @@ impl<
                 &Helper<'reg, 'rc>,
                 &'reg Registry,
                 &'rc Context,
-                &mut RenderContext<'reg>,
+                &mut RenderContext<'reg, 'rc>,
                 &mut dyn Output,
             ) -> HelperResult,
     > HelperDef for F
@@ -123,7 +123,7 @@ impl<
         h: &Helper<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg>,
+        rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         (*self)(h, r, ctx, rc, out)

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -50,8 +50,8 @@ pub type HelperResult = Result<(), RenderError>;
 /// fn dummy_block<'reg, 'rc>(
 ///     h: &Helper<'reg, 'rc>,
 ///     r: &'reg Handlebars,
-///     ctx: &Context,
-///     rc: &mut RenderContext<'reg>,
+///     ctx: &'rc Context,
+///     rc: &mut RenderContext<'reg, 'rc>,
 ///     out: &mut dyn Output,
 /// ) -> HelperResult {
 ///     h.template()
@@ -165,8 +165,8 @@ mod test {
             &self,
             h: &Helper<'reg, 'rc>,
             r: &'reg Registry,
-            ctx: &Context,
-            rc: &mut RenderContext<'reg>,
+            ctx: &'rc Context,
+            rc: &mut RenderContext<'reg, 'rc>,
             out: &mut dyn Output,
         ) -> Result<(), RenderError> {
             let v = h.param(0).unwrap();

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -109,11 +109,11 @@ where
     path_stack
 }
 
-pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<&'a str>, relative_path: &'a [PathSeg]) {
+pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<String>, relative_path: &'a [PathSeg]) {
     for seg in relative_path {
         match seg {
             PathSeg::Named(ref s) => {
-                path_stack.push(s);
+                path_stack.push(s.to_owned());
             }
             PathSeg::Ruled(Rule::path_root) => {}
             PathSeg::Ruled(Rule::path_up) => {

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -109,11 +109,11 @@ where
     path_stack
 }
 
-pub(crate) fn merge_json_path(path_stack: &mut Vec<String>, relative_path: &[PathSeg]) {
+pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<&'a str>, relative_path: &'a [PathSeg]) {
     for seg in relative_path {
         match seg {
-            PathSeg::Named(s) => {
-                path_stack.push(s.clone());
+            PathSeg::Named(ref s) => {
+                path_stack.push(s);
             }
             PathSeg::Ruled(Rule::path_root) => {}
             PathSeg::Ruled(Rule::path_up) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,8 @@ extern crate serde_json;
 #[cfg(feature = "dir_source")]
 extern crate walkdir;
 
-pub use self::context::{BlockParams, Context};
+pub use self::block::{BlockContext, BlockParams};
+pub use self::context::Context;
 pub use self::directives::DirectiveDef as DecoratorDef;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::helpers::{HelperDef, HelperResult};
@@ -363,6 +364,7 @@ pub use self::serde_json::Value as JsonValue;
 
 #[macro_use]
 mod macros;
+mod block;
 mod context;
 mod directives;
 mod error;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -14,7 +14,7 @@ fn render_partial<'reg: 'rc, 'rc>(
     d: &Directive<'reg, 'rc>,
     r: &'reg Registry,
     ctx: &'rc Context,
-    local_rc: &mut RenderContext<'reg>,
+    local_rc: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     // partial context path
@@ -49,7 +49,7 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
     d: &Directive<'reg, 'rc>,
     r: &'reg Registry,
     ctx: &'rc Context,
-    rc: &mut RenderContext<'reg>,
+    rc: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     // try eval inline partials first

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -448,8 +448,8 @@ mod test {
             &self,
             h: &Helper<'reg, 'rc>,
             r: &'reg Registry,
-            ctx: &Context,
-            rc: &mut RenderContext<'reg>,
+            ctx: &'rc Context,
+            rc: &mut RenderContext<'reg, 'rc>,
             out: &mut dyn Output,
         ) -> Result<(), RenderError> {
             h.template().unwrap().render(r, ctx, rc, out)
@@ -693,7 +693,7 @@ mod test {
             _: &Helper<'reg, 'rc>,
             _: &'reg Registry,
             _: &'rc Context,
-            _: &mut RenderContext<'reg>,
+            _: &mut RenderContext,
         ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
             Ok(Some(ScopedJson::Missing))
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,7 +56,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
             disable_escape: false,
         });
 
-        let blocks = VecDeque::with_capacity(5);
+        let mut blocks = VecDeque::with_capacity(5);
         blocks.push_front(BlockContext::new());
 
         let modified_context = None;
@@ -71,7 +71,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     pub(crate) fn new_for_block(&self) -> RenderContext<'reg, 'rc> {
         let inner = self.inner.clone();
 
-        let blocks = VecDeque::new();
+        let mut blocks = VecDeque::with_capacity(2);
         blocks.push_front(BlockContext::new());
 
         let modified_context = self.modified_context.clone();
@@ -127,7 +127,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     pub(crate) fn evaluate2(
         &self,
         context: &'rc Context,
-        path: &'rc [PathSeg],
+        path: &[PathSeg],
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         context.navigate(path, &self.blocks)
     }
@@ -138,6 +138,10 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
 
     pub fn set_partial(&mut self, name: String, result: &'reg Template) {
         self.inner_mut().partials.insert(name, result);
+    }
+
+    pub fn remove_partial(&mut self, name: &str) {
+        self.inner_mut().partials.remove(name);
     }
 
     pub fn get_local_var(&self, level: usize, name: &str) -> Option<&Json> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -127,7 +127,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     pub(crate) fn evaluate2(
         &self,
         context: &'rc Context,
-        path: &[PathSeg],
+        path: &'rc [PathSeg],
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         context.navigate(path, &self.blocks)
     }

--- a/tests/data_helper.rs
+++ b/tests/data_helper.rs
@@ -9,7 +9,7 @@ impl<'a> HelperDef for HelperWithBorrowedData<'a> {
         _: &Helper<'_reg, '_rc>,
         _: &'_reg Handlebars,
         _: &Context,
-        _: &mut RenderContext<'_reg>,
+        _: &mut RenderContext,
         out: &mut dyn Output,
     ) -> Result<(), RenderError> {
         out.write(self.0).map_err(RenderError::from)

--- a/tests/helper_function_lifetime.rs
+++ b/tests/helper_function_lifetime.rs
@@ -4,7 +4,7 @@ fn ifcond<'reg, 'rc>(
     h: &Helper<'reg, 'rc>,
     handle: &'reg Handlebars,
     ctx: &'rc Context,
-    render_ctx: &mut RenderContext<'reg>,
+    render_ctx: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     let cond = h


### PR DESCRIPTION
This patch attempts to create a set of block apis for helpers like `each` and `with`. It will catch the root value of current block so to reduce value seeking cost as we found in profiling results.

