### PR TITLE
Fix some typos/grammar in README and doc strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This library doesn't attempt to use some macro magic to allow you to
 write your template within your rust code. I admit that it's fun to do
 that but it doesn't fit real-world use cases.
 
-#### Limited but essential control structure built-in
+#### Limited but essential control structures built-in
 
 Only essential control directives `if` and `each` are built-in. This
 prevents you from putting too much application logic into your template.

--- a/src/block.rs
+++ b/src/block.rs
@@ -106,8 +106,8 @@ impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
     //     self.base_value = Some(value);
     // }
 
-    /// Get a block paramteter from this block.
-    /// Block paramters needed to be supported by the block helper.
+    /// Get a block parameter from this block.
+    /// Block parameters needed to be supported by the block helper.
     /// The typical syntax for block parameter is:
     ///
     /// ```skip
@@ -120,7 +120,7 @@ impl<'reg: 'rc, 'rc> BlockContext<'reg, 'rc> {
         self.block_params.get(block_param_name)
     }
 
-    /// Set a block paramter into this block.
+    /// Set a block parameter into this block.
     pub fn set_block_params(&mut self, block_params: BlockParams<'reg>) {
         self.block_params = block_params;
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -203,12 +203,12 @@ impl Context {
         }
     }
 
-    /// return the Json data wrapped in context
+    /// Return the Json data wrapped in context
     pub fn data(&self) -> &Json {
         &self.data
     }
 
-    /// return the mutable reference to Json data wrapped in context
+    /// Return the mutable reference to Json data wrapped in context
     pub fn data_mut(&mut self) -> &mut Json {
         &mut self.data
     }

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -9,14 +9,14 @@ pub type DecoratorResult = Result<(), RenderError>;
 
 /// Decorator Definition
 ///
-/// Implement this trait to define your own decorators or decorators. Currently
-/// decorator shares same definition with helper.
+/// Implement this trait to define your own decorators. Currently decorator
+/// shares same definition with helper.
 ///
 /// In handlebars, it is recommended to use decorator to change context data and update helper
 /// definition.
 /// ## Updating context data
 ///
-/// In decorator, you can change some context data your are about to render.
+/// In decorator, you can change some context data you are about to render.
 ///
 /// ```
 /// use handlebars::*;
@@ -66,7 +66,7 @@ pub trait DecoratorDef {
     ) -> DecoratorResult;
 }
 
-/// implement DecoratorDef for bare function so we can use function as decorator
+/// Implement DecoratorDef for bare function so we can use function as decorator
 impl<
         F: for<'reg, 'rc> Fn(
             &Decorator<'reg, 'rc>,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -17,7 +17,7 @@ pub type HelperResult = Result<(), RenderError>;
 
 /// Helper Definition
 ///
-/// Implement `HelperDef` to create custom helper. You can retrieve useful information from these arguments.
+/// Implement `HelperDef` to create custom helpers. You can retrieve useful information from these arguments.
 ///
 /// * `&Helper`: current helper template information, contains name, params, hashes and nested template
 /// * `&Registry`: the global registry, you can find templates by name from registry
@@ -25,7 +25,7 @@ pub type HelperResult = Result<(), RenderError>;
 /// * `&mut RenderContext`: you can access data or modify variables (starts with @)/partials in render context, for example, @index of #each. See its document for detail.
 /// * `&mut dyn Output`: where you write output to
 ///
-/// By default, you can use bare function as helper definition because we have supported unboxed_closure. If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
+/// By default, you can use a bare function as a helper definition because we have supported unboxed_closure. If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
 ///
 /// ## Define an inline helper
 ///
@@ -43,7 +43,7 @@ pub type HelperResult = Result<(), RenderError>;
 ///
 /// ## Define block helper
 ///
-/// Block helper is like `#if` or `#each` which has a inner template and an optional *inverse* template (the template in else branch). You can access the inner template by `helper.template()` and `helper.inverse()`. In most case you will just call `render` on it.
+/// Block helper is like `#if` or `#each` which has a inner template and an optional *inverse* template (the template in else branch). You can access the inner template by `helper.template()` and `helper.inverse()`. In most cases you will just call `render` on it.
 ///
 /// ```
 /// use handlebars::*;
@@ -63,7 +63,7 @@ pub type HelperResult = Result<(), RenderError>;
 ///
 /// ## Define helper function using macro
 ///
-/// In most case you just need some simple function to call from template. We have  `handlebars_helper!` macro to simplify the job.
+/// In most cases you just need some simple function to call from templates. We have a `handlebars_helper!` macro to simplify the job.
 ///
 /// ```
 /// use handlebars::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,17 @@
 //!
 //! This library doesn't attempt to use some macro magic to allow you to
 //! write your template within your rust code. I admit that it's fun to do
-//! that but it doesn't fit real-world use case in my opinion.
+//! that but it doesn't fit real-world use cases.
 //!
-//! ### Limited but essential control structure built-in
+//! ### Limited but essential control structures built-in
 //!
-//! Only essential control directive `if` and `each` were built-in. This
-//! prevents you to put too much application logic into your template.
+//! Only essential control directives `if` and `each` are built-in. This
+//! prevents you from putting too much application logic into your template.
 //!
 //! ### Extensible helper system
 //!
 //! You can write your own helper with Rust! It can be a block helper or
-//! inline helper. Put you logic into the helper and don't repeat
+//! inline helper. Put your logic into the helper and don't repeat
 //! yourself.
 //!
 //! The built-in helpers like `if` and `each` were written with these
@@ -67,19 +67,19 @@
 //!
 //! [t]: https://docs.djangoproject.com/en/1.9/ref/templates/language/#template-inheritance
 //!
-//! Template inclusion is not enough. In most case you will need a skeleton
-//! of page as parent (header, footer, etc.), and embed you page into this
-//! parent.
+//! Template include is not sufficient for template reuse. In most cases
+//! you will need a skeleton of page as parent (header, footer, etc.), and
+//! embed your page into this parent.
 //!
-//! You can find a real example for template inheritance in
-//! `examples/partials.rs`, and templates used by this file.
+//! You can find a real example of template inheritance in
+//! `examples/partials.rs` and templates used by this file.
 //!
 //! ### Strict mode
 //!
 //! Handlebars, the language designed to work with JavaScript, has no
-//! strict restriction on accessing non-existed fields or index. It
-//! generates empty string for such case. However, in Rust we want a
-//! little bit strict sometime.
+//! strict restriction on accessing nonexistent fields or indexes. It
+//! generates empty strings for such cases. However, in Rust we want to be
+//! a little stricter sometimes.
 //!
 //! By enabling `strict_mode` on handlebars:
 //!
@@ -89,37 +89,37 @@
 //! handlebars.set_strict_mode(true);
 //! ```
 //!
-//! You will get a `RenderError` when accessing fields that not exists.
+//! You will get a `RenderError` when accessing fields that do not exist.
 //!
 //! ## Limitations
 //!
 //! ### Compatibility with original JavaScript version
 //!
-//! This implementation is **not fully compatible** with the original javascript version.
+//! This implementation is **not fully compatible** with the original JavaScript version.
 //!
-//! First of all, mustache block is not supported. I suggest you to use `#if` and `#each` for
-//! same functionality.
+//! First of all, mustache blocks are not supported. I suggest you to use `#if` and `#each` for
+//! the same functionality.
 //!
 //! There are some other minor features missing:
 //!
 //! * Chained else [#12](https://github.com/sunng87/handlebars-rust/issues/12)
 //!
-//! Feel free to fire an issue on [github](https://github.com/sunng87/handlebars-rust/issues) if
+//! Feel free to file an issue on [github](https://github.com/sunng87/handlebars-rust/issues) if
 //! you find missing features.
 //!
 //! ### Types
 //!
 //! As a static typed language, it's a little verbose to use handlebars.
 //! Handlebars templating language is designed against JSON data type. In rust,
-//! we will convert user's structs, vectors or maps into SerDe-Json's `Value` type
-//! in order to use in template. You have to make sure your data implements the
+//! we will convert user's structs, vectors or maps into Serde-Json's `Value` type
+//! in order to use in templates. You have to make sure your data implements the
 //! `Serialize` trait from the [Serde](https://serde.rs) project.
 //!
 //! ## Usage
 //!
 //! ### Template Creation and Registration
 //!
-//! Templates are created from String and registered to `Handlebars` with a name.
+//! Templates are created from `String`s and registered to `Handlebars` with a name.
 //!
 //! ```
 //! # extern crate handlebars;
@@ -164,7 +164,7 @@
 //!
 //! That means, if you want to render something, you have to ensure the data type implements the `serde::Serialize` trait. Most rust internal types already have that trait. Use `#derive[Serialize]` for your types to generate default implementation.
 //!
-//! You can use default `render` function to render a template into `String`. From 0.9, there's `renderw` to render text into anything of `std::io::Write`.
+//! You can use default `render` function to render a template into `String`. From 0.9, there's `render_to_write` to render text into anything of `std::io::Write`.
 //!
 //! ```
 //! # use std::error::Error;
@@ -294,8 +294,8 @@
 //!
 //! ### Script Helper
 //!
-//! Like our Javascript counterparts, handlebars allows user to define simple helpers with
-//! a script language, [rhai](https://docs.rs/crate/rhai/). This can be enabled by
+//! Like our JavaScript counterparts, handlebars allows user to define simple helpers with
+//! a scripting language, [rhai](https://docs.rs/crate/rhai/). This can be enabled by
 //! turning on `script_helper` feature flag.
 //!
 //! A sample script:
@@ -322,7 +322,7 @@
 //! * `{{{{raw}}}} ... {{{{/raw}}}}` escape handlebars expression within the block
 //! * `{{#if ...}} ... {{else}} ... {{/if}}` if-else block
 //! * `{{#unless ...}} ... {{else}} .. {{/unless}}` if-not-else block
-//! * `{{#each ...}} ... {{/each}}` iterates over an array or object. Handlebar-rust doesn't support mustache iteration syntax so use this instead.
+//! * `{{#each ...}} ... {{/each}}` iterates over an array or object. Handlebars-rust doesn't support mustache iteration syntax so use this instead.
 //! * `{{#with ...}} ... {{/with}}` change current context. Similar to {{#each}}, used for replace corresponding mustache syntax.
 //! * `{{lookup ... ...}}` get value from array by `@index` or `@key`
 //! * `{{> ...}}` include template with name

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -26,7 +26,7 @@ use rhai::Engine;
 #[cfg(feature = "script_helper")]
 use crate::helpers::scripting::ScriptHelper;
 
-/// This type represents an *escape fn*, that is a function who's purpose it is
+/// This type represents an *escape fn*, that is a function whose purpose it is
 /// to escape potentially problematic characters in a string.
 ///
 /// An *escape fn* is represented as a `Box` to avoid unnecessary type
@@ -39,7 +39,7 @@ pub fn html_escape(data: &str) -> String {
     str::escape_html(data)
 }
 
-/// `EscapeFn` that do not change any thing. Useful when using in a non-html
+/// `EscapeFn` that does not change anything. Useful when using in a non-html
 /// environment.
 pub fn no_escape(data: &str) -> String {
     data.to_owned()
@@ -178,7 +178,7 @@ impl<'reg> Registry<'reg> {
 
     /// Register a template string
     ///
-    /// Returns `TemplateError` if there is syntax error on parsing template.
+    /// Returns `TemplateError` if there is syntax error on parsing the template.
     pub fn register_template_string<S>(
         &mut self,
         name: &str,
@@ -195,7 +195,7 @@ impl<'reg> Registry<'reg> {
     /// Register a partial string
     ///
     /// A named partial will be added to the registry. It will overwrite template with
-    /// same name. Currently registered partial is just identical to template.
+    /// same name. Currently a registered partial is just identical to a template.
     pub fn register_partial<S>(&mut self, name: &str, partial_str: S) -> Result<(), TemplateError>
     where
         S: AsRef<str>,
@@ -225,7 +225,7 @@ impl<'reg> Registry<'reg> {
     /// Hidden files and tempfile (starts with `#`) will be ignored. All registered
     /// will use their relative name as template name. For example, when `dir_path` is
     /// `templates/` and `tpl_extension` is `.hbs`, the file
-    /// `templates/some/path/file.hbs` will be registerd as `some/path/file`.
+    /// `templates/some/path/file.hbs` will be registered as `some/path/file`.
     ///
     /// This method is not available by default.
     /// You will need to enable the `dir_source` feature to use it.
@@ -283,12 +283,12 @@ impl<'reg> Registry<'reg> {
         Ok(())
     }
 
-    /// remove a template from the registry
+    /// Remove a template from the registry
     pub fn unregister_template(&mut self, name: &str) {
         self.templates.remove(name);
     }
 
-    /// register a helper
+    /// Register a helper
     pub fn register_helper(
         &mut self,
         name: &str,
@@ -299,8 +299,8 @@ impl<'reg> Registry<'reg> {
 
     /// Register a [rhai](https://docs.rs/rhai/) script as handlebars helper
     ///
-    /// Currently only simple helper are supported. You can do computation or
-    /// string format with rhai script.
+    /// Currently only simple helpers are supported. You can do computation or
+    /// string formatting with rhai script.
     ///
     /// Helper parameters and hash are available in rhai script as array `params`
     /// and map `hash`. Example script:
@@ -350,7 +350,7 @@ impl<'reg> Registry<'reg> {
         self.register_script_helper(name, script)
     }
 
-    /// register a decorator
+    /// Register a decorator
     pub fn register_decorator(
         &mut self,
         name: &str,
@@ -397,7 +397,7 @@ impl<'reg> Registry<'reg> {
         self.helpers.contains_key(name)
     }
 
-    /// Return a registered decorator, aka decorator
+    /// Return a registered decorator
     pub fn get_decorator(&self, name: &str) -> Option<&(dyn DecoratorDef + Send + Sync + 'reg)> {
         self.decorators.get(name).map(|v| v.as_ref())
     }
@@ -434,10 +434,10 @@ impl<'reg> Registry<'reg> {
 
     /// Render a registered template with some data into a string
     ///
-    /// * `name` is the template name you registred previously
-    /// * `ctx` is the data that implements `serde::Serialize`
+    /// * `name` is the template name you registered previously
+    /// * `data` is the data that implements `serde::Serialize`
     ///
-    /// Returns rendered string or an struct with error information
+    /// Returns rendered string or a struct with error information
     pub fn render<T>(&self, name: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
@@ -457,7 +457,7 @@ impl<'reg> Registry<'reg> {
         self.render_to_output(name, data, &mut output)
     }
 
-    /// render a template string using current registry without register it
+    /// Render a template string using current registry without registering it
     pub fn render_template<T>(
         &self,
         template_string: &str,
@@ -471,7 +471,7 @@ impl<'reg> Registry<'reg> {
         Ok(writer.into_string())
     }
 
-    /// render a template string using current registry without register it
+    /// Render a template string using current registry without registering it
     pub fn render_template_to_write<T, W>(
         &self,
         template_string: &str,
@@ -491,7 +491,7 @@ impl<'reg> Registry<'reg> {
             .map_err(TemplateRenderError::from)
     }
 
-    /// render a template source using current registry without register it
+    /// Render a template source using current registry without registering it
     pub fn render_template_source_to_write<T, R, W>(
         &self,
         template_source: &mut R,

--- a/src/render.rs
+++ b/src/render.rs
@@ -26,7 +26,7 @@ const BLOCK_HELPER_MISSING: &str = "blockHelperMissing";
 
 /// The context of a render call
 ///
-/// this context stores information of a render and a writer where generated
+/// This context stores information of a render and a writer where generated
 /// content is written to.
 ///
 #[derive(Clone, Debug)]
@@ -131,7 +131,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
 
     /// Evaluate a Json path in current scope.
     ///
-    /// Typically you don't need to evaluate it by your self.
+    /// Typically you don't need to evaluate it by yourself.
     /// The Helper and Decorator API will provide your evaluated value of
     /// their parameters and hash data.
     pub fn evaluate(
@@ -204,7 +204,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
         self.inner_mut().local_helpers.remove(name);
     }
 
-    /// Attemp to get a helper from current render context.
+    /// Attempt to get a helper from current render context.
     pub fn get_local_helper(&self, name: &str) -> Option<Rc<Box<dyn HelperDef + 'rc>>> {
         self.inner().local_helpers.get(name).cloned()
     }
@@ -494,7 +494,7 @@ pub trait Renderable {
     }
 }
 
-/// Evaluate decorator or decorator
+/// Evaluate decorator
 pub trait Evaluable {
     fn eval<'reg: 'rc, 'rc>(
         &'reg self,


### PR DESCRIPTION
I was reading through the docs and noticed a few typos, so fixed them as I went along.