### PR TITLE
feat: Add in trait Output in write_fmt to get access to write! macro

### DIFF
--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -23,8 +23,7 @@ fn format_helper(
     let param = h
         .param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
-    let rendered = format!("{} pts", param.value().render());
-    out.write(rendered.as_ref())?;
+    write!(out, "{} pts", param.value().render())?;
     Ok(())
 }
 
@@ -51,8 +50,7 @@ fn format_decorator(
                 let param = h
                     .param(0)
                     .ok_or(RenderError::new("Param 0 is required for format helper."))?;
-                let rendered = format!("{} {}", param.value().render(), suffix);
-                out.write(rendered.as_ref())?;
+                write!(out, "{} {}", param.value().render(), suffix)?;
                 Ok(())
             },
         ),

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -24,8 +24,7 @@ fn format_helper(
     let param = h
         .param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
-    let rendered = format!("{} pts", param.value().render());
-    out.write(rendered.as_ref())?;
+    write!(out, "{} pts", param.value().render())?;
     Ok(())
 }
 

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -27,8 +27,7 @@ fn format_helper(
     let param = h
         .param(0)
         .ok_or(RenderError::new("Param 0 is required for format helper."))?;
-    let rendered = format!("{} pts", param.value().render());
-    out.write(rendered.as_ref())?;
+    write!(out, "{} pts", param.value().render())?;
     Ok(())
 }
 

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -230,14 +230,14 @@ mod test {
                  _: &mut RenderContext<'_, '_>,
                  out: &mut dyn Output|
                  -> Result<(), RenderError> {
-                    let s = format!(
+                    write!(
+                        out,
                         "{}m",
                         h.param(0)
                             .as_ref()
                             .map(|v| v.value())
                             .unwrap_or(&to_json(0))
-                    );
-                    out.write(s.as_ref())?;
+                    )?;
                     Ok(())
                 },
             ),
@@ -262,15 +262,15 @@ mod test {
                                            _: &mut RenderContext<'_, '_>,
                                            out: &mut dyn Output|
                           -> Result<(), RenderError> {
-                        let s = format!(
+                        write!(
+                            out,
                             "{}{}",
                             h.param(0)
                                 .as_ref()
                                 .map(|v| v.value())
                                 .unwrap_or(&to_json(0)),
                             new_unit
-                        );
-                        out.write(s.as_ref())?;
+                        )?;
                         Ok(())
                     };
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -209,12 +209,9 @@ mod test {
             let v = h.param(0).unwrap();
 
             if !h.is_block() {
-                let output = format!("{}:{}", h.name(), v.value().render());
-                out.write(output.as_ref())?;
+                write!(out, "{}:{}", h.name(), v.value().render())?;
             } else {
-                let output = format!("{}:{}", h.name(), v.value().render());
-                out.write(output.as_ref())?;
-                out.write("->")?;
+                write!(out, "{}:{}->", h.name(), v.value().render())?;
                 h.template().unwrap().render(r, ctx, rc, out)?;
             };
             Ok(())
@@ -258,8 +255,7 @@ mod test {
                  _: &mut RenderContext<'_, '_>,
                  out: &mut dyn Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}{}", h.name(), h.param(0).unwrap().value());
-                    out.write(output.as_ref())?;
+                    write!(out, "{}{}", h.name(), h.param(0).unwrap().value())?;
                     Ok(())
                 },
             ),
@@ -273,8 +269,7 @@ mod test {
                  _: &mut RenderContext<'_, '_>,
                  out: &mut dyn Output|
                  -> Result<(), RenderError> {
-                    let output = format!("{}", h.hash_get("value").unwrap().value().render());
-                    out.write(output.as_ref())?;
+                    write!(out, "{}", h.hash_get("value").unwrap().value().render())?;
                     Ok(())
                 },
             ),

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -208,12 +208,11 @@ mod test {
         ) -> Result<(), RenderError> {
             let v = h.param(0).unwrap();
 
-            if !h.is_block() {
-                write!(out, "{}:{}", h.name(), v.value().render())?;
-            } else {
-                write!(out, "{}:{}->", h.name(), v.value().render())?;
+            write!(out, "{}:{}", h.name(), v.value().render())?;
+            if h.is_block() {
+                out.write("->")?;
                 h.template().unwrap().render(r, ctx, rc, out)?;
-            };
+            }
             Ok(())
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -11,7 +11,13 @@ pub trait Output {
     /// for backward compatibility and to avoid breakage the default implementation
     /// uses `format!` this may be not what you want.
     fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError> {
-        self.write(&std::fmt::format(args))
+        // Check if there is nothing to format to avoid allocation on case like
+        // write!(out, "hey")?;
+        if let Some(content) = args.as_str() {
+            self.write(content)
+        } else {
+            self.write(&std::fmt::format(args))
+        }
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,6 +6,7 @@ use std::string::FromUtf8Error;
 /// Handlebars uses this trait to define rendered output.
 pub trait Output {
     fn write(&mut self, seg: &str) -> Result<(), IOError>;
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError>;
 }
 
 pub struct WriteOutput<W: Write> {
@@ -15,6 +16,10 @@ pub struct WriteOutput<W: Write> {
 impl<W: Write> Output for WriteOutput<W> {
     fn write(&mut self, seg: &str) -> Result<(), IOError> {
         self.write.write_all(seg.as_bytes())
+    }
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError> {
+        self.write.write_fmt(args)
     }
 }
 
@@ -32,6 +37,10 @@ impl Output for StringOutput {
     fn write(&mut self, seg: &str) -> Result<(), IOError> {
         self.buf.extend_from_slice(seg.as_bytes());
         Ok(())
+    }
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError> {
+        self.buf.write_fmt(args)
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,7 +6,13 @@ use std::string::FromUtf8Error;
 /// Handlebars uses this trait to define rendered output.
 pub trait Output {
     fn write(&mut self, seg: &str) -> Result<(), IOError>;
-    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError>;
+
+    /// Designed to be used with `write!` macro.
+    /// for backward compatibility and to avoid breakage the default implementation
+    /// uses `format!` this may be not what you want.
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), IOError> {
+        self.write(&std::fmt::format(args))
+    }
 }
 
 pub struct WriteOutput<W: Write> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1159,7 +1159,7 @@ mod test {
                  out: &mut dyn Output|
                  -> Result<(), RenderError> {
                     let name = h.name();
-                    out.write(&format!("{} not resolved", name))?;
+                    write!(out, "{} not resolved", name)?;
                     Ok(())
                 },
             ),


### PR DESCRIPTION
Upside: It may help (or not) to avoid allocation, rustc, is not able every time able to discard format allocations.
Downsite API change, may not be worth it.

Edit: 
- had some personal mixed results on `cargo bench` so I removed the comments because it was mostly noise to retain the real addition of this PR: adding `write_fmt` to `Output` trait or not, totally ok if it's closed as "not worth the maintaining effort" or "not in the scope of the project" :)

Have a great day