### PR TITLE
[#312]: Re-enable usage of template names from walk dir

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -22,9 +22,11 @@ object_literal = { "{" ~ (string_literal ~ ":" ~ literal)?
                    ~ ("," ~ string_literal ~ ":" ~ literal)* ~ "}" }
 
 symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
+partial_symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'|"/"}
 path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }
+partial_identifier = @{ partial_symbol_char+ }
 reference = ${ path_inline }
 
 name = _{ subexpression | reference }
@@ -33,7 +35,7 @@ param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
 hash = { identifier ~ "=" ~ param }
 block_param = { "as" ~ "|" ~ identifier ~ identifier? ~ "|"}
 exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
-partial_exp_line = _{ (identifier ~ (hash|param)+) | name }
+partial_exp_line = _{ (partial_identifier ~ (hash|param)+) | name }
 
 subexpression = { "(" ~ ((identifier ~ (hash|param)+) | reference)  ~ ")" }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -214,7 +214,7 @@ impl Template {
         let rule = name_node.as_rule();
         let name_span = name_node.as_span();
         match rule {
-            Rule::identifier | Rule::invert_tag_item => {
+            Rule::identifier | Rule::partial_identifier | Rule::invert_tag_item => {
                 Ok(Parameter::Name(name_span.as_str().to_owned()))
             }
             Rule::reference => {

--- a/tests/template_names.rs
+++ b/tests/template_names.rs
@@ -1,0 +1,39 @@
+extern crate handlebars;
+#[macro_use]
+extern crate serde_json;
+
+use handlebars::Handlebars;
+
+#[test]
+fn test_walk_dir_template_name()  {
+    let mut hbs = Handlebars::new();
+
+    let data = json!({
+        "a": [1, 2, 3, 4],
+        "b": "top"
+    });
+
+    hbs.register_template_string("foo/bar", "{{@root/b}}").unwrap();
+    assert_eq!(
+        hbs.render_template("{{> foo/bar }}", &data)
+            .unwrap(),
+        "top"
+    );
+}
+
+#[test]
+fn test_walk_dir_template_name_with_args()  {
+    let mut hbs = Handlebars::new();
+
+    let data = json!({
+        "a": [1, 2, 3, 4],
+        "b": "top"
+    });
+
+    hbs.register_template_string("foo/bar", "{{this}}").unwrap();
+    assert_eq!(
+        hbs.render_template("{{> foo/bar b }}", &data)
+            .unwrap(),
+        "top"
+    );
+}


### PR DESCRIPTION
This change re-enables the ability to use the template names generated by the "walk dirs" feature of handlebars-rust. It generates template names like `foo/bar/baz`, which couldn't be used in 3.0.0, as the character `/` was not allowed in the name of the referenced template.