### PR TITLE
removed `Send + Sync` bound of `RenderContext.register_local_*`

### DIFF
--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -56,7 +56,7 @@ pub type DecoratorResult = Result<(), RenderError>;
 /// }
 /// ```
 ///
-pub trait DecoratorDef: Send + Sync {
+pub trait DecoratorDef {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
         d: &Decorator<'reg, 'rc>,
@@ -68,9 +68,7 @@ pub trait DecoratorDef: Send + Sync {
 
 /// implement DecoratorDef for bare function so we can use function as decorator
 impl<
-        F: Send
-            + Sync
-            + for<'reg, 'rc> Fn(
+        F: for<'reg, 'rc> Fn(
                 &Decorator<'reg, 'rc>,
                 &'reg Registry<'reg>,
                 &'rc Context,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -75,7 +75,7 @@ pub type HelperResult = Result<(), RenderError>;
 /// ```
 ///
 
-pub trait HelperDef: Send + Sync {
+pub trait HelperDef {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
         _: &Helper<'reg, 'rc>,
@@ -108,9 +108,7 @@ pub trait HelperDef: Send + Sync {
 
 /// implement HelperDef for bare function so we can use function as helper
 impl<
-        F: Send
-            + Sync
-            + for<'reg, 'rc> Fn(
+        F: for<'reg, 'rc> Fn(
                 &Helper<'reg, 'rc>,
                 &'reg Registry<'reg>,
                 &'rc Context,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -42,8 +42,8 @@ pub fn no_escape(data: &str) -> String {
 /// It maintains compiled templates and registered helpers.
 pub struct Registry<'reg> {
     templates: HashMap<String, Template>,
-    helpers: HashMap<String, Box<dyn HelperDef + 'reg>>,
-    decorators: HashMap<String, Box<dyn DecoratorDef + 'reg>>,
+    helpers: HashMap<String, Box<dyn HelperDef + Send + Sync + 'reg>>,
+    decorators: HashMap<String, Box<dyn DecoratorDef + Send + Sync + 'reg>>,
     escape_fn: EscapeFn,
     source_map: bool,
     strict_mode: bool,
@@ -266,8 +266,8 @@ impl<'reg> Registry<'reg> {
     pub fn register_helper(
         &mut self,
         name: &str,
-        def: Box<dyn HelperDef + 'reg>,
-    ) -> Option<Box<dyn HelperDef + 'reg>> {
+        def: Box<dyn HelperDef + Send + Sync + 'reg>,
+    ) -> Option<Box<dyn HelperDef + Send + Sync + 'reg>> {
         self.helpers.insert(name.to_string(), def)
     }
 
@@ -275,8 +275,8 @@ impl<'reg> Registry<'reg> {
     pub fn register_decorator(
         &mut self,
         name: &str,
-        def: Box<dyn DecoratorDef + 'reg>,
-    ) -> Option<Box<dyn DecoratorDef + 'reg>> {
+        def: Box<dyn DecoratorDef + Send + Sync + 'reg>,
+    ) -> Option<Box<dyn DecoratorDef + Send + Sync + 'reg>> {
         self.decorators.insert(name.to_string(), def)
     }
 
@@ -309,7 +309,7 @@ impl<'reg> Registry<'reg> {
     }
 
     /// Return a registered helper
-    pub fn get_helper(&self, name: &str) -> Option<&(dyn HelperDef)> {
+    pub fn get_helper(&self, name: &str) -> Option<&(dyn HelperDef + Send + Sync + 'reg)> {
         self.helpers.get(name).map(|v| v.as_ref())
     }
 
@@ -319,7 +319,7 @@ impl<'reg> Registry<'reg> {
     }
 
     /// Return a registered decorator, aka decorator
-    pub fn get_decorator(&self, name: &str) -> Option<&(dyn DecoratorDef)> {
+    pub fn get_decorator(&self, name: &str) -> Option<&(dyn DecoratorDef + Send + Sync + 'reg)> {
         self.decorators.get(name).map(|v| v.as_ref())
     }
 


### PR DESCRIPTION
* removed `Send + Sync` bound of `HelperDef` for `RenderContext::register_local_helper` and related functions.
* removed `Send + Sync` bound of `DecoratorDef` for `RenderContext::register_local_decorator` and related functions.
* refined some `'static` lifetimes to `'rc`

Background:
I use the `RenderContext` inside a HTTP request (the `Registry` is shared), and I want to register
local-helpers that access the HTTP request (for example a helper that resolves a URL)