### PR TITLE
Fix derived value in each and lookup helper

### DIFF
--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -239,8 +239,7 @@ mod test {
         assert_eq!("d", hb.render_template(template, &data).unwrap());
     }
 
-    // #[test]
-    // FIXME: fix this later, subexpression result should be used as literal
+    #[test]
     fn test_nested_derived_value() {
         let hb = Registry::new();
         let data = json!({"a": {"b": {"c": "d"}}});


### PR DESCRIPTION
This is a further patch to address issue in #355 . `base_value` is inherited in `each` block during iteration. 

We also enabled subexpression value access for `lookup` helper.