### PR TITLE
Dollar symbol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Added] Added two new APIs to reuse `Context` for rendering [#352]
 * [Changed] Update rhai to 0.17 [#354]
+* [Fixed] Fixed mustache.js html expression support, which is "&" instead of "$"
 
 ## [3.2.1](https://github.com/sunng87/handlebars-rust/compare/3.2.0...3.2.1) - 2020-06-28
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -21,7 +21,7 @@ array_literal = { "[" ~ literal? ~ ("," ~ literal)* ~ "]" }
 object_literal = { "{" ~ (string_literal ~ ":" ~ literal)?
                    ~ ("," ~ string_literal ~ ":" ~ literal)* ~ "}" }
 
-symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
+symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|"$"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
 partial_symbol_char = _{'a'..'z'|'A'..'Z'|ASCII_DIGIT|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'|"/"}
 path_char = _{ "/" }
 
@@ -47,9 +47,9 @@ expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~
               ~ pro_whitespace_omitter? ~ "}}" }
 html_expression_triple_bracket = _{ "{{{" ~ pre_whitespace_omitter? ~ name ~
                                     pro_whitespace_omitter? ~ "}}}" }
-dollar_expression = _{ "{{" ~ pre_whitespace_omitter? ~ "$" ~ name ~
+amp_expression = _{ "{{" ~ pre_whitespace_omitter? ~ "&" ~ name ~
                        pro_whitespace_omitter? ~ "}}" }
-html_expression = { html_expression_triple_bracket | dollar_expression }
+html_expression = { html_expression_triple_bracket | amp_expression }
 
 decorator_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
 pro_whitespace_omitter? ~ "}}" }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -81,6 +81,7 @@ mod test {
             "abc.[0].[nice]",
             "some-name",
             "this.[0].ok",
+            "[$id]",
         ];
         for i in s.iter() {
             assert_rule!(Rule::reference, i);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -81,7 +81,9 @@ mod test {
             "abc.[0].[nice]",
             "some-name",
             "this.[0].ok",
+            "this.[$id]",
             "[$id]",
+            "$id",
         ];
         for i in s.iter() {
             assert_rule!(Rule::reference, i);
@@ -194,7 +196,7 @@ mod test {
 
     #[test]
     fn test_html_expression() {
-        let s = vec!["{{{html}}}", "{{{(html)}}}", "{{{(html)}}}", "{{$html}}"];
+        let s = vec!["{{{html}}}", "{{{(html)}}}", "{{{(html)}}}", "{{&html}}"];
         for i in s.iter() {
             assert_rule!(Rule::html_expression, i);
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -866,7 +866,7 @@ mod test {
             "<b>bold</b>"
         );
         assert_eq!(
-            reg.render_template("{{ $a }}", &json!({"a": "<b>bold</b>"}))
+            reg.render_template("{{ &a }}", &json!({"a": "<b>bold</b>"}))
                 .unwrap(),
             "<b>bold</b>"
         );


### PR DESCRIPTION
Fixes #357 

It seems I had a terrible mistake in #339 , which should be `&` char instead of `$`. And `$`, as described in https://handlebarsjs.com/guide/expressions.html#literal-segments, is valid as a symbol char. 