### PR TITLE
Fix partial block referencing in nested partials

### DIFF
--- a/src/partial.rs
+++ b/src/partial.rs
@@ -451,4 +451,26 @@ name: there
 "#
         );
     }
+
+    #[test]
+    fn test_nested_partial() {
+        let mut hb = Registry::new();
+        hb.register_template_string("partial", "{{> @partial-block}}")
+            .unwrap();
+        hb.register_template_string(
+            "index",
+            r#"{{#>partial}}
+    Yo
+    {{#>partial}}
+    Yo 2
+    {{/partial}}
+{{/partial}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"    Yo
+    Yo 2"#,
+            hb.render("index", &()).unwrap()
+        );
+    }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -476,5 +476,19 @@ name: there
 "#,
             hb.render("index", &()).unwrap()
         );
+
+        hb.register_template_string("partial2", "{{> @partial-block}}")
+            .unwrap();
+        let r2 = hb
+            .render_template(
+                r#"{{#> partial}}
+{{#> partial2}}
+:(
+{{/partial2}}
+{{/partial}}"#,
+                &(),
+            )
+            .unwrap();
+        assert_eq!(":(\n", r2);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -190,7 +190,10 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     }
 
     pub(crate) fn dec_partial_block_depth(&mut self) {
-        self.inner_mut().partial_block_depth -= 1;
+        let depth = &mut self.inner_mut().partial_block_depth;
+        if *depth > 0 {
+            *depth -= 1;
+        }
     }
 
     /// Remove a registered partial
@@ -275,6 +278,7 @@ impl<'reg, 'rc> fmt::Debug for RenderContextInner<'reg, 'rc> {
         f.debug_struct("RenderContextInner")
             .field("partials", &self.partials)
             .field("partial_block_stack", &self.partial_block_stack)
+            .field("partial_block_depth", &self.partial_block_depth)
             .field("root_template", &self.root_template)
             .field("current_template", &self.current_template)
             .field("disable_escape", &self.disable_escape)


### PR DESCRIPTION
Fixes #487

We can only increase `patial_block_depth` for scenarios where
consecutive `@partial-block` are rendered.