### PR TITLE
Fix block param scope leaked into partials

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -45,7 +45,7 @@ fn parse_json_visitor<'a, 'reg>(
     for path_seg in relative_path {
         match path_seg {
             PathSeg::Named(the_path) => {
-                // FIXME: block params resolution for 495
+                // FIXME: partial block params resolution for 495
                 // we should not search whole block stack for the
                 // param, if there is a same name in current block
                 if let Some((holder, base_path)) = get_in_block_params(block_contexts, the_path) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -45,9 +45,6 @@ fn parse_json_visitor<'a, 'reg>(
     for path_seg in relative_path {
         match path_seg {
             PathSeg::Named(the_path) => {
-                // FIXME: partial block params resolution for 495
-                // we should not search whole block stack for the
-                // param, if there is a same name in current block
                 if let Some((holder, base_path)) = get_in_block_params(block_contexts, the_path) {
                     with_block_param = Some((holder, base_path));
                 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -45,6 +45,9 @@ fn parse_json_visitor<'a, 'reg>(
     for path_seg in relative_path {
         match path_seg {
             PathSeg::Named(the_path) => {
+                // FIXME: block params resolution for 495
+                // we should not search whole block stack for the
+                // param, if there is a same name in current block
                 if let Some((holder, base_path)) = get_in_block_params(block_contexts, the_path) {
                     with_block_param = Some((holder, base_path));
                 }
@@ -172,9 +175,6 @@ impl Context {
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         // always use absolute at the moment until we get base_value lifetime issue fixed
         let resolved_visitor = parse_json_visitor(relative_path, block_contexts, true);
-
-        // debug logging
-        debug!("Accessing context value: {:?}", resolved_visitor);
 
         match resolved_visitor {
             ResolvedPath::AbsolutePath(paths) => {

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use serde_json::value::{to_value, Value as Json};
+use serde_json::value::Value as Json;
 
 use crate::block::BlockContext;
 use crate::context::{merge_json, Context};

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -491,4 +491,33 @@ name: there
             .unwrap();
         assert_eq!(":(\n", r2);
     }
+
+    #[test]
+    fn test_partial_context_issue_495() {
+        let mut hb = Registry::new();
+        hb.register_template_string(
+            "t",
+            r#"{{~#*inline "displayName"~}}
+Template:{{name}}
+{{/inline}}
+{{#each data as |name|}}
+Name:{{name}}
+{{>displayName name="aaaa"}}
+{{/each}}"#,
+        )
+        .unwrap();
+
+        let data = json!({
+            "data": ["hudel", "test"]
+        });
+
+        assert_eq!(
+            r#"Name:hudel
+Template:aaaa
+Name:test
+Template:aaaa
+"#,
+            hb.render("t", &data).unwrap()
+        );
+    }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -79,7 +79,9 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
             let mut block = BlockContext::new();
             *block.base_path_mut() = base_path.to_vec();
             block_created = true;
-            // TODO: temporary fix
+
+            // clear blocks to prevent block params from parent
+            // template to be leaked into partials
             local_rc.clear_blocks();
             local_rc.push_block(block);
         } else if !d.hash().is_empty() {
@@ -95,10 +97,14 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
                 local_rc.evaluate2(ctx, &Path::current())?.as_json(),
                 &hash_ctx,
             );
-            // TODO: temporary fix
-            local_rc.clear_blocks();
+
             block.set_base_value(merged_context);
             block_created = true;
+
+            // clear blocks to prevent block params from parent
+            // template to be leaked into partials
+            // see `test_partial_context_issue_495` for the case.
+            local_rc.clear_blocks();
             local_rc.push_block(block);
         }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -500,7 +500,7 @@ name: there
     fn test_partial_context_issue_495() {
         let mut hb = Registry::new();
         hb.register_template_string(
-            "t",
+            "t1",
             r#"{{~#*inline "displayName"~}}
 Template:{{name}}
 {{/inline}}
@@ -511,17 +511,29 @@ Name:{{name}}
         )
         .unwrap();
 
+        hb.register_template_string(
+            "t1",
+            r#"{{~#*inline "displayName"~}}
+Template:{{this}}
+{{/inline}}
+{{#each data as |name|}}
+Name:{{name}}
+{{>displayName}}
+{{/each}}"#,
+        )
+        .unwrap();
+
         let data = json!({
             "data": ["hudel", "test"]
         });
 
         assert_eq!(
             r#"Name:hudel
-Template:aaaa
+Template:hudel
 Name:test
-Template:aaaa
+Template:test
 "#,
-            hb.render("t", &data).unwrap()
+            hb.render("t1", &data).unwrap()
         );
     }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -79,6 +79,8 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
             let mut block = BlockContext::new();
             *block.base_path_mut() = base_path.to_vec();
             block_created = true;
+            // TODO: temporary fix
+            local_rc.clear_blocks();
             local_rc.push_block(block);
         } else if !d.hash().is_empty() {
             let mut block = BlockContext::new();
@@ -89,13 +91,13 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
                 .map(|(k, v)| (*k, v.value()))
                 .collect::<HashMap<&str, &Json>>();
 
-            // let merged_context = merge_json(
-            //     // FIXME: not current path, should be current block
-            //     // context path
-            //     local_rc.evaluate2(ctx, )?.as_json(),
-            //     &hash_ctx,
-            // );
-            block.set_base_value(to_value(hash_ctx)?);
+            let merged_context = merge_json(
+                local_rc.evaluate2(ctx, &Path::current())?.as_json(),
+                &hash_ctx,
+            );
+            // TODO: temporary fix
+            local_rc.clear_blocks();
+            block.set_base_value(merged_context);
             block_created = true;
             local_rc.push_block(block);
         }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use serde_json::value::Value as Json;
+use serde_json::value::{to_value, Value as Json};
 
 use crate::block::BlockContext;
 use crate::context::{merge_json, Context};
@@ -89,11 +89,13 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
                 .map(|(k, v)| (*k, v.value()))
                 .collect::<HashMap<&str, &Json>>();
 
-            let merged_context = merge_json(
-                local_rc.evaluate2(ctx, &Path::current())?.as_json(),
-                &hash_ctx,
-            );
-            block.set_base_value(merged_context);
+            // let merged_context = merge_json(
+            //     // FIXME: not current path, should be current block
+            //     // context path
+            //     local_rc.evaluate2(ctx, )?.as_json(),
+            //     &hash_ctx,
+            // );
+            block.set_base_value(to_value(hash_ctx)?);
             block_created = true;
             local_rc.push_block(block);
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -101,6 +101,10 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
         self.blocks.pop_front();
     }
 
+    pub(crate) fn clear_blocks(&mut self) {
+        self.blocks.clear();
+    }
+
     /// Borrow a reference to current block context
     pub fn block(&self) -> Option<&BlockContext<'reg>> {
         self.blocks.front()


### PR DESCRIPTION
Fixes #495 

This patch fixes issue mentioned in #495, that block params like `{{#each data as |name|}}` leaked into partials, so that partial context was override. An example of javascript version is [here](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B~%23*inline%20%5C%22displayName%5C%22~%7D%7D%5CnTemplate%3A%7B%7Bname%7D%7D%5Cn%7B%7B%2Finline%7D%7D%5Cn%7B%7B%23each%20data%20as%20%7Cname%7C%7D%7D%5CnName%3A%7B%7Bname%7D%7D%5Cn%7B%7B%3EdisplayName%20name%3D%5C%22aaa%5C%22%7D%7D%5Cn%7B%7B%2Feach%7D%7D%5Cn%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22data%5C%22%3A%20%5B%5C%22hudel%5C%22%2C%20%5C%22test%5C%22%5D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%22%2C%22output%22%3A%22Name%3Ahudel%5CnTemplate%3Aaaa%5CnName%3Atest%5CnTemplate%3Aaaa%5Cn%22%2C%22preparationScript%22%3A%22%2F%2F%20Handlebars.registerHelper('loud'%2C%20function(string)%20%7B%5Cn%2F%2F%20%20%20%20return%20string.toUpperCase()%5Cn%2F%2F%20%7D)%3B%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.7%22%7D). 

The fix removes all existed blocks from partial render context, `local_rc` as in `partial.rs`.