### PR TITLE
Remove local path root

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -52,7 +52,6 @@ impl<'reg> BlockParams<'reg> {
 pub struct BlockContext<'reg: 'rc, 'rc> {
     base_path: Vec<String>,
     base_value: Option<&'rc Json>,
-    local_path_root: Vec<String>,
     // current block context variables
     block_params: BlockParams<'reg>,
     // local variables in current context
@@ -99,13 +98,5 @@ impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
 
     pub fn set_block_params(&mut self, block_params: BlockParams<'reg>) {
         self.block_params = block_params;
-    }
-
-    pub fn local_path_root(&self) -> &Vec<String> {
-        &self.local_path_root
-    }
-
-    pub fn set_local_path_root(&mut self, path_root: Vec<String>) {
-        self.local_path_root = path_root;
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -189,14 +189,8 @@ impl Context {
                     ptr = get_data(ptr, p)?;
                 }
 
-                let path_root = if !relative_path.is_empty() {
-                    parse_json_visitor(&relative_path[..1], block_contexts, true)?.full_path()
-                } else {
-                    None
-                };
-
                 Ok(ptr
-                    .map(|v| ScopedJson::Context(v, paths, path_root))
+                    .map(|v| ScopedJson::Context(v, paths))
                     .unwrap_or_else(|| ScopedJson::Missing))
             }
             ResolvedPath::RelativePath(_paths) => {
@@ -207,14 +201,8 @@ impl Context {
                 //     ptr = get_data(ptr, p)?;
                 // }
 
-                // let path_root = if !relative_path.is_empty() {
-                //     parse_json_visitor(&relative_path[..1], block_contexts, true)?.full_path()
-                // } else {
-                //     None
-                // };
-
                 // Ok(ptr
-                //     .map(|v| ScopedJson::Context(v, paths, path_root))
+                //     .map(|v| ScopedJson::Context(v, paths))
                 //     .unwrap_or_else(|| ScopedJson::Missing))
             }
             ResolvedPath::BlockParamValue(paths, value) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -113,10 +113,6 @@ fn parse_json_visitor<'reg: 'rc, 'rc>(
 }
 
 fn get_data<'a>(d: Option<&'a Json>, p: &str) -> Result<Option<&'a Json>, RenderError> {
-    if p == "this" {
-        return Ok(d);
-    }
-
     let result = match d {
         Some(&Json::Array(ref l)) => p
             .parse::<usize>()

--- a/src/context.rs
+++ b/src/context.rs
@@ -43,7 +43,7 @@ fn parse_json_visitor<'reg: 'rc, 'rc>(
     block_contexts: &VecDeque<BlockContext<'reg, 'rc>>,
     always_for_absolute_path: bool,
 ) -> Result<ResolvedPath, RenderError> {
-    let mut path_context_depth: i64 = -1;
+    let mut path_context_depth: i64 = 0;
     let mut with_block_param = None;
     let mut from_root = false;
 
@@ -81,10 +81,10 @@ fn parse_json_visitor<'reg: 'rc, 'rc>(
             Ok(ResolvedPath::AbsolutePath(path_stack))
         }
         None => {
-            if path_context_depth >= 0 {
+            if path_context_depth > 0 {
                 if let Some(ref context_base_path) = block_contexts
                     .get(path_context_depth as usize)
-                    .map(|blk| blk.local_path_root())
+                    .map(|blk| blk.base_path())
                 {
                     path_stack.extend_from_slice(context_base_path);
                 } else {

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -38,10 +38,6 @@ impl HelperDef for EachHelper {
                     // block_context.set_base_value(value.value());
                 }
 
-                let local_path_root = value.path_root();
-                if let Some(p) = local_path_root {
-                    block_context.set_local_path_root(p.to_vec());
-                }
                 rc.push_block(block_context);
 
                 let rendered = match (value.value().is_truthy(false), value.value()) {

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -59,10 +59,10 @@ mod test {
     fn test_lookup() {
         let mut handlebars = Registry::new();
         assert!(handlebars
-            .register_template_string("t0", "{{#each v1}}{{lookup ../../v2 @index}}{{/each}}")
+            .register_template_string("t0", "{{#each v1}}{{lookup ../v2 @index}}{{/each}}")
             .is_ok());
         assert!(handlebars
-            .register_template_string("t1", "{{#each v1}}{{lookup ../../v2 1}}{{/each}}")
+            .register_template_string("t1", "{{#each v1}}{{lookup ../v2 1}}{{/each}}")
             .is_ok());
         assert!(handlebars
             .register_template_string("t2", "{{lookup kk \"a\"}}")

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -29,11 +29,6 @@ impl HelperDef for WithHelper {
         if not_empty {
             let mut block = BlockContext::new();
 
-            let local_path_root = param.path_root();
-            if let Some(path_root) = local_path_root {
-                block.set_local_path_root(path_root.to_vec());
-            }
-
             let new_path = param.context_path();
             if let Some(new_path) = new_path {
                 *block.base_path_mut() = new_path.clone();

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -98,7 +98,10 @@ where
                 path_stack.push(PathSeg::Ruled(Rule::path_up));
             }
             Rule::path_id | Rule::path_raw_id => {
-                path_stack.push(PathSeg::Named(n.as_str().to_string()));
+                let name = n.as_str();
+                if name != "this" {
+                    path_stack.push(PathSeg::Named(name.to_string()));
+                }
             }
             _ => {}
         }

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -116,9 +116,7 @@ pub(crate) fn merge_json_path<'a>(path_stack: &mut Vec<String>, relative_path: &
                 path_stack.push(s.to_owned());
             }
             PathSeg::Ruled(Rule::path_root) => {}
-            PathSeg::Ruled(Rule::path_up) => {
-                path_stack.pop();
-            }
+            PathSeg::Ruled(Rule::path_up) => {}
             _ => {}
         }
     }

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -13,8 +13,8 @@ pub(crate) static DEFAULT_VALUE: Json = Json::Null;
 pub enum ScopedJson<'reg: 'rc, 'rc> {
     Constant(&'reg Json),
     Derived(Json),
-    // represents a json reference to context value, its full path, and current root path
-    Context(&'rc Json, Vec<String>, Option<Vec<String>>),
+    // represents a json reference to context value, its full path
+    Context(&'rc Json, Vec<String>),
     // represents a block param json with resolve full path
     // this path is different from `PathAndJson`
     // TODO: merge this with context?
@@ -28,7 +28,7 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
         match self {
             ScopedJson::Constant(j) => j,
             ScopedJson::Derived(ref j) => j,
-            ScopedJson::Context(j, _, _) => j,
+            ScopedJson::Context(j, _) => j,
             ScopedJson::BlockContext(j, _) => j,
             _ => &DEFAULT_VALUE,
         }
@@ -52,14 +52,7 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
 
     pub fn context_path(&self) -> Option<&Vec<String>> {
         match self {
-            ScopedJson::BlockContext(_, ref p) | ScopedJson::Context(_, ref p, _) => Some(p),
-            _ => None,
-        }
-    }
-
-    pub fn path_root(&self) -> Option<&Vec<String>> {
-        match self {
-            ScopedJson::Context(_, _, ref p) => p.as_ref(),
+            ScopedJson::BlockContext(_, ref p) | ScopedJson::Context(_, ref p) => Some(p),
             _ => None,
         }
     }
@@ -99,11 +92,6 @@ impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
     /// Returns full path to this value if any
     pub fn context_path(&self) -> Option<&Vec<String>> {
         self.value.context_path()
-    }
-
-    /// Return root level of this path if any
-    pub fn path_root(&self) -> Option<&Vec<String>> {
-        self.value.path_root()
     }
 
     /// Returns the value


### PR DESCRIPTION
This patch fixes previous `../` implementation. Now we don't need to track each scope's `local_path_root` and use upper scope's base_path directly. 

This patch provides up to 20% performance improvement against current master.