### PR TITLE
(fix) fix upper-case acronyms where it is possible

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -250,7 +250,7 @@ impl fmt::Display for TemplateError {
 quick_error! {
     #[derive(Debug)]
     pub enum ScriptError {
-        IOError(err: IOError) {
+        IoError(err: IOError) {
             from()
             source(err)
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -761,8 +761,8 @@ impl Renderable for TemplateElement {
                 out.write(v.as_ref())?;
                 Ok(())
             }
-            Expression(ref ht) | HTMLExpression(ref ht) => {
-                let is_html_expression = matches!(self, HTMLExpression(_));
+            Expression(ref ht) | HtmlExpression(ref ht) => {
+                let is_html_expression = matches!(self, HtmlExpression(_));
                 if is_html_expression {
                     rc.set_disable_escape(true);
                 }
@@ -883,7 +883,7 @@ fn test_expression() {
 #[test]
 fn test_html_expression() {
     let r = Registry::new();
-    let element = HTMLExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
+    let element = HtmlExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
         &["hello"],
     ))));
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -602,7 +602,7 @@ impl Template {
                                 let el = if rule == Rule::expression {
                                     Expression(Box::new(helper_template))
                                 } else {
-                                    HTMLExpression(Box::new(helper_template))
+                                    HtmlExpression(Box::new(helper_template))
                                 };
                                 let t = template_stack.front_mut().unwrap();
                                 t.push_element(el, line_no, col_no);
@@ -722,7 +722,7 @@ impl Template {
 #[derive(PartialEq, Clone, Debug)]
 pub enum TemplateElement {
     RawString(String),
-    HTMLExpression(Box<HelperTemplate>),
+    HtmlExpression(Box<HelperTemplate>),
     Expression(Box<HelperTemplate>),
     HelperBlock(Box<HelperTemplate>),
     DecoratorExpression(Box<DecoratorTemplate>),
@@ -781,7 +781,7 @@ fn test_parse_template() {
 
     assert_eq!(
         *t.elements.get(3).unwrap(),
-        HTMLExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
+        HtmlExpression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
             &["content"],
         ))))
     );


### PR DESCRIPTION
Adopt new clippy rules on uppercase symbol name