### PR TITLE
Hash support for helper macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/sunng87/handlebars-rust/compare/3.1.0...Unreleased) - ReleaseDate
 
 * [Added] API to register an pre-processed template [#331]
+* [Added] Helper macro now has support for named argument and helepr hash [#338]
 * [Changed] Update rhai to 0.15
 
 ## [3.1.0](https://github.com/sunng87/handlebars-rust/compare/3.0.1...3.1.0) - 2020-06-01

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@
 /// ```
 #[macro_export]
 macro_rules! handlebars_helper {
-    ($struct_name:ident: |$($name:ident: $tpe:tt),* $($hash_name:ident: $hash_tpe:tt=$default_value:literal),*| $body:expr ) => {
+    ($struct_name:ident: |$($name:ident: $tpe:tt$(= $dft_val: literal)?),* | $body:expr ) => {
         #[allow(non_camel_case_types)]
         pub struct $struct_name;
 
@@ -54,21 +54,6 @@ macro_rules! handlebars_helper {
                                   )))
                         )?;
                     param_idx += 1;
-                )*
-
-                $(
-                    let $hash_name = h.hash_get(stringify!($hash_name))
-                        .map(|x| x.value())
-                        .and_then(|x|
-                                  handlebars_helper!(@as_json_value x, $hash_tpe)
-                                  .ok_or_else(|| $crate::RenderError::new(&format!(
-                                      "`{}` helper: Couldn't convert parameter {} to type `{}`. \
-                                       It's {:?} as JSON. Got these hash: {:?}",
-                                      stringify!($fn_name), stringify!($hash_name), stringify!($hash_tpe),
-                                      x, h.hash(),
-                                  )))
-                        )?
-                        .unwrap_or($default_value);
                 )*
 
                 let result = $body;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@
 /// ```
 #[macro_export]
 macro_rules! handlebars_helper {
-    ($struct_name:ident: |$($name:ident: $tpe:tt),*| $body:expr ) => {
+    ($struct_name:ident: |$($name:ident: $tpe:tt),* $($hash_name:ident: $hash_tpe:tt=$default_value:literal),*| $body:expr ) => {
         #[allow(non_camel_case_types)]
         pub struct $struct_name;
 
@@ -54,6 +54,21 @@ macro_rules! handlebars_helper {
                                   )))
                         )?;
                     param_idx += 1;
+                )*
+
+                $(
+                    let $hash_name = h.hash_get(stringify!($hash_name))
+                        .map(|x| x.value())
+                        .and_then(|x|
+                                  handlebars_helper!(@as_json_value x, $hash_tpe)
+                                  .ok_or_else(|| $crate::RenderError::new(&format!(
+                                      "`{}` helper: Couldn't convert parameter {} to type `{}`. \
+                                       It's {:?} as JSON. Got these hash: {:?}",
+                                      stringify!($fn_name), stringify!($hash_name), stringify!($hash_tpe),
+                                      x, h.hash(),
+                                  )))
+                        )?
+                        .unwrap_or($default_value);
                 )*
 
                 let result = $body;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,7 @@
 /// Macro that allows you to quickly define a handlebars helper by passing a
-/// name and a closure.
+/// name and a closure. The closure arguments are mapped to helper parameters
+/// one by one. Named argument with default value is also supported and mapped
+/// to helper hash.
 ///
 /// # Examples
 ///
@@ -8,16 +10,22 @@
 /// #[macro_use] extern crate serde_json;
 ///
 /// handlebars_helper!(is_above_10: |x: u64| x > 10);
+/// handlebars_helper!(is_above: |x: u64, { compare: u64 = 10 }| x > compare);
 ///
 /// # fn main() {
 /// #
 /// let mut handlebars = handlebars::Handlebars::new();
 /// handlebars.register_helper("is-above-10", Box::new(is_above_10));
+/// handlebars.register_helper("is-above", Box::new(is_above));
 ///
 /// let result = handlebars
 ///     .render_template("{{#if (is-above-10 12)}}great!{{else}}okay{{/if}}", &json!({}))
 ///     .unwrap();
 ///  assert_eq!(&result, "great!");
+/// let result2 = handlebars
+///     .render_template("{{#if (is-above 12 compare=10)}}great!{{else}}okay{{/if}}", &json!({}))
+///     .unwrap();
+///  assert_eq!(&result2, "great!");
 /// # }
 /// ```
 

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -8,6 +8,7 @@ use handlebars::Handlebars;
 handlebars_helper!(lower: |s: str| s.to_lowercase());
 handlebars_helper!(upper: |s: str| s.to_uppercase());
 handlebars_helper!(hex: |v: i64| format!("0x{:x}", v));
+handlebars_helper!(money: |v: i64, cur: str="$"| format!("{}{}.00", cur, v));
 
 #[test]
 fn test_macro_helper() {

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -8,7 +8,8 @@ use handlebars::Handlebars;
 handlebars_helper!(lower: |s: str| s.to_lowercase());
 handlebars_helper!(upper: |s: str| s.to_uppercase());
 handlebars_helper!(hex: |v: i64| format!("0x{:x}", v));
-handlebars_helper!(money: |v: i64, cur: str="$"| format!("{}{}.00", cur, v));
+handlebars_helper!(money: |v: i64, {cur: str="$"}| format!("{}{}.00", cur, v));
+handlebars_helper!(all_hash: |{cur: str="$"}| cur);
 
 #[test]
 fn test_macro_helper() {
@@ -17,6 +18,7 @@ fn test_macro_helper() {
     hbs.register_helper("lower", Box::new(lower));
     hbs.register_helper("upper", Box::new(upper));
     hbs.register_helper("hex", Box::new(hex));
+    hbs.register_helper("money", Box::new(money));
 
     let data = json!("Teixeira");
 
@@ -29,4 +31,14 @@ fn test_macro_helper() {
         "TEIXEIRA"
     );
     assert_eq!(hbs.render_template("{{hex 16}}", &()).unwrap(), "0x10");
+
+    assert_eq!(
+        hbs.render_template("{{money 5000}}", &()).unwrap(),
+        "$5000.00"
+    );
+    assert_eq!(
+        hbs.render_template("{{money 5000 cur=\"£\"}}", &())
+            .unwrap(),
+        "£5000.00"
+    );
 }


### PR DESCRIPTION
Fixes #335 

This patch added support for named argument in helper macro `handlebars_helper!`.  The syntax is like:

```rust
handlebars_helper!(is_above, |x: u64, { compare: u64 = 10 }| x > compare);
```

Multiple named arguments are supported with `,` separated. 

When using this helper, you can either 

```handlebars
{{is_above 100 compare=99}} or {{is_above 100}}
```

