### PR TITLE
Update grammar for partials to allow subexpressions + parameters

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -35,7 +35,7 @@ param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
 hash = { identifier ~ "=" ~ param }
 block_param = { "as" ~ "|" ~ identifier ~ identifier? ~ "|"}
 exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
-partial_exp_line = _{ (partial_identifier ~ (hash|param)+) | name }
+partial_exp_line = _{ ((partial_identifier|name) ~ (hash|param)*) }
 
 subexpression = { "(" ~ ((identifier ~ (hash|param)+) | reference)  ~ ")" }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -319,6 +319,7 @@ mod test {
             "{{> (hello)}}",
             "{{~> hello a}}",
             "{{> hello a=1}}",
+            "{{> (hello) a=1}}",
         ];
         for i in s.iter() {
             assert_rule!(Rule::partial_expression, i);


### PR DESCRIPTION
You can now pass parameters to partials that are referenced through subexpressions. For example:

```handlebars
{{> (lookup foo "bar") name="value"}}
```

[This syntax is supported by handlebars.js](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22This%20is%20a%20test.%20%7B%7B%3E%20(x%20%40root)%20name%3D%5C%22fred%5C%22%7D%7D%22%2C%22partials%22%3A%5B%7B%22name%22%3A%22two%22%2C%22content%22%3A%22Lets%20test%20%7B%7Bname%7D%7D%22%7D%5D%2C%22input%22%3A%22%7B%7D%22%2C%22output%22%3A%22This%20is%20a%20test.%20Lets%20test%20fred%22%2C%22preparationScript%22%3A%22Handlebars.registerHelper(%5C%22x%5C%22%2C%20()%20%3D%3E%20%5C%22two%5C%22)%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.6%22%7D).
