### PR TITLE
Document register_templates_directory being dependent on the dir_source feature

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -200,6 +200,9 @@ impl<'reg> Registry<'reg> {
     /// will use their relative name as template name. For example, when `dir_path` is
     /// `templates/` and `tpl_extension` is `.hbs`, the file
     /// `templates/some/path/file.hbs` will be registerd as `some/path/file`.
+    ///
+    /// This method is not available by default.
+    /// You will need to enable the `dir_source` feature to use it.
     #[cfg(feature = "dir_source")]
     pub fn register_templates_directory<P>(
         &mut self,


### PR DESCRIPTION
I had to check the source code to figure out what was going on, this should help others avoid needing to do that.