### PR TITLE
Add Tide to supported web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Handlebars 3.0 can be used in WebAssembly projects.
 * Tower-web: [Built-in](https://github.com/carllerche/tower-web)
 * Actix: [handlebars
   example](https://github.com/actix/examples/blob/master/template_handlebars/src/main.rs)
+* Tide: [tide-handlebars](https://github.com/No9/tide-handlebars)
 
 ### Adopters
 


### PR DESCRIPTION
tide-handlebars has been added to the tide community crates https://github.com/http-rs/tide/wiki/Community-Crates So adding it to the list on this site too.