### PR TITLE
Partial indent support

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -4,47 +4,6 @@
 #[grammar = "grammar.pest"]
 pub struct HandlebarsParser;
 
-#[inline]
-pub(crate) fn whitespace_matcher(c: char) -> bool {
-    c == ' ' || c == '\t'
-}
-
-#[inline]
-pub(crate) fn newline_matcher(c: char) -> bool {
-    c == '\n' || c == '\r'
-}
-
-#[inline]
-pub(crate) fn strip_first_newline(s: &str) -> &str {
-    if let Some(s) = s.strip_prefix("\r\n") {
-        s
-    } else if let Some(s) = s.strip_prefix('\n') {
-        s
-    } else {
-        s
-    }
-}
-
-pub(crate) fn find_trailing_whitespace_chars(s: &str) -> Option<&str> {
-    let trimmed = s.trim_end_matches(whitespace_matcher);
-    if trimmed.len() == s.len() {
-        None
-    } else {
-        Some(&s[trimmed.len()..])
-    }
-}
-
-pub(crate) fn ends_with_empty_line(text: &str) -> bool {
-    let s = text.trim_end_matches(whitespace_matcher);
-    // also matches when text is just whitespaces
-    s.ends_with(newline_matcher) || s.is_empty()
-}
-
-pub(crate) fn starts_with_empty_line(text: &str) -> bool {
-    text.trim_start_matches(whitespace_matcher)
-        .starts_with(newline_matcher)
-}
-
 #[cfg(test)]
 mod test {
     use super::{HandlebarsParser, Rule};

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -25,6 +25,15 @@ pub(crate) fn strip_first_newline(s: &str) -> &str {
     }
 }
 
+pub(crate) fn find_trailing_whitespace_chars(s: &str) -> Option<&str> {
+    let trimmed = s.trim_end_matches(whitespace_matcher);
+    if trimmed.len() == s.len() {
+        None
+    } else {
+        Some(&s[trimmed.len()..])
+    }
+}
+
 pub(crate) fn ends_with_empty_line(text: &str) -> bool {
     let s = text.trim_end_matches(whitespace_matcher);
     // also matches when text is just whitespaces

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -457,13 +457,13 @@ foofoofoo"#,
 
         assert_eq!(
             result,
-            r#"name: inner_solo
+            r#"                name: inner_solo
 
-name: hello
-name: there
+                name: hello
+                name: there
 
-name: hello
-name: there
+        name: hello
+        name: there
 "#
         );
     }
@@ -556,13 +556,14 @@ Template:test
   inner first line
   inner second line
 {{/inline}}
-  {{> thepartial}}"#,
+  {{> thepartial}}
+outer third line"#,
         )
         .unwrap();
         assert_eq!(
             r#"    inner first line
     inner second line
-"#,
+outer third line"#,
             hb.render("t1", &()).unwrap()
         );
 
@@ -571,26 +572,28 @@ Template:test
             r#"{{#*inline "thepartial"}}inner first line
 inner second line
 {{/inline}}
-  {{> thepartial}}"#,
+  {{> thepartial}}
+outer third line"#,
         )
         .unwrap();
         assert_eq!(
             r#"  inner first line
   inner second line
-"#,
+outer third line"#,
             hb.render("t2", &()).unwrap()
         );
 
         hb.register_template_string(
             "t3",
             r#"{{#*inline "thepartial"}}{{a}}{{/inline}}
-  {{> thepartial}}"#,
+  {{> thepartial}}
+outer third line"#,
         )
         .unwrap();
         assert_eq!(
             r#"
   inner first line
-  inner second line"#,
+  inner second lineouter third line"#,
             hb.render("t3", &json!({"a": "inner first line\ninner second line"}))
                 .unwrap()
         );
@@ -604,13 +607,14 @@ inner second line
   inner first line
   inner second line
 {{/inline}}
-  {{> thepartial}}"#,
+  {{> thepartial}}
+outer third line"#,
         )
         .unwrap();
         assert_eq!(
             r#"    inner first line
   inner second line
-"#,
+outer third line"#,
             hb2.render("t1", &()).unwrap()
         )
     }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -113,6 +113,9 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
             local_rc.push_partial_block(pb);
         }
 
+        // indent
+        local_rc.set_indent_string(d.indent());
+
         let result = t.render(r, ctx, &mut local_rc, out);
 
         // cleanup
@@ -546,7 +549,6 @@ Template:test
     #[test]
     fn test_multiline_partial() {
         let mut hb = Registry::new();
-        hb.set_prevent_indent(false);
 
         hb.register_template_string(
             "t1",
@@ -562,6 +564,21 @@ Template:test
     inner second line
 "#,
             hb.render("t1", &()).unwrap()
+        );
+
+        hb.register_template_string(
+            "t2",
+            r#"{{#*inline "thepartial"}}inner first line
+inner second line
+{{/inline}}
+  {{> thepartial}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"  inner first line
+  inner second line
+"#,
+            hb.render("t2", &()).unwrap()
         );
     }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -547,7 +547,7 @@ Template:test
     }
 
     #[test]
-    fn test_multiline_partial() {
+    fn test_multiline_partial_indent() {
         let mut hb = Registry::new();
 
         hb.register_template_string(
@@ -580,5 +580,38 @@ inner second line
 "#,
             hb.render("t2", &()).unwrap()
         );
+
+        hb.register_template_string(
+            "t3",
+            r#"{{#*inline "thepartial"}}{{a}}{{/inline}}
+  {{> thepartial}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"
+  inner first line
+  inner second line"#,
+            hb.render("t3", &json!({"a": "inner first line\ninner second line"}))
+                .unwrap()
+        );
+
+        let mut hb2 = Registry::new();
+        hb2.set_prevent_indent(true);
+
+        hb2.register_template_string(
+            "t1",
+            r#"{{#*inline "thepartial"}}
+  inner first line
+  inner second line
+{{/inline}}
+  {{> thepartial}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"    inner first line
+  inner second line
+"#,
+            hb2.render("t1", &()).unwrap()
+        )
     }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -542,4 +542,26 @@ Template:test
             hb.render("t1", &data).unwrap()
         );
     }
+
+    #[test]
+    fn test_multiline_partial() {
+        let mut hb = Registry::new();
+        hb.set_prevent_indent(false);
+
+        hb.register_template_string(
+            "t1",
+            r#"{{#*inline "thepartial"}}
+  inner first line
+  inner second line
+{{/inline}}
+  {{> thepartial}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"    inner first line
+    inner second line
+"#,
+            hb.render("t1", &()).unwrap()
+        );
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -443,6 +443,7 @@ pub struct Decorator<'reg, 'rc> {
     params: Vec<PathAndJson<'reg, 'rc>>,
     hash: BTreeMap<&'reg str, PathAndJson<'reg, 'rc>>,
     template: Option<&'reg Template>,
+    indent: Option<&'reg str>,
 }
 
 impl<'reg: 'rc, 'rc> Decorator<'reg, 'rc> {
@@ -471,6 +472,7 @@ impl<'reg: 'rc, 'rc> Decorator<'reg, 'rc> {
             params: pv,
             hash: hm,
             template: dt.template.as_ref(),
+            indent: dt.indent.as_ref().map(|s| s.as_ref()),
         })
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -206,6 +206,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
         self.inner_mut().indent_string = indent;
     }
 
+    #[inline]
     pub(crate) fn get_indent_string(&self) -> Option<&'reg String> {
         self.inner.indent_string
     }

--- a/src/support.rs
+++ b/src/support.rs
@@ -57,6 +57,64 @@ pub mod str {
         output
     }
 
+    /// add indent for lines but last
+    pub fn with_indent<'a>(s: &'a str, indent: &String) -> String {
+        let mut output = String::new();
+
+        let mut it = s.chars().peekable();
+        while let Some(c) = it.next() {
+            output.push(c);
+            // check if c is not the last character, we don't append
+            // indent for last line break
+            if c == '\n' && it.peek().is_some() {
+                output.push_str(indent);
+            }
+        }
+
+        output
+    }
+
+    #[inline]
+    pub(crate) fn whitespace_matcher(c: char) -> bool {
+        c == ' ' || c == '\t'
+    }
+
+    #[inline]
+    pub(crate) fn newline_matcher(c: char) -> bool {
+        c == '\n' || c == '\r'
+    }
+
+    #[inline]
+    pub(crate) fn strip_first_newline(s: &str) -> &str {
+        if let Some(s) = s.strip_prefix("\r\n") {
+            s
+        } else if let Some(s) = s.strip_prefix('\n') {
+            s
+        } else {
+            s
+        }
+    }
+
+    pub(crate) fn find_trailing_whitespace_chars(s: &str) -> Option<&str> {
+        let trimmed = s.trim_end_matches(whitespace_matcher);
+        if trimmed.len() == s.len() {
+            None
+        } else {
+            Some(&s[trimmed.len()..])
+        }
+    }
+
+    pub(crate) fn ends_with_empty_line(text: &str) -> bool {
+        let s = text.trim_end_matches(whitespace_matcher);
+        // also matches when text is just whitespaces
+        s.ends_with(newline_matcher) || s.is_empty()
+    }
+
+    pub(crate) fn starts_with_empty_line(text: &str) -> bool {
+        text.trim_start_matches(whitespace_matcher)
+            .starts_with(newline_matcher)
+    }
+
     #[cfg(test)]
     mod test {
         use crate::support::str::StringWriter;

--- a/src/template.rs
+++ b/src/template.rs
@@ -435,8 +435,7 @@ impl Template {
                 support::str::ends_with_empty_line(&source[..current_span.start()]);
 
             // prevent_indent: a special toggle for partial expression
-            // (>) that leading whitespaces are kept, default to false
-            // to partial_expression and true for any other statements
+            // (>) that leading whitespaces are kept
             if prevent_indent && with_leading_newline {
                 let t = template_stack.front_mut().unwrap();
                 // check the last element before current
@@ -723,8 +722,7 @@ impl Template {
                             Rule::decorator_expression | Rule::partial_expression => {
                                 // do not auto trim ident spaces for
                                 // partial_expression(>)
-                                let prevent_indent =
-                                    options.prevent_indent || rule != Rule::partial_expression;
+                                let prevent_indent = rule != Rule::partial_expression;
                                 trim_line_required = Template::process_standalone_statement(
                                     &mut template_stack,
                                     source,


### PR DESCRIPTION
Fixes #504 

This patch implements indent feature for partial statement `{{> partial}}`. Since handlebars 2.0, all text lines generated from `{{> partial}}` follows the indent for that statement.