### PR TITLE
feat: AsyncHelperDef WIP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0.39"
 walkdir = { version = "2.2.3", optional = true }
 rhai = { version = "1.6", optional = true, features = ["sync", "serde"] }
 rust-embed = { version = "6.3.0", optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"
@@ -48,6 +49,7 @@ dir_source = ["walkdir"]
 script_helper = ["rhai"]
 no_logging = []
 default = []
+async_helper = ["async-trait"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "async_helper")]
+use async_trait::async_trait;
+
 use crate::context::Context;
 use crate::error::RenderError;
 use crate::json::value::ScopedJson;
@@ -140,6 +143,19 @@ pub trait HelperDef {
             }
         }
     }
+}
+
+#[cfg(feature = "async_helper")]
+#[async_trait]
+pub trait AsyncHelperDef {
+    async fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Registry<'reg>,
+        ctx: &'rc Context,
+        //   rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut (dyn Output + Send + Sync),
+    ) -> HelperResult;
 }
 
 /// implement HelperDef for bare function so we can use function as helper


### PR DESCRIPTION
Fixes #157 

This is an attempt in progress to add async support for handlebars helper. The whole render call stack needs to be `async` when any of the helper is `async`.

TODO Items:

- [ ] async helper registartion
- [ ] `Registry` APIs support for async helpers, like `has_helper`
- [ ] async render
- [ ] test and examples