### PR TITLE
Fix: Calling each on empty iterator without else block

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -80,7 +80,9 @@ impl HelperDef for EachHelper {
 
         match template {
             Some(t) => match *value.value() {
-                Json::Array(ref list) if !list.is_empty() => {
+                Json::Array(ref list)
+                    if !list.is_empty() || (list.is_empty() && h.inverse().is_none()) =>
+                {
                     let block_context = create_block(&value);
                     rc.push_block(block_context);
 
@@ -108,7 +110,9 @@ impl HelperDef for EachHelper {
                     rc.pop_block();
                     Ok(())
                 }
-                Json::Object(ref obj) if !obj.is_empty() => {
+                Json::Object(ref obj)
+                    if !obj.is_empty() || (obj.is_empty() && h.inverse().is_none()) =>
+                {
                     let block_context = create_block(&value);
                     rc.push_block(block_context);
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -162,6 +162,19 @@ mod test {
     use std::str::FromStr;
 
     #[test]
+    fn test_empty_each() {
+        let mut hbs = Registry::new();
+        hbs.set_strict_mode(true);
+
+        let data = json!({
+            "a": [ ],
+        });
+
+        let template = "{{#each a}}each{{/each}}";
+        assert_eq!(hbs.render_template(template, &data).unwrap(), "");
+    }
+
+    #[test]
     fn test_each() {
         let mut handlebars = Registry::new();
         assert!(handlebars


### PR DESCRIPTION
I added this test because updating from `3` to `4` broke my software in a weird way, where a variable was noted as not there, but it was there.

So here's a test to check whether things still work with empty iterables in the `#each` helper, because I was not able to get my local clone to run through `cargo test` (some weird issue with pprof not compiling... I don't know. The quick fix is to push this through github actions).