### PR TITLE
Helper call support in html expression

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -44,7 +44,8 @@ pro_whitespace_omitter = { "~" }
 expression = { !invert_tag ~ "{{" ~ pre_whitespace_omitter? ~
               ((identifier ~ (hash|param)+) | name )
               ~ pro_whitespace_omitter? ~ "}}" }
-html_expression_triple_bracket = _{ "{{{" ~ pre_whitespace_omitter? ~ name ~
+html_expression_triple_bracket = _{ "{{{" ~ pre_whitespace_omitter? ~
+                                    ((identifier ~ (hash|param)+) | name ) ~
                                     pro_whitespace_omitter? ~ "}}}" }
 amp_expression = _{ "{{" ~ pre_whitespace_omitter? ~ "&" ~ name ~
                        pro_whitespace_omitter? ~ "}}" }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -198,7 +198,14 @@ mod test {
 
     #[test]
     fn test_html_expression() {
-        let s = vec!["{{{html}}}", "{{{(html)}}}", "{{{(html)}}}", "{{&html}}"];
+        let s = vec![
+            "{{{html}}}",
+            "{{{(html)}}}",
+            "{{{(html)}}}",
+            "{{&html}}",
+            "{{{html 1}}}",
+            "{{{html p=true}}}",
+        ];
         for i in s.iter() {
             assert_rule!(Rule::html_expression, i);
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -853,7 +853,9 @@ fn test_expression() {
 #[test]
 fn test_html_expression() {
     let r = Registry::new();
-    let element = HTMLExpression(Parameter::Path(Path::with_named_paths(&["hello"])));
+    let element = HTMLExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
+        &["hello"],
+    ))));
 
     let mut out = StringOutput::new();
     let mut m: BTreeMap<String, String> = BTreeMap::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -791,7 +791,9 @@ fn test_parse_template() {
 
     assert_eq!(
         *t.elements.get(3).unwrap(),
-        HTMLExpression(Parameter::Path(Path::with_named_paths(&["content"])))
+        HTMLExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
+            &["content"],
+        ))))
     );
 
     match *t.elements.get(5).unwrap() {

--- a/src/template.rs
+++ b/src/template.rs
@@ -598,12 +598,7 @@ impl Template {
                         omit_pro_ws = exp.omit_pro_ws;
 
                         match rule {
-                            Rule::html_expression => {
-                                let el = HTMLExpression(exp.name);
-                                let t = template_stack.front_mut().unwrap();
-                                t.push_element(el, line_no, col_no);
-                            }
-                            Rule::expression => {
+                            Rule::expression | Rule::html_expression => {
                                 let helper_template = HelperTemplate {
                                     name: exp.name,
                                     params: exp.params,
@@ -613,7 +608,11 @@ impl Template {
                                     template: None,
                                     inverse: None,
                                 };
-                                let el = Expression(Box::new(helper_template));
+                                let el = if rule == Rule::expression {
+                                    Expression(Box::new(helper_template))
+                                } else {
+                                    HTMLExpression(Box::new(helper_template))
+                                };
                                 let t = template_stack.front_mut().unwrap();
                                 t.push_element(el, line_no, col_no);
                             }
@@ -733,7 +732,7 @@ impl Template {
 #[derive(PartialEq, Clone, Debug)]
 pub enum TemplateElement {
     RawString(String),
-    HTMLExpression(Parameter),
+    HTMLExpression(Box<HelperTemplate>),
     Expression(Box<HelperTemplate>),
     HelperBlock(Box<HelperTemplate>),
     DecoratorExpression(Box<DecoratorTemplate>),

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -68,4 +68,9 @@ fn test_macro_helper() {
         hbs.render_template("{{tag \"html\"}}", &()).unwrap(),
         "&lt;html&gt;"
     );
+
+    assert_eq!(
+        hbs.render_template("{{{tag \"html\"}}}", &()).unwrap(),
+        "<html>"
+    );
 }


### PR DESCRIPTION
This is a follow up of #373 that adds helper call support in html expression.

This patch introduces break change in `TemplateElement` API. 