### PR TITLE
(doc) mention no_escape() in the "Escaping" section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@
 //!
 //! #### Escaping
 //!
-//! As per the handlebars spec, output using `{{expression}}` is escaped by default (to be precise, the characters `&"<>` are replaced by their respective html / xml entities). However, since the use cases of a rust template engine are probably a bit more diverse than those of a JavaScript one, this implementation allows the user to supply a custom escape function to be used instead. For more information see the `EscapeFn` type and `Handlebars::register_escape_fn()` method.
+//! As per the handlebars spec, output using `{{expression}}` is escaped by default (to be precise, the characters `&"<>` are replaced by their respective html / xml entities). However, since the use cases of a rust template engine are probably a bit more diverse than those of a JavaScript one, this implementation allows the user to supply a custom escape function to be used instead. For more information see the `EscapeFn` type and `Handlebars::register_escape_fn()` method. In particular, `no_escape()` can be used as the escape function if no escaping at all should be performed.
 //!
 //! ### Custom Helper
 //!


### PR DESCRIPTION
This seems to be by far the most popular argument when calling
register_escape_fn(), judging from GitHub code search, and so it seems
worthwhile to mention it here to avoid the need for the people to write
their own trivial escape function doing nothing only to discover that
such function already exists in Handlebars itself.

---

A really trivial PR just to save some time to the others who might also waste time as I did before discovering `no_escape()`.