### PR TITLE
Standalone dot as parameter

### DIFF
--- a/examples/partials/template2.hbs
+++ b/examples/partials/template2.hbs
@@ -1,4 +1,4 @@
 {{#*inline "page"}}
   <p>Rendered in partial, parent is {{parent}}</p>
 {{/inline}}
-{{> (lookup this "parent")}}
+{{> (lookup . "parent")}}

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -32,7 +32,7 @@ path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }
 partial_identifier = @{ partial_symbol_char+ | ("[" ~ ANY+ ~ "]") | ("'" ~ (!"'" ~ ("\\'" | ANY))+ ~ "'") }
-reference = ${ path_inline }
+reference = { path_inline }
 
 name = _{ subexpression | reference }
 
@@ -127,9 +127,9 @@ path_sep = _{ "/" | "." }
 path_up = { ".." }
 path_key = _{ "[" ~  path_raw_id ~ "]" }
 path_root = { "@root" }
-path_current = _{ "this" ~ path_sep | "./" }
+path_current = @{ ("this" ~ path_sep) | "./" }
 path_item = _{ path_id|path_key }
 path_local = { "@" }
-path_this_standalone = _{ "." }
+path_current_standalone = _{ "." }
 path_inline = ${ path_current? ~ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
-path = _{ (path_this_standalone ~ EOI) | (path_inline ~ EOI) }
+path = _{ (path_inline ~ EOI) | (path_current_standalone ~ EOI) }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -40,7 +40,7 @@ param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
 hash = { identifier ~ "=" ~ param }
 block_param = { "as" ~ "|" ~ identifier ~ identifier? ~ "|"}
 exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
-partial_exp_line = _{ ((partial_identifier|name) ~ (hash|param)*) }
+partial_exp_line = _{ (partial_identifier|name) ~ (hash|param)* }
 
 subexpression = { "(" ~ ((identifier ~ (hash|param)+) | reference)  ~ ")" }
 
@@ -130,5 +130,6 @@ path_root = { "@root" }
 path_current = _{ "this" ~ path_sep | "./" }
 path_item = _{ path_id|path_key }
 path_local = { "@" }
+path_this_standalone = _{ "." }
 path_inline = ${ path_current? ~ (path_root ~ path_sep)? ~ path_local? ~ (path_up ~ path_sep)*  ~ path_item ~ (path_sep ~  path_item)* }
-path = _{ path_inline ~ EOI }
+path = _{ (path_this_standalone ~ EOI) | (path_inline ~ EOI) }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -183,6 +183,7 @@ mod test {
             "{{exp key=(sub)}}",
             "{{exp key=(sub 0)}}",
             "{{exp key=(sub 0 key=1)}}",
+            "{{exp .}}",
         ];
         for i in s.iter() {
             assert_rule!(Rule::expression, i);
@@ -306,6 +307,8 @@ mod test {
             "[foo]",
             "@root/a/b",
             "nullable",
+            ".",
+            "this",
         ];
         for i in s.iter() {
             assert_rule_match!(Rule::path, i);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -85,6 +85,8 @@ mod test {
             "[$id]",
             "$id",
             "this.[null]",
+            ".",
+            "this",
         ];
         for i in s.iter() {
             assert_rule!(Rule::reference, i);


### PR DESCRIPTION
This changeset attempts to add support for standalone dot as a valid parameter in current parser.