### PR TITLE
Remove line separator for invisible elements

### DIFF
--- a/examples/decorator/template.hbs
+++ b/examples/decorator/template.hbs
@@ -7,12 +7,12 @@
   <body>
     <h1>CSL {{year}}</h1>
     <ul>
-    {{#each teams as |t| ~}}
+    {{#each teams as |t|}}
       <li class="{{ranking_label @index ../teams}}">
       {{~log @index~}}
       <b>{{t.name}}</b>: {{format t.pts ~}}
       </li>
-    {{/each~}}
+    {{/each}}
     </ul>
 
     {{*set version="v3.0"}}

--- a/examples/error/template.hbs
+++ b/examples/error/template.hbs
@@ -5,13 +5,13 @@
   <body>
     <h1>CSL {{year}}</h1>
     <ul>
-      {{#each teams as |t| ~}}
+      {{#each teams as |t|}}
       {{! ranking_label will produce a render error when first parameter is not a number }}
       <li class="{{ranking_label true ../teams}}">
       {{~log @index~}}
       <b>{{t.name}}</b>: {{format t.pts ~}}
       </li>
-    {{/each~}}
+    {{/each}}
     </ul>
 
     <p>Rendered by Handlebars from {{engine}} data.</p>

--- a/examples/partials/base0.hbs
+++ b/examples/partials/base0.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base0.hbs</h1></div>
-    {{~> page}}
+    {{> page}}
   </body>
 </html>

--- a/examples/partials/base1.hbs
+++ b/examples/partials/base1.hbs
@@ -2,6 +2,6 @@
   <head>{{title}}</head>
   <body>
     <div><h1>Derived from base1.hbs</h1></div>
-    {{~> page}}
+    {{> page}}
   </body>
 </html>

--- a/examples/partials/template2.hbs
+++ b/examples/partials/template2.hbs
@@ -1,5 +1,4 @@
 {{#*inline "page"}}
   <p>Rendered in partial, parent is {{parent}}</p>
 {{/inline}}
-{{! remove whitespaces with ~ }}
-{{~> (parent)~}}
+{{> (parent)}}

--- a/examples/render/template.hbs
+++ b/examples/render/template.hbs
@@ -5,12 +5,12 @@
   <body>
     <h1>CSL {{year}}</h1>
     <ul>
-    {{#each teams as |t| ~}}
+    {{#each teams as |t|}}
       <li class="{{ranking_label @index ../teams}}">
       {{~log @index~}}
       <b>{{t.name}}</b>: {{format t.pts ~}}
       </li>
-    {{/each~}}
+    {{/each}}
     </ul>
 
     <p>Rendered by Handlebars from {{engine}} data.</p>

--- a/examples/script/template.hbs
+++ b/examples/script/template.hbs
@@ -1,10 +1,10 @@
 Bundesliga Match Day
-{{#each this as |match| ~}}
+{{#each this as |match|}}
   {{#each match as |team|}}
     {{team.name}} - {{score team.goals}}
     {{#each team.goals as |scorer|}}
       > {{scorer}}
     {{/each}}
-  {{~ /each}}
+  {{/each}}
   ---
 {{/each}}

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -56,36 +56,36 @@ pro_whitespace_omitter? ~ "}}" }
 partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
                      ~ pro_whitespace_omitter? ~ "}}" }
 invert_tag_item = { "else"|"^" }
-invert_tag = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
-             ~ pro_whitespace_omitter? ~ "}}"}
-helper_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
-                     pro_whitespace_omitter? ~ "}}" }
-helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                   pro_whitespace_omitter? ~ "}}" }
+invert_tag = { !escape ~ PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
+             ~ pro_whitespace_omitter? ~ "}}" ~ POP }
+helper_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
+                     pro_whitespace_omitter? ~ "}}" ~ POP }
+helper_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                   pro_whitespace_omitter? ~ "}}" ~ POP }
 helper_block = _{ helper_block_start ~ template ~
                   (invert_tag ~ template)? ~ helper_block_end }
 
-decorator_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
-                        ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-decorator_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                        pro_whitespace_omitter? ~ "}}" }
+decorator_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
+                        ~ exp_line ~ pro_whitespace_omitter? ~ "}}" ~ POP }
+decorator_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                        pro_whitespace_omitter? ~ "}}" ~ POP }
 decorator_block = _{ decorator_block_start ~ template ~
                      decorator_block_end }
 
-partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
-                        ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
-partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
-                      pro_whitespace_omitter? ~ "}}" }
+partial_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
+                        ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" ~ POP }
+partial_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
+                      pro_whitespace_omitter? ~ "}}" ~ POP }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
-raw_block_start = { "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
-                    pro_whitespace_omitter? ~ "}}}}" }
-raw_block_end = { "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                  pro_whitespace_omitter? ~ "}}}}" }
+raw_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
+                    pro_whitespace_omitter? ~ "}}}}" ~ POP }
+raw_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                  pro_whitespace_omitter? ~ "}}}}" ~ POP }
 raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
-hbs_comment = { "{{!--" ~ (!"--}}" ~ ANY)* ~ "--}}" }
-hbs_comment_compact = { "{{!" ~ (!"}}" ~ ANY)* ~ "}}" }
+hbs_comment = { PUSH(LINE_SEPARATOR?) ~ "{{!--" ~ (!"--}}" ~ ANY)* ~ "--}}" ~ POP }
+hbs_comment_compact = { PUSH(LINE_SEPARATOR?) ~ "{{!" ~ (!"}}" ~ ANY)* ~ "}}" ~ POP }
 
 template = { (
             raw_text |

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -55,37 +55,45 @@ decorator_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
 pro_whitespace_omitter? ~ "}}" }
 partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
                      ~ pro_whitespace_omitter? ~ "}}" }
+
+brackets_open = @{ ("\r"? ~ "\n" ~ (" "|"\t")*)? ~ "{{" }
+brackets_close = @{ "}}" ~ ((" "|"\t")* ~ "\r"? ~ "\n")? }
+
 invert_tag_item = { "else"|"^" }
-invert_tag = { !escape ~ PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
-             ~ pro_whitespace_omitter? ~ "}}" ~ POP }
-helper_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
-                     pro_whitespace_omitter? ~ "}}" ~ POP }
-helper_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                   pro_whitespace_omitter? ~ "}}" ~ POP }
+invert_tag = { !escape ~ brackets_open ~ pre_whitespace_omitter? ~ invert_tag_item
+             ~ pro_whitespace_omitter? ~ brackets_close }
+helper_block_start = { brackets_open ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
+                     pro_whitespace_omitter? ~ brackets_close }
+helper_block_end = { brackets_open ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                   pro_whitespace_omitter? ~ brackets_close }
 helper_block = _{ helper_block_start ~ template ~
                   (invert_tag ~ template)? ~ helper_block_end }
 
-decorator_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
-                        ~ exp_line ~ pro_whitespace_omitter? ~ "}}" ~ POP }
-decorator_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                        pro_whitespace_omitter? ~ "}}" ~ POP }
+decorator_block_start = { brackets_open ~ pre_whitespace_omitter? ~ "#" ~ "*"
+                        ~ exp_line ~ pro_whitespace_omitter? ~ brackets_close }
+decorator_block_end = { brackets_open ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                        pro_whitespace_omitter? ~ brackets_close }
 decorator_block = _{ decorator_block_start ~ template ~
                      decorator_block_end }
 
-partial_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
-                        ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" ~ POP }
-partial_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{" ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
-                      pro_whitespace_omitter? ~ "}}" ~ POP }
+partial_block_start = { brackets_open ~ pre_whitespace_omitter? ~ "#" ~ ">"
+                        ~ partial_exp_line ~ pro_whitespace_omitter? ~ brackets_close }
+partial_block_end = { brackets_open ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
+                      pro_whitespace_omitter? ~ brackets_close }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
-raw_block_start = { PUSH(LINE_SEPARATOR?) ~ "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
-                    pro_whitespace_omitter? ~ "}}}}" ~ POP }
-raw_block_end = { PUSH(LINE_SEPARATOR?) ~ "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                  pro_whitespace_omitter? ~ "}}}}" ~ POP }
+double_brackets_open = @{ ("\r"? ~ "\n" ~ (" "|"\t")*)? ~ "{{{{" }
+double_brackets_close = @{ "}}}}" ~ ((" "|"\t")* ~ "\r"? ~ "\n")? }
+
+raw_block_start = { double_brackets_open ~ pre_whitespace_omitter? ~ exp_line ~
+                    pro_whitespace_omitter? ~ double_brackets_close }
+raw_block_end = { double_brackets_open ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
+                  pro_whitespace_omitter? ~ double_brackets_close }
 raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
-hbs_comment = { PUSH(LINE_SEPARATOR?) ~ "{{!--" ~ (!"--}}" ~ ANY)* ~ "--}}" ~ POP }
-hbs_comment_compact = { PUSH(LINE_SEPARATOR?) ~ "{{!" ~ (!"}}" ~ ANY)* ~ "}}" ~ POP }
+comment_brackets_open = @{ ("\r"? ~ "\n" ~ (" "|"\t")*)? ~ "{{!" }
+hbs_comment = { comment_brackets_open ~ "--" ~ (!"--}}" ~ ANY)* ~ "--" ~ brackets_close }
+hbs_comment_compact = { comment_brackets_open ~ (!"}}" ~ ANY)* ~ brackets_close }
 
 template = { (
             raw_text |

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -56,8 +56,8 @@ pro_whitespace_omitter? ~ "}}" }
 partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
                      ~ pro_whitespace_omitter? ~ "}}" }
 
-brackets_open = @{ ("\r"? ~ "\n" ~ (" "|"\t")*)? ~ "{{" }
-brackets_close = @{ "}}" ~ ((" "|"\t")* ~ "\r"? ~ "\n")? }
+brackets_open = @{ (NEWLINE ~ (" "|"\t")*)? ~ "{{" }
+brackets_close = @{ "}}" ~ ((" "|"\t")* ~ NEWLINE)? }
 
 invert_tag_item = { "else"|"^" }
 invert_tag = { !escape ~ brackets_open ~ pre_whitespace_omitter? ~ invert_tag_item
@@ -82,8 +82,8 @@ partial_block_end = { brackets_open ~ pre_whitespace_omitter? ~ "/" ~ partial_id
                       pro_whitespace_omitter? ~ brackets_close }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
-double_brackets_open = @{ ("\r"? ~ "\n" ~ (" "|"\t")*)? ~ "{{{{" }
-double_brackets_close = @{ "}}}}" ~ ((" "|"\t")* ~ "\r"? ~ "\n")? }
+double_brackets_open = @{ (NEWLINE ~ (" "|"\t")*)? ~ "{{{{" }
+double_brackets_close = @{ "}}}}" ~ ((" "|"\t")* ~ NEWLINE)? }
 
 raw_block_start = { double_brackets_open ~ pre_whitespace_omitter? ~ exp_line ~
                     pro_whitespace_omitter? ~ double_brackets_close }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -145,7 +145,9 @@ mod test {
         let s = vec!["{{!-- <hello {{ a-b c-d}} {{d-c}} ok --}}",
                  "{{!--
                     <li><a href=\"{{up-dir nest-count}}{{base-url}}index.html\">{{this.title}}</a></li>
-                --}}"];
+                --}}",
+                     "\r\n     {{!-- yes --}}    \r\n",
+                     "{{!    -- good  --}}"];
         for i in s.iter() {
             assert_rule!(Rule::hbs_comment, i);
         }
@@ -227,6 +229,8 @@ mod test {
             "{{#each assets}}",
             "\n{{#each assets}}\n",
             "\r\n{{#each assets}}\r\n",
+            "\r\n      {{#each assets}}\r\n",
+            "\r\n\t\t{{#each assets}}\r\n",
         ];
         for i in s.iter() {
             assert_rule!(Rule::helper_block_start, i);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -225,6 +225,8 @@ mod test {
             "{{#each people as |person|}}",
             "{{#each-obj obj as |val key|}}",
             "{{#each assets}}",
+            "\n{{#each assets}}\n",
+            "\r\n{{#each assets}}\r\n",
         ];
         for i in s.iter() {
             assert_rule!(Rule::helper_block_start, i);
@@ -252,6 +254,7 @@ mod test {
             "{{#if}}hello{{else~}}world{{/if}}",
             "{{#if}}hello{{~^~}}world{{/if}}",
             "{{#if}}{{/if}}",
+            "\r\n{{#if}}\r\n\r\n{{/if}}\r\n",
         ];
         for i in s.iter() {
             assert_rule!(Rule::helper_block, i);
@@ -263,6 +266,7 @@ mod test {
         let s = vec![
             "{{{{if hello}}}}good {{hello}}{{{{/if}}}}",
             "{{{{if hello}}}}{{#if nice}}{{/if}}{{{{/if}}}}",
+            "\n{{{{if hello}}}}\n{{#if nice}}{{/if}}{{{{/if}}}}",
         ];
         for i in s.iter() {
             assert_rule!(Rule::raw_block, i);

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -126,4 +126,14 @@ mod test {
                 .unwrap()
         );
     }
+
+    #[test]
+    fn test_invisible_line_stripping() {
+        let hbs = Registry::new();
+        assert_eq!(
+            "yes\n",
+            hbs.render_template("{{#if a}}\nyes\n{{/if}}\n", &json!({"a": true}))
+                .unwrap()
+        );
+    }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -441,7 +441,18 @@ impl Template {
         // remove escape from our pair queue
         let mut it = parser_queue
             .flatten()
-            .filter(|p| p.as_rule() != Rule::escape)
+            .filter(|p| {
+                // remove rules that should be silent but not for now due to pest limitation
+                !matches!(
+                    p.as_rule(),
+                    Rule::escape
+                        | Rule::brackets_open
+                        | Rule::brackets_close
+                        | Rule::double_brackets_open
+                        | Rule::double_brackets_close
+                        | Rule::comment_brackets_open
+                )
+            })
             .peekable();
         let mut end_pos: Option<Position<'_>> = None;
         loop {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1025,7 +1025,9 @@ fn test_whitespace_elements() {
         "  {{elem}}\n\t{{#if true}} \
          {{/if}}\n{{{{raw}}}} {{{{/raw}}}}\n{{{{raw}}}}{{{{/raw}}}}\n",
     );
-    assert_eq!(c.ok().unwrap().elements.len(), 9);
+    let r = c.unwrap();
+    // the \n after last raw block is dropped by pest
+    assert_eq!(r.elements.len(), 6);
 }
 
 #[test]


### PR DESCRIPTION
This patch is an attempt to fix #258 with pest grammar. 

The draw back of current solution is it removed whitespaces after `}}` even if there is no line separator. Therefore this is going to be a break change. Case like

```handlebars
{{#each a}}{{this}}{{/each}} {{b}}
```
```json
{"a": [1,2,3,4], "b": "good"}
```

Now renders as `1234good` instead of `1234 good`.

I'm trying to figure out if there is any solution to retain these whitespaces.

Update: the issue is fixed via 181565f

