### PR TITLE
Fix out of bounds index when parsing JSON path

### DIFF
--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -74,7 +74,7 @@ fn get_local_path_and_level(paths: &[PathSeg]) -> Option<(usize, String)> {
     paths.get(0).and_then(|seg| {
         if seg == &PathSeg::Ruled(Rule::path_local) {
             let mut level = 0;
-            while paths[level + 1] == PathSeg::Ruled(Rule::path_up) {
+            while paths.get(level + 1)? == &PathSeg::Ruled(Rule::path_up) {
                 level += 1;
             }
             if let Some(PathSeg::Named(name)) = paths.get(level + 1) {

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -53,3 +53,17 @@ fn test_subexpression() {
         "Success"
     );
 }
+
+#[test]
+fn invalid_json_path() {
+    // The data here is not important
+    let data = &Vec::<()>::new();
+
+    let hbs = Handlebars::new();
+
+    let error = hbs.render_template("{{x[]@this}}", &data).unwrap_err();
+
+    let expected = "Error rendering \"Unnamed template\" line 1, col 1: Helper not defined: \"x\"";
+
+    assert_eq!(format!("{}", error), expected);
+}


### PR DESCRIPTION
Fixes a bug I found when running the fuzzer for a bit after #427 was fixed

Not sure if the test here is in the right place or if you want me to put it in with the other test function.

Ran the fuzzer for a while after this and didn't see any issues. I'll make a new PR for the fuzzing target (or just lump it in here) if you want, it uses [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz).