### PR TITLE
Strict helpers

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -527,4 +527,31 @@ mod test {
         let rendered = reg.render("walk", &input).unwrap();
         assert_eq!(expected_output, rendered);
     }
+
+    #[test]
+    fn test_strict_each() {
+        let mut reg = Registry::new();
+
+        assert!(reg
+            .render_template("{{#each data}}{{/each}}", &json!({}))
+            .is_ok());
+        assert!(reg
+            .render_template("{{#each data}}{{/each}}", &json!({"data": 24}))
+            .is_ok());
+
+        reg.set_strict_mode(true);
+
+        assert!(reg
+            .render_template("{{#each data}}{{/each}}", &json!({}))
+            .is_err());
+        assert!(reg
+            .render_template("{{#each data}}{{/each}}", &json!({"data": 24}))
+            .is_err());
+        assert!(reg
+            .render_template("{{#each data}}{{else}}food{{/each}}", &json!({}))
+            .is_ok());
+        assert!(reg
+            .render_template("{{#each data}}{{else}}food{{/each}}", &json!({"data": 24}))
+            .is_ok());
+    }
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -138,9 +138,12 @@ impl HelperDef for EachHelper {
                 }
                 _ => {
                     if let Some(else_template) = h.inverse() {
-                        else_template.render(r, ctx, rc, out)?;
+                        else_template.render(r, ctx, rc, out)
+                    } else if r.strict_mode() {
+                        Err(RenderError::strict_error(value.relative_path()))
+                    } else {
+                        Ok(())
                     }
-                    Ok(())
                 }
             },
             None => Ok(()),

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -84,4 +84,21 @@ mod test {
         let r2 = handlebars.render("t2", &m2);
         assert_eq!(r2.ok().unwrap(), "world".to_string());
     }
+
+    #[test]
+    fn test_strict_lookup() {
+        let mut hbs = Registry::new();
+
+        assert_eq!(
+            hbs.render_template("{{lookup kk 1}}", &json!({"kk": []}))
+                .unwrap(),
+            ""
+        );
+
+        hbs.set_strict_mode(true);
+
+        assert!(hbs
+            .render_template("{{lookup kk 1}}", &json!({"kk": []}))
+            .is_err());
+    }
 }

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -14,7 +14,7 @@ impl HelperDef for LookupHelper {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
         h: &Helper<'reg, 'rc>,
-        _: &'reg Registry<'reg>,
+        r: &'reg Registry<'reg>,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
@@ -38,7 +38,11 @@ impl HelperDef for LookupHelper {
                 .map(|i| ScopedJson::Derived(i.clone())),
             _ => None,
         };
-        Ok(value)
+        if r.strict_mode() && value.is_none() {
+            Err(RenderError::strict_error(None))
+        } else {
+            Ok(value)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #384 

This patch add strict mode support for `each`, `with` and `lookup` helper. 

When inverse block was not defined for `each` and `with`, it throws `RenderError` on null value and invalid values.