### PR TITLE
Helper macro enhancement

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,14 @@
 /// Macro that allows you to quickly define a handlebars helper by passing a
-/// name and a closure. The closure arguments are mapped to helper parameters
-/// one by one. Named argument with default value is also supported and mapped
-/// to helper hash.
+/// name and a closure.
+///
+/// There are several types of arguments available to closure:
+///
+/// * Parameters are mapped to closure arguments one by one. Any declared
+/// parameters are required
+/// * Hash are mapped as named arguments and declared in a bracket block.
+/// All named arguments are optional so default value is required.
+/// * An optional `*args` provides a vector of all helper parameters.
+/// * An optional `**kwargs` provides a map of all helper hash.
 ///
 /// # Examples
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,8 +32,10 @@
 #[macro_export]
 macro_rules! handlebars_helper {
     ($struct_name:ident: |$($name:ident: $tpe:tt),*
-                          $($(,)?{$($hash_name:ident: $hash_tpe:tt=$dft_val:literal),*})?|
-                            $body:expr ) => {
+     $($(,)?{$($hash_name:ident: $hash_tpe:tt=$dft_val:literal),*})?
+     $($(,)?*$args:ident)?
+     $($(,)?**$kwargs:ident)?|
+     $body:expr ) => {
         #[allow(non_camel_case_types)]
         pub struct $struct_name;
 
@@ -83,6 +85,9 @@ macro_rules! handlebars_helper {
                                 .unwrap_or_else(|| Ok($dft_val))?;
                         )*
                     )?
+
+                    $(let $args = h.params().iter().map(|x| x.value()).collect::<Vec<&serde_json::Value>>();)?
+                    $(let $kwargs = h.hash().iter().map(|(k, v)| (k.to_owned(), v.value())).collect::<std::collections::BTreeMap<&str, &serde_json::Value>>();)?
 
                 let result = $body;
                 Ok(Some($crate::ScopedJson::Derived($crate::JsonValue::from(result))))

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -10,6 +10,9 @@ handlebars_helper!(upper: |s: str| s.to_uppercase());
 handlebars_helper!(hex: |v: i64| format!("0x{:x}", v));
 handlebars_helper!(money: |v: i64, {cur: str="$"}| format!("{}{}.00", cur, v));
 handlebars_helper!(all_hash: |{cur: str="$"}| cur);
+handlebars_helper!(nargs: |*args| args.len());
+handlebars_helper!(has_a: |{a:i64 = 99}, **kwargs|
+                   format!("{}, {}", a, kwargs.get("a").is_some()));
 
 #[test]
 fn test_macro_helper() {
@@ -19,6 +22,8 @@ fn test_macro_helper() {
     hbs.register_helper("upper", Box::new(upper));
     hbs.register_helper("hex", Box::new(hex));
     hbs.register_helper("money", Box::new(money));
+    hbs.register_helper("nargs", Box::new(nargs));
+    hbs.register_helper("has_a", Box::new(has_a));
 
     let data = json!("Teixeira");
 
@@ -40,5 +45,20 @@ fn test_macro_helper() {
         hbs.render_template("{{money 5000 cur=\"£\"}}", &())
             .unwrap(),
         "£5000.00"
+    );
+    assert_eq!(
+        hbs.render_template("{{nargs 1 1 1 1 1}}", &()).unwrap(),
+        "5"
+    );
+    assert_eq!(hbs.render_template("{{nargs}}", &()).unwrap(), "0");
+
+    assert_eq!(
+        hbs.render_template("{{has_a a=1 b=2}}", &()).unwrap(),
+        "1, true"
+    );
+
+    assert_eq!(
+        hbs.render_template("{{has_a x=1 b=2}}", &()).unwrap(),
+        "99, false"
     );
 }


### PR DESCRIPTION
Added support for python's `*args` and `**kwargs` style arguments support for helper macro. 

* `*args` provides a vector of all helper parameters as `&serde_json::Value`
* `**kwargs` provides a map of all helper hash `<&str, &serde_json::Value>`

A usage example is included in test case.

