### PR TITLE
Allow Context reuse in render API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased](https://github.com/sunng87/handlebars-rust/compare/3.2.1...Unreleased) - ReleaseDate
+
+* [Added] Added two new APIs to reuse `Context` for rendering [#352]
+
 ## [3.2.1](https://github.com/sunng87/handlebars-rust/compare/3.2.0...3.2.1) - 2020-06-28
 
 * [Fixed] block context leak introduced in 3.2.0, #346 [#349]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use criterion::profiler::Profiler;
 use criterion::Criterion;
-use handlebars::{to_json, Handlebars, Template};
+use handlebars::{to_json, Context, Handlebars, Template};
 use pprof::protos::Message;
 use pprof::ProfilerGuard;
 use serde_json::value::Value as Json;
@@ -122,9 +122,9 @@ fn render_template(c: &mut Criterion) {
         .ok()
         .expect("Invalid template format");
 
-    let data = make_data();
+    let ctx = Context::wraps(make_data()).unwrap();
     c.bench_function("render_template", move |b| {
-        b.iter(|| handlebars.render("table", &data).ok().unwrap())
+        b.iter(|| handlebars.render_with_context("table", &ctx).ok().unwrap())
     });
 }
 
@@ -147,8 +147,9 @@ fn large_loop_helper(c: &mut Criterion) {
         .collect();
     let rows = RowWrapper { real, dummy };
 
+    let ctx = Context::wraps(&rows).unwrap();
     c.bench_function("large_loop_helper", move |b| {
-        b.iter(|| handlebars.render("test", &rows).ok().unwrap())
+        b.iter(|| handlebars.render_with_context("test", &ctx).ok().unwrap())
     });
 }
 
@@ -174,8 +175,9 @@ fn large_nested_loop(c: &mut Criterion) {
 
     let rows = NestedRowWrapper { parent };
 
+    let ctx = Context::wraps(&rows).unwrap();
     c.bench_function("large_nested_loop", move |b| {
-        b.iter(|| handlebars.render("test", &rows).ok().unwrap())
+        b.iter(|| handlebars.render_with_context("test", &ctx).ok().unwrap())
     });
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -153,6 +153,30 @@ fn large_loop_helper(c: &mut Criterion) {
     });
 }
 
+fn large_loop_helper_with_context_creation(c: &mut Criterion) {
+    let mut handlebars = Handlebars::new();
+    handlebars
+        .register_template_string("test", "BEFORE\n{{#each real}}{{this.v}}{{/each}}AFTER")
+        .ok()
+        .expect("Invalid template format");
+
+    let real: Vec<DataWrapper> = (1..1000)
+        .map(|i| DataWrapper {
+            v: format!("n={}", i),
+        })
+        .collect();
+    let dummy: Vec<DataWrapper> = (1..1000)
+        .map(|i| DataWrapper {
+            v: format!("n={}", i),
+        })
+        .collect();
+    let rows = RowWrapper { real, dummy };
+
+    c.bench_function("large_loop_helper_with_context_creation", move |b| {
+        b.iter(|| handlebars.render("test", &rows).ok().unwrap())
+    });
+}
+
 fn large_nested_loop(c: &mut Criterion) {
     let mut handlebars = Handlebars::new();
     handlebars
@@ -184,6 +208,7 @@ fn large_nested_loop(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = profiled();
-    targets = parse_template, render_template, large_loop_helper, large_nested_loop
+    targets = parse_template, render_template, large_loop_helper, large_loop_helper_with_context_creation,
+              large_nested_loop
 );
 criterion_main!(benches);

--- a/src/context.rs
+++ b/src/context.rs
@@ -211,6 +211,15 @@ impl Context {
     }
 }
 
+impl Serialize for Context {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        self.data.serialize(serializer)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::block::{BlockContext, BlockParams};

--- a/src/context.rs
+++ b/src/context.rs
@@ -211,15 +211,6 @@ impl Context {
     }
 }
 
-impl Serialize for Context {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::Serializer,
-    {
-        self.data.serialize(serializer)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::block::{BlockContext, BlockParams};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -871,4 +871,28 @@ mod test {
             "<b>bold</b>"
         );
     }
+
+    #[test]
+    fn test_render_context() {
+        let mut reg = Registry::new();
+
+        let data = json!([0, 1, 2, 3]);
+
+        assert_eq!(
+            "0123",
+            reg.render_template_with_context(
+                "{{#each this}}{{this}}{{/each}}",
+                &Context::wraps(&data).unwrap()
+            )
+            .unwrap()
+        );
+
+        reg.register_template_string("t0", "{{#each this}}{{this}}{{/each}}")
+            .unwrap();
+        assert_eq!(
+            "0123",
+            reg.render_with_context("t0", &Context::wraps(&data).unwrap())
+                .unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Fixes #351 

According to our benchmark, the creation of `Context` can take up to 50% time of template rendering, due to data copy in serde_json. 

![image](https://user-images.githubusercontent.com/221942/86997147-f9246080-c1df-11ea-9e91-3baea813153a.png)

This patch added two new API to `Registry` aka `Handlebars` to allow user to reuse `Context` and avoid that copy.

I'm considering a better `Context` to avoid copy as much as possible in future release.