### PR TITLE
Add fuzzing harness

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "handlebars-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.handlebars]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "render_template_no_data"
+path = "fuzz_targets/render_template_no_data.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/render_template_no_data.rs
+++ b/fuzz/fuzz_targets/render_template_no_data.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let tpl = handlebars::Handlebars::new();
+
+    let _ = tpl.render_template(&data, &Vec::<u32>::new());
+});


### PR DESCRIPTION
I get *really slow* test cases with this, so I'm guessing there's some non-linear time parsing that can cause extreme slowdowns with this.

You can specify a max length when running the fuzzer, I've found a length of 64 doesn't run into those issues and lets me test for panics, but it might be worth having a look at the slow cases, I've not been able to get a clean test case for the slowdown issue.