### PR TITLE
Dev mode and template sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## [Unreleased](https://github.com/sunng87/handlebars-rust/compare/3.4.0...Unreleased) - ReleaseDate
 
+* [Added] `dev_mode` for registry: templates and scripts loaded from file are always
+  reloaded when dev mode enabled [#395]
+* [Added] Registry is now `Clone` [#395]
 * [Changed] `#each` helper now renders else block for non-iterable data [#380]
+* [Changed] `TemplateError` and `ScriptError` is now a cause of `RenderError` [#395]
 * [Fixed] reference starts with `null`, `true` and `false` were parsed incorrectly [#382]
 * [Fixed] dir source path separator bug on windows [#389]
+* [Removed] option to disable source map is removed [#395]
+* [Removed] `TemplateFileError` and `TemplateRenderError` are removed and merged into
+  `TemplateError` and `RenderError` [#395]
 
 ## [3.4.0](https://github.com/sunng87/handlebars-rust/compare/3.3.0...3.4.0) - 2020-08-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ maplit = "1.0.0"
 serde_derive = "1.0.75"
 tempfile = "3.0.0"
 criterion = "0.3"
+warp = "0.2"
+tokio = { version = "0.2", features = ["macros"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.3.13", features = ["flamegraph", "protobuf"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pest_derive = "2.1.0"
 serde = "1.0.0"
 serde_json = "1.0.39"
 walkdir = { version = "2.2.3", optional = true }
-rhai = { version = "0.19.4", optional = true, features = ["sync", "serde"] }
+rhai = { version = "0.19.6", optional = true, features = ["sync", "serde"] }
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ embed your page into this parent.
 You can find a real example of template inheritance in
 `examples/partials.rs` and templates used by this file.
 
+#### Auto-reload in dev mode
+
+By turning on `dev_mode`, handlebars auto reloads any template and scripts that
+loaded from files or directory. This can be handy for template development.
+
 #### WebAssembly compatible
 
 Handlebars 3.0 can be used in WebAssembly projects.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Examples are provided in source tree to demo usage of various api.
   just like using javascript for handlebarsjs
 * [error](https://github.com/sunng87/handlebars-rust/blob/master/examples/error.rs)
   simple case for error
+* [dev_mode](https://github.com/sunng87/handlebars-rust/blob/master/examples/dev_mode.rs)
+  a web server hosts handlebars in `dev_mode`, you can edit the template and see the change
+  without restarting your server.
 
 ## Minimum Rust Version Policy
 

--- a/examples/dev_mode.rs
+++ b/examples/dev_mode.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use handlebars::Handlebars;
+use serde_json::json;
+use warp::{self, Filter};
+
+#[tokio::main]
+async fn main() {
+    let mut reg = Handlebars::new();
+    // enable dev mode for template reloading
+    reg.set_dev_mode(true);
+    // register a template from the file
+    // modified the file after the server starts to see things changing
+    reg.register_template_file("tpl", "./examples/dev_mode/template.hbs")
+        .unwrap();
+
+    let hbs = Arc::new(reg);
+    let route = warp::get().map(move || {
+        let result = hbs
+            .render("tpl", &json!({"model": "t14s", "brand": "Thinkpad"}))
+            .unwrap_or_else(|e| e.to_string());
+        warp::reply::html(result)
+    });
+
+    println!("Edit ./examples/dev_mode/template.hbs and request http://localhost:3030 to see the change on the run.");
+    warp::serve(route).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/examples/dev_mode/template.hbs
+++ b/examples/dev_mode/template.hbs
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>My Laptop</title>
+  </head>
+  <body>
+    <p>My current laptop is {{brand}}: <b>{{model}}</b></p>
+  </body>
+</html>

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -129,9 +129,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let data = make_data();
 
-    let mut source_template = File::open(&"./examples/render_file/template.hbs")?;
+    handlebars
+        .register_template_file("template", "./examples/render_file/template.hbs")
+        .unwrap();
+
     let mut output_file = File::create("target/table.html")?;
-    handlebars.render_template_source_to_write(&mut source_template, &data, &mut output_file)?;
+    handlebars.render_to_write("template", &data, &mut output_file)?;
     println!("target/table.html generated");
     Ok(())
 }

--- a/examples/script/goals.rhai
+++ b/examples/script/goals.rhai
@@ -1,3 +1,3 @@
 let goals = params[0];
 
-len(goals)
+goals.len()

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,7 +36,7 @@ fn parse_json_visitor<'a, 'reg>(
     relative_path: &[PathSeg],
     block_contexts: &'a VecDeque<BlockContext<'reg>>,
     always_for_absolute_path: bool,
-) -> Result<ResolvedPath<'a>, RenderError> {
+) -> ResolvedPath<'a> {
     let mut path_context_depth: i64 = 0;
     let mut with_block_param = None;
     let mut from_root = false;
@@ -65,7 +65,7 @@ fn parse_json_visitor<'a, 'reg>(
     match with_block_param {
         Some((BlockParamHolder::Value(ref value), _)) => {
             merge_json_path(&mut path_stack, &relative_path[1..]);
-            Ok(ResolvedPath::BlockParamValue(path_stack, value))
+            ResolvedPath::BlockParamValue(path_stack, value)
         }
         Some((BlockParamHolder::Path(ref paths), base_path)) => {
             extend(&mut path_stack, base_path);
@@ -74,7 +74,7 @@ fn parse_json_visitor<'a, 'reg>(
             }
             merge_json_path(&mut path_stack, &relative_path[1..]);
 
-            Ok(ResolvedPath::AbsolutePath(path_stack))
+            ResolvedPath::AbsolutePath(path_stack)
         }
         None => {
             if path_context_depth > 0 {
@@ -90,24 +90,24 @@ fn parse_json_visitor<'a, 'reg>(
                     }
                 }
                 merge_json_path(&mut path_stack, relative_path);
-                Ok(ResolvedPath::AbsolutePath(path_stack))
+                ResolvedPath::AbsolutePath(path_stack)
             } else if from_root {
                 merge_json_path(&mut path_stack, relative_path);
-                Ok(ResolvedPath::AbsolutePath(path_stack))
+                ResolvedPath::AbsolutePath(path_stack)
             } else if always_for_absolute_path {
                 if let Some(base_value) = block_contexts.front().and_then(|blk| blk.base_value()) {
                     merge_json_path(&mut path_stack, relative_path);
-                    Ok(ResolvedPath::LocalValue(path_stack, base_value))
+                    ResolvedPath::LocalValue(path_stack, base_value)
                 } else {
                     if let Some(base_path) = block_contexts.front().map(|blk| blk.base_path()) {
                         extend(&mut path_stack, base_path);
                     }
                     merge_json_path(&mut path_stack, relative_path);
-                    Ok(ResolvedPath::AbsolutePath(path_stack))
+                    ResolvedPath::AbsolutePath(path_stack)
                 }
             } else {
                 merge_json_path(&mut path_stack, relative_path);
-                Ok(ResolvedPath::RelativePath(path_stack))
+                ResolvedPath::RelativePath(path_stack)
             }
         }
     }
@@ -170,7 +170,7 @@ impl Context {
         block_contexts: &VecDeque<BlockContext<'reg>>,
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         // always use absolute at the moment until we get base_value lifetime issue fixed
-        let resolved_visitor = parse_json_visitor(&relative_path, block_contexts, true)?;
+        let resolved_visitor = parse_json_visitor(&relative_path, block_contexts, true);
 
         // debug logging
         debug!("Accessing context value: {:?}", resolved_visitor);

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,12 @@ impl From<ParseIntError> for RenderError {
     }
 }
 
+impl From<TemplateError> for RenderError {
+    fn from(e: TemplateError) -> RenderError {
+        RenderError::from_error("Error with parsing template.", e)
+    }
+}
+
 #[cfg(feature = "script_helper")]
 impl From<Box<EvalAltResult>> for RenderError {
     fn from(e: Box<EvalAltResult>) -> RenderError {
@@ -119,7 +125,7 @@ impl RenderError {
 
 quick_error! {
 /// Template parsing error
-    #[derive(PartialEq, Debug, Clone)]
+    #[derive(Debug)]
     pub enum TemplateErrorReason {
         MismatchingClosedHelper(open: String, closed: String) {
             display("helper {:?} was opened, but {:?} is closing",
@@ -138,11 +144,20 @@ quick_error! {
         NestedSubexpression {
             display("nested subexpression is not supported")
         }
+        IoError(err: IOError, name: String) {
+            from(err)
+            display("Template \"{}\": {}", name, err)
+        }
+        #[cfg(feature = "dir_source")]
+        WalkdirError(err: WalkdirError) {
+            from(err)
+            display("Walk dir error: {}", err)
+        }
     }
 }
 
 /// Error on parsing template.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TemplateError {
     pub reason: TemplateErrorReason,
     pub template_name: Option<String>,
@@ -219,64 +234,6 @@ impl fmt::Display for TemplateError {
                 self.reason
             ),
             _ => write!(f, "{}", self.reason),
-        }
-    }
-}
-
-quick_error! {
-    /// A combined error type for `TemplateError` and `IOError`
-    #[derive(Debug)]
-    pub enum TemplateFileError {
-        TemplateError(err: TemplateError) {
-            from()
-            source(err)
-            display("{}", err)
-        }
-        IOError(err: IOError, name: String) {
-            source(err)
-            display("Template \"{}\": {}", name, err)
-        }
-    }
-}
-
-#[cfg(feature = "dir_source")]
-impl From<WalkdirError> for TemplateFileError {
-    fn from(error: WalkdirError) -> TemplateFileError {
-        let path_string: String = error
-            .path()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-        TemplateFileError::IOError(IOError::from(error), path_string)
-    }
-}
-
-quick_error! {
-    /// A combined error type for `TemplateError`, `IOError` and `RenderError`
-    #[derive(Debug)]
-    pub enum TemplateRenderError {
-        TemplateError(err: TemplateError) {
-            from()
-            source(err)
-            display("{}", err)
-        }
-        RenderError(err: RenderError) {
-            from()
-            source(err)
-            display("{}", err)
-        }
-        IOError(err: IOError, name: String) {
-            source(err)
-            display("Template \"{}\": {}", name, err)
-        }
-    }
-}
-
-impl TemplateRenderError {
-    pub fn as_render_error(&self) -> Option<&RenderError> {
-        if let TemplateRenderError::RenderError(ref e) = *self {
-            Some(&e)
-        } else {
-            None
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,13 +145,11 @@ quick_error! {
             display("nested subexpression is not supported")
         }
         IoError(err: IOError, name: String) {
-            from(err)
-            display("Template \"{}\": {}", name, err)
+             display("Template \"{}\": {}", name, err)
         }
         #[cfg(feature = "dir_source")]
         WalkdirError(err: WalkdirError) {
-            from(err)
-            display("Walk dir error: {}", err)
+             display("Walk dir error: {}", err)
         }
     }
 }
@@ -191,6 +189,20 @@ impl TemplateError {
 }
 
 impl Error for TemplateError {}
+
+impl From<(IOError, String)> for TemplateError {
+    fn from(err_info: (IOError, String)) -> TemplateError {
+        let (e, name) = err_info;
+        TemplateError::of(TemplateErrorReason::IoError(e, name))
+    }
+}
+
+#[cfg(feature = "dir_source")]
+impl From<WalkdirError> for TemplateError {
+    fn from(e: WalkdirError) -> TemplateError {
+        TemplateError::of(TemplateErrorReason::WalkdirError(e))
+    }
+}
 
 fn template_segment(template_str: &str, line: usize, col: usize) -> String {
     let range = 3;

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,17 +101,6 @@ impl RenderError {
         RenderError::new(&msg)
     }
 
-    #[deprecated]
-    pub fn with<E>(cause: E) -> RenderError
-    where
-        E: Error + Send + Sync + 'static,
-    {
-        let mut e = RenderError::new(cause.to_string());
-        e.cause = Some(Box::new(cause));
-
-        e
-    }
-
     pub fn from_error<E>(error_kind: &str, cause: E) -> RenderError
     where
         E: Error + Send + Sync + 'static,

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,13 @@ impl From<Box<EvalAltResult>> for RenderError {
     }
 }
 
+#[cfg(feature = "script_helper")]
+impl From<ScriptError> for RenderError {
+    fn from(e: ScriptError) -> RenderError {
+        RenderError::from_error("Error loading rhai script.", e)
+    }
+}
+
 impl RenderError {
     pub fn new<T: AsRef<str>>(desc: T) -> RenderError {
         RenderError {

--- a/src/helpers/block_util.rs
+++ b/src/helpers/block_util.rs
@@ -1,10 +1,9 @@
 use crate::block::BlockContext;
-use crate::error::RenderError;
 use crate::json::value::PathAndJson;
 
 pub(crate) fn create_block<'reg: 'rc, 'rc>(
     param: &'rc PathAndJson<'reg, 'rc>,
-) -> Result<BlockContext<'reg>, RenderError> {
+) -> BlockContext<'reg> {
     let mut block = BlockContext::new();
 
     if let Some(new_path) = param.context_path() {
@@ -14,5 +13,5 @@ pub(crate) fn create_block<'reg: 'rc, 'rc>(
         block.set_base_value(param.value().clone());
     }
 
-    Ok(block)
+    block
 }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -81,7 +81,7 @@ impl HelperDef for EachHelper {
         match template {
             Some(t) => match *value.value() {
                 Json::Array(ref list) if !list.is_empty() => {
-                    let block_context = create_block(&value)?;
+                    let block_context = create_block(&value);
                     rc.push_block(block_context);
 
                     let len = list.len();
@@ -109,7 +109,7 @@ impl HelperDef for EachHelper {
                     Ok(())
                 }
                 Json::Object(ref obj) if !obj.is_empty() => {
-                    let block_context = create_block(&value)?;
+                    let block_context = create_block(&value);
                     rc.push_block(block_context);
 
                     let mut is_first = true;

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -25,7 +25,7 @@ impl HelperDef for WithHelper {
             .ok_or_else(|| RenderError::new("Param not found for helper \"with\""))?;
 
         if param.value().is_truthy(false) {
-            let mut block = create_block(&param)?;
+            let mut block = create_block(&param);
 
             if let Some(block_param) = h.block_param() {
                 let mut params = BlockParams::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,6 +397,7 @@ mod output;
 mod partial;
 mod registry;
 mod render;
+mod sources;
 mod support;
 pub mod template;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ extern crate serde_json;
 pub use self::block::{BlockContext, BlockParams};
 pub use self::context::Context;
 pub use self::decorators::DecoratorDef;
-pub use self::error::{RenderError, TemplateError, TemplateFileError, TemplateRenderError};
+pub use self::error::{RenderError, TemplateError};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::json::path::Path;
 pub use self::json::value::{to_json, JsonRender, PathAndJson, ScopedJson};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,19 @@
 //!
 //! ### Extensible helper system
 //!
-//! You can write your own helper with Rust! It can be a block helper or
-//! inline helper. Put your logic into the helper and don't repeat
-//! yourself.
+//! Helper is the control system of handlebars language. In the original JavaScript
+//! version, you can implement your own helper with JavaScript.
+//!
+//! Handlebars-rust offers similar mechanism that custom helper can be defined with
+//! rust function, or [rhai](https://github.com/jonathandturner/rhai) script.
 //!
 //! The built-in helpers like `if` and `each` were written with these
 //! helper APIs and the APIs are fully available to developers.
+//!
+//! ### Auto-reload in dev mode
+//!
+//! By turning on `dev_mode`, handlebars auto reloads any template and scripts that
+//! loaded from files or directory. This can be handy for template development.
 //!
 //! ### Template inheritance
 //!

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -762,10 +762,7 @@ mod test {
         let render_error = r
             .render_template("accessing non-exists key {{the_key_never_exists}}", &data)
             .unwrap_err();
-        assert_eq!(
-            render_error.as_render_error().unwrap().column_no.unwrap(),
-            26
-        );
+        assert_eq!(render_error.column_no.unwrap(), 26);
 
         let data2 = json!([1, 2, 3]);
         assert!(r
@@ -777,10 +774,7 @@ mod test {
         let render_error2 = r
             .render_template("accessing invalid array index {{this.[3]}}", &data2)
             .unwrap_err();
-        assert_eq!(
-            render_error2.as_render_error().unwrap().column_no.unwrap(),
-            31
-        );
+        assert_eq!(render_error2.column_no.unwrap(), 31);
     }
 
     use crate::json::value::ScopedJson;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -70,6 +70,8 @@ impl<'reg> Debug for Registry<'reg> {
             .field("templates", &self.templates)
             .field("helpers", &self.helpers.keys())
             .field("decorators", &self.decorators.keys())
+            .field("strict_mode", &self.strict_mode)
+            .field("dev_mode", &self.dev_mode)
             .finish()
     }
 }
@@ -140,15 +142,15 @@ impl<'reg> Registry<'reg> {
         self
     }
 
-    /// Enable handlebars strict mode
+    /// Enable or disable handlebars strict mode
     ///
     /// By default, handlebars renders empty string for value that
     /// undefined or never exists. Since rust is a static type
     /// language, we offer strict mode in handlebars-rust.  In strict
     /// mode, if you were to render a value that doesn't exist, a
     /// `RenderError` will be raised.
-    pub fn set_strict_mode(&mut self, enable: bool) {
-        self.strict_mode = enable;
+    pub fn set_strict_mode(&mut self, enabled: bool) {
+        self.strict_mode = enabled;
     }
 
     /// Return strict mode state, default is false.
@@ -160,6 +162,22 @@ impl<'reg> Registry<'reg> {
     /// `RenderError` will be raised.
     pub fn strict_mode(&self) -> bool {
         self.strict_mode
+    }
+
+    /// Return dev mode state, default is false
+    ///
+    /// With dev mode turned on, handlebars enables a set of development
+    /// firendly features, that may affect its performance.
+    pub fn dev_mode(&self) -> bool {
+        self.dev_mode
+    }
+
+    /// Enable or disable dev mode
+    ///
+    /// With dev mode turned on, handlebars enables a set of development
+    /// firendly features, that may affect its performance.
+    pub fn set_dev_mode(&mut self, enabled: bool) {
+        self.dev_mode = enabled;
     }
 
     /// Register a `Template`

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,6 +15,7 @@ use crate::error::{RenderError, TemplateError, TemplateFileError, TemplateRender
 use crate::helpers::{self, HelperDef};
 use crate::output::{Output, StringOutput, WriteOutput};
 use crate::render::{RenderContext, Renderable};
+use crate::sources::Source;
 use crate::support::str::{self, StringWriter};
 use crate::template::Template;
 
@@ -53,6 +54,9 @@ pub fn no_escape(data: &str) -> String {
 /// It maintains compiled templates and registered helpers.
 pub struct Registry<'reg> {
     templates: HashMap<String, Template>,
+    template_sources:
+        HashMap<String, Box<dyn Source<Item = Template, Error = TemplateError> + 'reg>>,
+
     helpers: HashMap<String, Box<dyn HelperDef + Send + Sync + 'reg>>,
     decorators: HashMap<String, Box<dyn DecoratorDef + Send + Sync + 'reg>>,
     escape_fn: EscapeFn,
@@ -417,6 +421,7 @@ impl<'reg> Registry<'reg> {
         self.templates.clear();
     }
 
+    #[inline]
     fn render_to_output<O>(
         &self,
         name: &str,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -381,20 +381,13 @@ impl<'reg> Registry<'reg> {
                 .get(name)
                 .map(Cow::Borrowed)
                 .ok_or_else(|| RenderError::new(format!("Template not found: {}", name)))
+        } else if let Some(source) = self.template_sources.get(name) {
+            source.load().map(Cow::Owned).map_err(RenderError::from)
         } else {
-            if let Some(source) = self.template_sources.get(name) {
-                source
-                    .load()
-                    .map(Cow::Owned)
-                    .map_err(RenderError::from)
-                    .into()
-            } else {
-                self.templates
-                    .get(name)
-                    .map(Cow::Borrowed)
-                    .ok_or_else(|| RenderError::new(format!("Template not found: {}", name)))
-                    .into()
-            }
+            self.templates
+                .get(name)
+                .map(Cow::Borrowed)
+                .ok_or_else(|| RenderError::new(format!("Template not found: {}", name)))
         }
     }
 
@@ -497,7 +490,7 @@ impl<'reg> Registry<'reg> {
             tpl.render(self, &ctx, &mut render_context, &mut out)?;
         }
 
-        out.into_string().map_err(|e| RenderError::from(e))
+        out.into_string().map_err(RenderError::from)
     }
 
     /// Render a template string using current registry without registering it

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -413,7 +413,7 @@ impl<'reg> Registry<'reg> {
         if let (true, Some(source)) = (self.dev_mode, self.script_sources.get(name)) {
             return source
                 .load()
-                .map_err(|e| ScriptError::from(e))
+                .map_err(ScriptError::from)
                 .and_then(|s| {
                     let helper = Box::new(ScriptHelper {
                         script: self.engine.compile(&s)?,
@@ -423,7 +423,7 @@ impl<'reg> Registry<'reg> {
                 .map_err(RenderError::from);
         }
 
-        Ok(self.helpers.get(name).map(|v| v.clone()))
+        Ok(self.helpers.get(name).cloned())
     }
 
     #[inline]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -994,11 +994,8 @@ mod test {
     fn test_script_helper() {
         let mut reg = Registry::new();
 
-        reg.register_script_helper(
-            "acc",
-            "params.reduce(|sum, x| if sum.type_of() == \"()\" { x } else { x + sum} )",
-        )
-        .unwrap();
+        reg.register_script_helper("acc", "params.reduce(|sum, x| x + sum, || 0 )")
+            .unwrap();
 
         assert_eq!(
             reg.render_template("{{acc 1 2 3 4}}", &json!({})).unwrap(),
@@ -1016,11 +1013,7 @@ mod test {
         let file1_path = dir.path().join("acc.rhai");
         {
             let mut file1: File = File::create(&file1_path).unwrap();
-            write!(
-                file1,
-                "params.reduce(|sum, x| if sum.type_of() == \"()\" {{ x }} else {{ x + sum }} )"
-            )
-            .unwrap();
+            write!(file1, "params.reduce(|sum, x| x + sum, || 0 )").unwrap();
         }
 
         reg.register_script_helper_file("acc", &file1_path).unwrap();
@@ -1032,11 +1025,7 @@ mod test {
 
         {
             let mut file1: File = File::create(&file1_path).unwrap();
-            write!(
-                file1,
-                "params.reduce(|sum, x| if sum.type_of() == \"()\" {{ x }} else {{ x * sum }} )"
-            )
-            .unwrap();
+            write!(file1, "params.reduce(|sum, x| x * sum, || 1 )").unwrap();
         }
 
         assert_eq!(

--- a/src/render.rs
+++ b/src/render.rs
@@ -887,7 +887,7 @@ fn test_template() {
     let template = Template {
         elements,
         name: None,
-        mapping: None,
+        mapping: Vec::new(),
     };
 
     {

--- a/src/render.rs
+++ b/src/render.rs
@@ -624,11 +624,9 @@ impl Renderable for Template {
             t.render(registry, ctx, rc, out).map_err(|mut e| {
                 // add line/col number if the template has mapping data
                 if e.line_no.is_none() {
-                    if let Some(ref mapping) = self.mapping {
-                        if let Some(&TemplateMapping(line, col)) = mapping.get(idx) {
-                            e.line_no = Some(line);
-                            e.column_no = Some(col);
-                        }
+                    if let Some(&TemplateMapping(line, col)) = self.mapping.get(idx) {
+                        e.line_no = Some(line);
+                        e.column_no = Some(col);
                     }
                 }
 
@@ -655,11 +653,9 @@ impl Evaluable for Template {
         for (idx, t) in iter.enumerate() {
             t.eval(registry, ctx, rc).map_err(|mut e| {
                 if e.line_no.is_none() {
-                    if let Some(ref mapping) = self.mapping {
-                        if let Some(&TemplateMapping(line, col)) = mapping.get(idx) {
-                            e.line_no = Some(line);
-                            e.column_no = Some(col);
-                        }
+                    if let Some(&TemplateMapping(line, col)) = self.mapping.get(idx) {
+                        e.line_no = Some(line);
+                        e.column_no = Some(col);
                     }
                 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,8 +1,5 @@
-use crate::error::{TemplateError, TemplateErrorReason};
-use crate::template::Template;
-
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Error as IOError, Read};
 use std::path::PathBuf;
 
 pub(crate) trait Source {
@@ -12,32 +9,26 @@ pub(crate) trait Source {
     fn load(&self) -> Result<Self::Item, Self::Error>;
 }
 
-pub(crate) struct FileTemplateSource {
-    name: String,
+pub(crate) struct FileSource {
     path: PathBuf,
 }
 
-impl FileTemplateSource {
-    pub(crate) fn new(path: PathBuf, name: String) -> FileTemplateSource {
-        FileTemplateSource { path, name }
+impl FileSource {
+    pub(crate) fn new(path: PathBuf) -> FileSource {
+        FileSource { path }
     }
 }
 
-impl Source for FileTemplateSource {
-    type Item = Template;
-    type Error = TemplateError;
+impl Source for FileSource {
+    type Item = String;
+    type Error = IOError;
 
     fn load(&self) -> Result<Self::Item, Self::Error> {
-        let mut reader =
-            BufReader::new(File::open(&self.path).map_err(|e| {
-                TemplateError::of(TemplateErrorReason::IoError(e, self.name.clone()))
-            })?);
+        let mut reader = BufReader::new(File::open(&self.path)?);
 
         let mut buf = String::new();
-        reader
-            .read_to_string(&mut buf)
-            .map_err(|e| TemplateError::of(TemplateErrorReason::IoError(e, self.name.clone())))?;
+        reader.read_to_string(&mut buf)?;
 
-        Template::compile_with_name(buf, self.name.clone())
+        Ok(buf)
     }
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,0 +1,38 @@
+use crate::error::TemplateError;
+use crate::template::Template;
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+pub(crate) trait Source {
+    type Item;
+    type Error;
+
+    fn load(&mut self) -> Result<Self::Item, Self::Error>;
+}
+
+pub(crate) struct FileTemplateSource {
+    path: Path,
+}
+
+impl FileTemplateSource {
+    fn new(path: Path) -> FileTemplateSource {
+        FileTemplateSource { path }
+    }
+}
+
+impl Source for FileTemplateSource {
+    type Item = Template;
+    type Error = TemplateError;
+
+    fn load(&mut self) -> Result<Self::Item, Self::Error> {
+        let mut reader = BufReader::new(
+            File::open(tpl_path).map_err(|e| TemplateFileError::IOError(e, name.to_owned()))?,
+        );
+        let mut buf = String::new();
+        tpl_source
+            .read_to_string(&mut buf)
+            .map_err(|e| TemplateFileError::IOError(e, name.to_owned()))?;
+    }
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -18,7 +18,7 @@ use self::TemplateElement::*;
 pub struct TemplateMapping(pub usize, pub usize);
 
 /// A handlebars template
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Default)]
 pub struct Template {
     pub name: Option<String>,
     pub elements: Vec<TemplateElement>,
@@ -168,11 +168,7 @@ impl Parameter {
 
 impl Template {
     pub fn new() -> Template {
-        Template {
-            elements: Vec::new(),
-            name: None,
-            mapping: Vec::new(),
-        }
+        Template::default()
     }
 
     fn push_element(&mut self, e: TemplateElement, line: usize, col: usize) {

--- a/src/template.rs
+++ b/src/template.rs
@@ -831,12 +831,11 @@ fn test_parse_block_partial_path_identifier() {
 fn test_parse_error() {
     let source = "{{#ifequals name compare=\"hello\"}}\nhello\n\t{{else}}\ngood";
 
-    let t = Template::compile(source.to_string());
+    let terr = Template::compile(source.to_string()).unwrap_err();
 
-    assert_eq!(
-        t.unwrap_err(),
-        TemplateError::of(TemplateErrorReason::InvalidSyntax).at(source, 4, 5)
-    );
+    assert!(matches!(terr.reason, TemplateErrorReason::InvalidSyntax));
+    assert_eq!(terr.line_no.unwrap(), 4);
+    assert_eq!(terr.column_no.unwrap(), 5);
 }
 
 #[test]
@@ -1017,16 +1016,12 @@ fn test_literal_parameter_parser() {
 
 #[test]
 fn test_template_mapping() {
-    match Template::compile2("hello\n  {{~world}}\n{{#if nice}}\n\thello\n{{/if}}", true) {
+    match Template::compile("hello\n  {{~world}}\n{{#if nice}}\n\thello\n{{/if}}") {
         Ok(t) => {
-            if let Some(ref mapping) = t.mapping {
-                assert_eq!(mapping.len(), t.elements.len());
-                assert_eq!(mapping[0], TemplateMapping(1, 1));
-                assert_eq!(mapping[1], TemplateMapping(2, 3));
-                assert_eq!(mapping[3], TemplateMapping(3, 1));
-            } else {
-                panic!("should contains mapping");
-            }
+            assert_eq!(t.mapping.len(), t.elements.len());
+            assert_eq!(t.mapping[0], TemplateMapping(1, 1));
+            assert_eq!(t.mapping[1], TemplateMapping(2, 3));
+            assert_eq!(t.mapping[3], TemplateMapping(3, 1));
         }
         Err(e) => panic!("{}", e),
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -279,11 +279,7 @@ impl Template {
         Ok((key, value))
     }
 
-    fn parse_block_param<'a, I>(
-        _: &'a str,
-        it: &mut Peekable<I>,
-        limit: usize,
-    ) -> Result<BlockParam, TemplateError>
+    fn parse_block_param<'a, I>(_: &'a str, it: &mut Peekable<I>, limit: usize) -> BlockParam
     where
         I: Iterator<Item = Pair<'a, Rule>>,
     {
@@ -303,9 +299,9 @@ impl Template {
 
         if let Some(p2) = p2 {
             it.next();
-            Ok(BlockParam::Pair((Parameter::Name(p1), Parameter::Name(p2))))
+            BlockParam::Pair((Parameter::Name(p1), Parameter::Name(p2)))
         } else {
-            Ok(BlockParam::Single(Parameter::Name(p1)))
+            BlockParam::Single(Parameter::Name(p1))
         }
     }
 
@@ -356,7 +352,7 @@ impl Template {
                     hashes.insert(key, value);
                 }
                 Rule::block_param => {
-                    block_param = Some(Template::parse_block_param(source, it.by_ref(), end)?);
+                    block_param = Some(Template::parse_block_param(source, it.by_ref(), end));
                 }
                 Rule::pro_whitespace_omitter => {
                     omit_pro_ws = true;


### PR DESCRIPTION
This patch adds a new concept in handlebars called dev mode. In dev mode, we will enable some development friendly features.

The first dev mode feature is template auto-reload. In dev-mode, templates that registered from files or directory, are not cached . Changes made in template file will be reflected immediately without restart your server.

In addition to dev mode, I made template mapping a default feature since it's useful to debug any template error in any scenario.

- [x] tests for dev mode and template reload
- [x] script reload support and tests
- [x] docs
- [x] example for dev mode
- [x] changelog for breaking changes