### PR TITLE
Make registry public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ mod json;
 mod local_vars;
 mod output;
 mod partial;
-mod registry;
+pub mod registry;
 mod render;
 mod sources;
 mod support;


### PR DESCRIPTION
This is needed to be able to assign the registry to a static ref using lazy_static as the type cannot be inferred and must be declared.