### PR TITLE
Fix incorrect parse error for partial identifiers

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -71,7 +71,7 @@ decorator_block = _{ decorator_block_start ~ template ~
 
 partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
                         ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
-partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
                       pro_whitespace_omitter? ~ "}}" }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -833,6 +833,12 @@ fn test_parse_template() {
 }
 
 #[test]
+fn test_parse_block_partial_path_identifier() {
+    let source = "{{#> foo/bar}}{{/foo/bar}}";
+    assert!(Template::compile(source.to_string()).is_ok());
+}
+
+#[test]
 fn test_parse_error() {
     let source = "{{#ifequals name compare=\"hello\"}}\nhello\n\t{{else}}\ngood";
 


### PR DESCRIPTION
This PR fixes a parse error that arises when using paths, containing `/`, as partial block identifiers.

Closes #321 