### PR TITLE
Rename directive to decorator

### DIFF
--- a/src/decorators/inline.rs
+++ b/src/decorators/inline.rs
@@ -1,15 +1,15 @@
 use crate::context::Context;
-use crate::directives::{DirectiveDef, DirectiveResult};
+use crate::decorators::{DecoratorDef, DecoratorResult};
 use crate::error::RenderError;
 use crate::registry::Registry;
-use crate::render::{Directive, RenderContext};
+use crate::render::{Decorator, RenderContext};
 
 #[derive(Clone, Copy)]
-pub struct InlineDirective;
+pub struct InlineDecorator;
 
-fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<&'rc str, RenderError> {
+fn get_name<'reg: 'rc, 'rc>(d: &'rc Decorator<'reg, 'rc>) -> Result<&'rc str, RenderError> {
     d.param(0)
-        .ok_or_else(|| RenderError::new("Param required for directive \"inline\""))
+        .ok_or_else(|| RenderError::new("Param required for decorator \"inline\""))
         .and_then(|v| {
             v.value()
                 .as_str()
@@ -17,14 +17,14 @@ fn get_name<'reg: 'rc, 'rc>(d: &'rc Directive<'reg, 'rc>) -> Result<&'rc str, Re
         })
 }
 
-impl DirectiveDef for InlineDirective {
+impl DecoratorDef for InlineDecorator {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        d: &Directive<'reg, 'rc>,
+        d: &Decorator<'reg, 'rc>,
         _: &'reg Registry,
         _: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
-    ) -> DirectiveResult {
+    ) -> DecoratorResult {
         let name = get_name(d)?;
 
         let template = d
@@ -36,7 +36,7 @@ impl DirectiveDef for InlineDirective {
     }
 }
 
-pub static INLINE_DIRECTIVE: InlineDirective = InlineDirective;
+pub static INLINE_DECORATOR: InlineDecorator = InlineDecorator;
 
 #[cfg(test)]
 mod test {

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -1,15 +1,15 @@
 use crate::context::Context;
 use crate::error::RenderError;
 use crate::registry::Registry;
-use crate::render::{Directive, RenderContext};
+use crate::render::{Decorator, RenderContext};
 
-pub use self::inline::INLINE_DIRECTIVE;
+pub use self::inline::INLINE_DECORATOR;
 
-pub type DirectiveResult = Result<(), RenderError>;
+pub type DecoratorResult = Result<(), RenderError>;
 
 /// Decorator Definition
 ///
-/// Implement this trait to define your own decorators or directives. Currently
+/// Implement this trait to define your own decorators or decorators. Currently
 /// decorator shares same definition with helper.
 ///
 /// In handlebars, it is recommended to use decorator to change context data and update helper
@@ -56,35 +56,35 @@ pub type DirectiveResult = Result<(), RenderError>;
 /// }
 /// ```
 ///
-pub trait DirectiveDef: Send + Sync {
+pub trait DecoratorDef: Send + Sync {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        d: &Directive<'reg, 'rc>,
+        d: &Decorator<'reg, 'rc>,
         r: &'reg Registry,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
-    ) -> DirectiveResult;
+    ) -> DecoratorResult;
 }
 
-/// implement DirectiveDef for bare function so we can use function as directive
+/// implement DecoratorDef for bare function so we can use function as decorator
 impl<
         F: Send
             + Sync
             + for<'reg, 'rc> Fn(
-                &Directive<'reg, 'rc>,
+                &Decorator<'reg, 'rc>,
                 &'reg Registry,
                 &'rc Context,
                 &mut RenderContext,
-            ) -> DirectiveResult,
-    > DirectiveDef for F
+            ) -> DecoratorResult,
+    > DecoratorDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        d: &Directive<'reg, 'rc>,
+        d: &Decorator<'reg, 'rc>,
         reg: &'reg Registry,
         ctx: &'rc Context,
         rc: &mut RenderContext,
-    ) -> DirectiveResult {
+    ) -> DecoratorResult {
         (*self)(d, reg, ctx, rc)
     }
 }
@@ -98,7 +98,7 @@ mod test {
     use crate::json::value::{as_string, to_json};
     use crate::output::Output;
     use crate::registry::Registry;
-    use crate::render::{Directive, Helper, RenderContext};
+    use crate::render::{Decorator, Helper, RenderContext};
 
     #[test]
     fn test_register_decorator() {
@@ -116,7 +116,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Directive,
+                |_: &Decorator,
                  _: &Registry,
                  _: &Context,
                  _: &mut RenderContext|
@@ -141,7 +141,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Directive,
+                |_: &Decorator,
                  _: &Registry,
                  ctx: &Context,
                  rc: &mut RenderContext|
@@ -169,7 +169,7 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |d: &Directive,
+                |d: &Decorator,
                  _: &Registry,
                  _: &Context,
                  rc: &mut RenderContext|
@@ -247,7 +247,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |d: &Directive,
+                |d: &Decorator,
                  _: &Registry,
                  _: &Context,
                  rc: &mut RenderContext|
@@ -284,7 +284,7 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |_: &Directive,
+                |_: &Decorator,
                  _: &Registry,
                  _: &Context,
                  rc: &mut RenderContext|

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,8 +97,8 @@ quick_error! {
             display("helper {:?} was opened, but {:?} is closing",
                 open, closed)
         }
-        MismatchingClosedDirective(open: String, closed: String) {
-            display("directive {:?} was opened, but {:?} is closing",
+        MismatchingClosedDecorator(open: String, closed: String) {
+            display("decorator {:?} was opened, but {:?} is closing",
                 open, closed)
         }
         InvalidSyntax {

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -46,7 +46,7 @@ expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~
 html_expression = { "{{{" ~ pre_whitespace_omitter? ~ name ~
 pro_whitespace_omitter? ~ "}}}" }
 
-directive_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
+decorator_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
 pro_whitespace_omitter? ~ "}}" }
 partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
                      ~ pro_whitespace_omitter? ~ "}}" }
@@ -60,12 +60,12 @@ helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
 helper_block = _{ helper_block_start ~ template ~
                   (invert_tag ~ template)? ~ helper_block_end }
 
-directive_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
+decorator_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
                         ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-directive_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+decorator_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
                         pro_whitespace_omitter? ~ "}}" }
-directive_block = _{ directive_block_start ~ template ~
-                     directive_block_end }
+decorator_block = _{ decorator_block_start ~ template ~
+                     decorator_block_end }
 
 partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
                         ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
@@ -90,8 +90,8 @@ template = { (
             raw_block |
             hbs_comment |
             hbs_comment_compact |
-            directive_expression |
-            directive_block |
+            decorator_expression |
+            decorator_block |
             partial_expression |
             partial_block )* }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -293,22 +293,22 @@ fn test_path() {
 }
 
 #[test]
-fn test_directive_expression() {
+fn test_decorator_expression() {
     let s = vec!["{{* ssh}}", "{{~* ssh}}"];
     for i in s.iter() {
-        assert_rule!(Rule::directive_expression, i);
+        assert_rule!(Rule::decorator_expression, i);
     }
 }
 
 #[test]
-fn test_directive_block() {
+fn test_decorator_block() {
     let s = vec![
         "{{#* inline}}something{{/inline}}",
         "{{~#* inline}}hello{{/inline}}",
         "{{#* inline \"partialname\"}}something{{/inline}}",
     ];
     for i in s.iter() {
-        assert_rule!(Rule::directive_block, i);
+        assert_rule!(Rule::decorator_block, i);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,14 +349,14 @@ extern crate walkdir;
 
 pub use self::block::{BlockContext, BlockParams};
 pub use self::context::Context;
-pub use self::directives::DirectiveDef as DecoratorDef;
+pub use self::decorators::DecoratorDef;
 pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::json::path::Path;
 pub use self::json::value::{to_json, JsonRender, PathAndJson, ScopedJson};
 pub use self::output::Output;
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
-pub use self::render::{Directive as Decorator, Evaluable, Helper, RenderContext, Renderable};
+pub use self::render::{Decorator, Evaluable, Helper, RenderContext, Renderable};
 pub use self::template::Template;
 
 #[doc(hidden)]
@@ -366,7 +366,7 @@ pub use self::serde_json::Value as JsonValue;
 mod macros;
 mod block;
 mod context;
-mod directives;
+mod decorators;
 mod error;
 mod grammar;
 mod helpers;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -7,12 +7,12 @@ use crate::error::RenderError;
 use crate::json::path::Path;
 use crate::output::Output;
 use crate::registry::Registry;
-use crate::render::{Directive, Evaluable, RenderContext, Renderable};
+use crate::render::{Decorator, Evaluable, RenderContext, Renderable};
 use crate::template::Template;
 
 fn render_partial<'reg: 'rc, 'rc>(
     t: &'reg Template,
-    d: &Directive<'reg, 'rc>,
+    d: &Decorator<'reg, 'rc>,
     r: &'reg Registry,
     ctx: &'rc Context,
     local_rc: &mut RenderContext<'reg, 'rc>,
@@ -52,7 +52,7 @@ fn render_partial<'reg: 'rc, 'rc>(
 }
 
 pub fn expand_partial<'reg: 'rc, 'rc>(
-    d: &Directive<'reg, 'rc>,
+    d: &Decorator<'reg, 'rc>,
     r: &'reg Registry,
     ctx: &'rc Context,
     rc: &mut RenderContext<'reg, 'rc>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::context::Context;
-use crate::directives::{self, DirectiveDef};
+use crate::decorators::{self, DecoratorDef};
 use crate::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
 use crate::helpers::{self, HelperDef};
 use crate::output::{Output, StringOutput, WriteOutput};
@@ -43,7 +43,7 @@ pub fn no_escape(data: &str) -> String {
 pub struct Registry<'reg> {
     templates: HashMap<String, Template>,
     helpers: HashMap<String, Box<dyn HelperDef + 'reg>>,
-    directives: HashMap<String, Box<dyn DirectiveDef + 'reg>>,
+    decorators: HashMap<String, Box<dyn DecoratorDef + 'reg>>,
     escape_fn: EscapeFn,
     source_map: bool,
     strict_mode: bool,
@@ -54,7 +54,7 @@ impl<'reg> Debug for Registry<'reg> {
         f.debug_struct("Handlebars")
             .field("templates", &self.templates)
             .field("helpers", &self.helpers.keys())
-            .field("directives", &self.directives.keys())
+            .field("decorators", &self.decorators.keys())
             .field("source_map", &self.source_map)
             .finish()
     }
@@ -86,7 +86,7 @@ impl<'reg> Registry<'reg> {
         let r = Registry {
             templates: HashMap::new(),
             helpers: HashMap::new(),
-            directives: HashMap::new(),
+            decorators: HashMap::new(),
             escape_fn: Box::new(html_escape),
             source_map: true,
             strict_mode: false,
@@ -114,7 +114,7 @@ impl<'reg> Registry<'reg> {
         self.register_helper("or", Box::new(helpers::helper_boolean::or));
         self.register_helper("not", Box::new(helpers::helper_boolean::not));
 
-        self.register_decorator("inline", Box::new(directives::INLINE_DIRECTIVE));
+        self.register_decorator("inline", Box::new(decorators::INLINE_DECORATOR));
         self
     }
 
@@ -272,9 +272,9 @@ impl<'reg> Registry<'reg> {
     pub fn register_decorator(
         &mut self,
         name: &str,
-        def: Box<dyn DirectiveDef + 'reg>,
-    ) -> Option<Box<dyn DirectiveDef + 'reg>> {
-        self.directives.insert(name.to_string(), def)
+        def: Box<dyn DecoratorDef + 'reg>,
+    ) -> Option<Box<dyn DecoratorDef + 'reg>> {
+        self.decorators.insert(name.to_string(), def)
     }
 
     /// Register a new *escape fn* to be used from now on by this registry.
@@ -310,9 +310,9 @@ impl<'reg> Registry<'reg> {
         self.helpers.get(name).map(|v| v.as_ref())
     }
 
-    /// Return a registered directive, aka decorator
-    pub fn get_decorator(&self, name: &str) -> Option<&(dyn DirectiveDef)> {
-        self.directives.get(name).map(|v| v.as_ref())
+    /// Return a registered decorator, aka decorator
+    pub fn get_decorator(&self, name: &str) -> Option<&(dyn DecoratorDef)> {
+        self.decorators.get(name).map(|v| v.as_ref())
     }
 
     /// Return all templates registered


### PR DESCRIPTION
This patch renames `Directive`s to handlebars' standard name `Decorator`. 