### PR TITLE
Escaping helper expression results

### DIFF
--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -3,7 +3,7 @@ use crate::error::RenderError;
 use crate::json::value::ScopedJson;
 use crate::output::Output;
 use crate::registry::Registry;
-use crate::render::{Helper, RenderContext};
+use crate::render::{do_escape, Helper, RenderContext};
 
 pub use self::helper_each::EACH_HELPER;
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
@@ -98,7 +98,9 @@ pub trait HelperDef {
             if r.strict_mode() && result.is_missing() {
                 return Err(RenderError::strict_error(None));
             } else {
-                out.write(result.render().as_ref())?;
+                // auto escape according to settings
+                let output = do_escape(r, rc, result.render());
+                out.write(output.as_ref())?;
             }
         }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -710,6 +710,14 @@ fn render_helper<'reg: 'rc, 'rc>(
     }
 }
 
+fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: String) -> String {
+    if !rc.is_disable_escape() {
+        r.get_escape_fn()(&content)
+    } else {
+        content
+    }
+}
+
 impl Renderable for TemplateElement {
     fn render<'reg: 'rc, 'rc>(
         &'reg self,
@@ -746,11 +754,7 @@ impl Renderable for TemplateElement {
                             }
                         } else {
                             let rendered = context_json.value().render();
-                            let output = if !rc.is_disable_escape() {
-                                registry.get_escape_fn()(&rendered)
-                            } else {
-                                rendered
-                            };
+                            let output = do_escape(registry, rc, rendered);
                             out.write(output.as_ref())?;
                             Ok(())
                         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -710,7 +710,7 @@ fn render_helper<'reg: 'rc, 'rc>(
     }
 }
 
-fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: String) -> String {
+pub(crate) fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: String) -> String {
     if !rc.is_disable_escape() {
         r.get_escape_fn()(&content)
     } else {

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -13,6 +13,7 @@ handlebars_helper!(all_hash: |{cur: str="$"}| cur);
 handlebars_helper!(nargs: |*args| args.len());
 handlebars_helper!(has_a: |{a:i64 = 99}, **kwargs|
                    format!("{}, {}", a, kwargs.get("a").is_some()));
+handlebars_helper!(tag: |t: str| format!("<{}>", t));
 
 #[test]
 fn test_macro_helper() {
@@ -24,6 +25,7 @@ fn test_macro_helper() {
     hbs.register_helper("money", Box::new(money));
     hbs.register_helper("nargs", Box::new(nargs));
     hbs.register_helper("has_a", Box::new(has_a));
+    hbs.register_helper("tag", Box::new(tag));
 
     let data = json!("Teixeira");
 
@@ -60,5 +62,10 @@ fn test_macro_helper() {
     assert_eq!(
         hbs.render_template("{{has_a x=1 b=2}}", &()).unwrap(),
         "99, false"
+    );
+
+    assert_eq!(
+        hbs.render_template("{{tag \"html\"}}", &()).unwrap(),
+        "&lt;html&gt;"
     );
 }


### PR DESCRIPTION
Fixes #361 

This patch partially fixed issue as mentioned in #361 that result of helper call should be escaped by default.

Further support for `{{{html expression}}}` that doesn't escape the result will be supported in 4.0