### PR TITLE
Helper tag with leading whitespaces fix

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -15,8 +15,9 @@ pub(crate) fn newline_matcher(c: char) -> bool {
 }
 
 pub(crate) fn ends_with_empty_line(text: &str) -> bool {
-    text.trim_end_matches(whitespace_matcher)
-        .ends_with(newline_matcher)
+    let s = text.trim_end_matches(whitespace_matcher);
+    // also matches when text is just whitespaces
+    s.ends_with(newline_matcher) || s.is_empty()
 }
 
 pub(crate) fn starts_with_empty_line(text: &str) -> bool {

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -153,10 +153,10 @@ mod test {
   bar
   baz"#,
             hbs.render_template(
-                r#"{{~#if true}}
+                r#"  {{#if true}}
   foo
   bar
-{{/if}}
+  {{/if}}
   baz"#,
                 &json!({})
             )

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -137,6 +137,12 @@ mod test {
         );
 
         assert_eq!(
+            "yes\r\n",
+            hbs.render_template("{{#if a}}\r\nyes\r\n{{/if}}\r\n", &json!({"a": true}))
+                .unwrap()
+        );
+
+        assert_eq!(
             "x\ny",
             hbs.render_template("{{#if a}}x{{/if}}\ny", &json!({"a": true}))
                 .unwrap()

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -149,6 +149,23 @@ mod test {
         );
 
         assert_eq!(
+            r#"yes
+  foo
+  bar
+  baz"#,
+            hbs.render_template(
+                r#"yes
+  {{#if true}}
+  foo
+  bar
+  {{/if}}
+  baz"#,
+                &json!({})
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
             r#"  foo
   bar
   baz"#,

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -147,5 +147,20 @@ mod test {
             hbs.render_template("{{#if a}}\nx\n{{^}}\ny\n{{/if}}\nz", &json!({"a": false}))
                 .unwrap()
         );
+
+        assert_eq!(
+            r#"  foo
+  bar
+  baz"#,
+            hbs.render_template(
+                r#"{{~#if true}}
+  foo
+  bar
+{{/if}}
+  baz"#,
+                &json!({})
+            )
+            .unwrap()
+        );
     }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -330,4 +330,30 @@ mod test {
             "fruit: carrot,fruit: tomato,"
         );
     }
+
+    #[test]
+    fn line_stripping_with_inline_and_partial() {
+        let tpl0 = r#"{{#*inline "foo"}}foo
+{{/inline}}
+{{> foo}}
+{{> foo}}
+{{> foo}}"#;
+        let tpl1 = r#"{{#*inline "foo"}}foo{{/inline}}
+{{> foo}}
+{{> foo}}
+{{> foo}}"#;
+
+        let hbs = Registry::new();
+        assert_eq!(
+            r#"foo
+foo
+foo
+"#,
+            hbs.render_template(tpl0, &json!({})).unwrap()
+        );
+        assert_eq!(
+            r#"foofoofoo"#,
+            hbs.render_template(tpl1, &json!({})).unwrap()
+        );
+    }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -352,7 +352,8 @@ foo
             hbs.render_template(tpl0, &json!({})).unwrap()
         );
         assert_eq!(
-            r#"foofoofoo"#,
+            r#"
+foofoofoo"#,
             hbs.render_template(tpl1, &json!({})).unwrap()
         );
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -682,6 +682,14 @@ impl Template {
                                 t.push_element(el, line_no, col_no);
                             }
                             Rule::decorator_expression | Rule::partial_expression => {
+                                // standalone statement check, it also removes leading whitespaces of
+                                // previous rawstring when standalone statement detected
+                                trim_line_requiered = Template::process_standalone_statement(
+                                    &mut template_stack,
+                                    source,
+                                    &span,
+                                );
+
                                 let decorator = DecoratorTemplate {
                                     name: exp.name,
                                     params: exp.params,


### PR DESCRIPTION
This patch adds some corner cases for #448 

- statement with leading white-spaces at the beginning of the template
- partial expression (`{{> foo}}`) should follow the same pattern