### PR TITLE
Export `push_partial_block` and `pop_partial_block`

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -177,11 +177,11 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
         self.inner_mut().partials.insert(name, partial);
     }
 
-    pub(crate) fn push_partial_block(&mut self, partial: &'reg Template) {
+    pub fn push_partial_block(&mut self, partial: &'reg Template) {
         self.inner_mut().partial_block_stack.push_front(partial);
     }
 
-    pub(crate) fn pop_partial_block(&mut self) {
+    pub fn pop_partial_block(&mut self) {
         self.inner_mut().partial_block_stack.pop_front();
     }
 


### PR DESCRIPTION
This allows custom helpers to manipulate the `@partial-block` variable.