### PR TITLE
Disable partial indent with leading `~`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased](https://github.com/sunng87/handlebars-rust/compare/4.3.2...Unreleased) - ReleaseDate
+
+* [Fixed] Disable partial expression indentation with `{{~> partial}}` to
+  bring behavior closer in line with original javascript version. [#518]
+
 ## [4.3.2](https://github.com/sunng87/handlebars-rust/compare/4.3.1...4.3.2) - 2022-07-14
 
 * [Added] Render functions that reuse `Context` for custom `std::io::Write`:

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -595,6 +595,23 @@ outer third line"#,
                 .unwrap()
         );
 
+        hb.register_template_string(
+            "t4",
+            r#"{{#*inline "thepartial"}}
+  inner first line
+  inner second line
+{{/inline}}
+  {{~> thepartial}}
+outer third line"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r#"  inner first line
+  inner second line
+outer third line"#,
+            hb.render("t4", &()).unwrap()
+        );
+
         let mut hb2 = Registry::new();
         hb2.set_prevent_indent(true);
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -728,7 +728,10 @@ impl Template {
 
                                 // indent for partial expression >
                                 let mut indent = None;
-                                if rule == Rule::partial_expression && !options.prevent_indent {
+                                if rule == Rule::partial_expression
+                                    && !options.prevent_indent
+                                    && !exp.omit_pre_ws
+                                {
                                     indent = support::str::find_trailing_whitespace_chars(
                                         &source[..span.start()],
                                     );


### PR DESCRIPTION
[In handlebars.js, `{{~> partial}}` disables indentation for every line of partial content](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23*inline%20%5C%22thepartial%5C%22%7D%7D%5Cn%20%20inner%20first%20line%5Cn%20%20inner%20second%20line%5Cn%7B%7B%2Finline%7D%7D%5Cn%20%20%7B%7B~%3E%20thepartial%7D%7D%5Cnouter%20third%20line%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20firstname%3A%20%5C%22Yehuda%5C%22%2C%5Cn%20%20lastname%3A%20%5C%22Katz%5C%22%2C%5Cn%7D%5Cn%22%2C%22output%22%3A%22%20%20inner%20first%20line%5Cn%20%20inner%20second%20line%5Cnouter%20third%20line%22%2C%22preparationScript%22%3A%22%2F%2F%20Handlebars.registerHelper('loud'%2C%20function(string)%20%7B%5Cn%2F%2F%20%20%20%20return%20string.toUpperCase()%5Cn%2F%2F%20%7D)%3B%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.7%22%7D). However, the handebars-rust indent support added in #505 did not work this way, with `~` instead only removing the indent from the first line. This changeset fixes that, bringing handlebars-rust behavior closer to handlebars.js.