### PR TITLE
issue 529: simplify lifetime requirements

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -68,9 +68,9 @@ pub struct BlockContext<'rc> {
     local_variables: LocalVars,
 }
 
-impl<'reg> BlockContext<'reg> {
+impl<'rc> BlockContext<'rc> {
     /// create a new `BlockContext` with default data
-    pub fn new() -> BlockContext<'reg> {
+    pub fn new() -> BlockContext<'rc> {
         BlockContext::default()
     }
 
@@ -120,7 +120,7 @@ impl<'reg> BlockContext<'reg> {
     }
 
     /// Set a block parameter into this block.
-    pub fn set_block_params(&mut self, block_params: BlockParams<'reg>) {
+    pub fn set_block_params(&mut self, block_params: BlockParams<'rc>) {
         self.block_params = block_params;
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -56,14 +56,14 @@ impl<'reg> BlockParams<'reg> {
 
 /// A data structure holds contextual data for current block scope.
 #[derive(Debug, Clone, Default)]
-pub struct BlockContext<'reg> {
+pub struct BlockContext<'rc> {
     /// the base_path of current block scope
     base_path: Vec<String>,
     /// the base_value of current block scope, when the block is using a
     /// constant or derived value as block base
     base_value: Option<Json>,
     /// current block context variables
-    block_params: BlockParams<'reg>,
+    block_params: BlockParams<'rc>,
     /// local variables in current context
     local_variables: LocalVars,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -169,7 +169,7 @@ impl Context {
         &'rc self,
         relative_path: &[PathSeg],
         block_contexts: &VecDeque<BlockContext<'reg>>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         // always use absolute at the moment until we get base_value lifetime issue fixed
         let resolved_visitor = parse_json_visitor(relative_path, block_contexts, true);
 
@@ -239,7 +239,7 @@ mod test {
     fn navigate_from_root<'reg, 'rc>(
         ctx: &'rc Context,
         path: &str,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         let relative_path = Path::parse(path).unwrap();
         ctx.navigate(relative_path.segs().unwrap(), &VecDeque::new())
     }

--- a/src/decorators/inline.rs
+++ b/src/decorators/inline.rs
@@ -7,7 +7,7 @@ use crate::render::{Decorator, RenderContext};
 #[derive(Clone, Copy)]
 pub struct InlineDecorator;
 
-fn get_name<'reg: 'rc, 'rc>(d: &Decorator<'reg, 'rc>) -> Result<String, RenderError> {
+fn get_name<'reg: 'rc, 'rc>(d: &Decorator<'rc>) -> Result<String, RenderError> {
     d.param(0)
         .ok_or_else(|| RenderError::new("Param required for decorator \"inline\""))
         .and_then(|v| {
@@ -21,7 +21,7 @@ fn get_name<'reg: 'rc, 'rc>(d: &Decorator<'reg, 'rc>) -> Result<String, RenderEr
 impl DecoratorDef for InlineDecorator {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        d: &Decorator<'reg, 'rc>,
+        d: &Decorator<'rc>,
         _: &'reg Registry<'reg>,
         _: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -59,7 +59,7 @@ pub type DecoratorResult = Result<(), RenderError>;
 pub trait DecoratorDef {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        d: &Decorator<'reg, 'rc>,
+        d: &Decorator<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
@@ -68,17 +68,17 @@ pub trait DecoratorDef {
 
 /// Implement DecoratorDef for bare function so we can use function as decorator
 impl<
-        F: for<'reg, 'rc> Fn(
-            &Decorator<'reg, 'rc>,
-            &'reg Registry<'reg>,
-            &'rc Context,
-            &mut RenderContext<'reg, 'rc>,
-        ) -> DecoratorResult,
-    > DecoratorDef for F
+    F: for<'reg, 'rc> Fn(
+        &Decorator<'rc>,
+        &'reg Registry<'reg>,
+        &'rc Context,
+        &mut RenderContext<'reg, 'rc>,
+    ) -> DecoratorResult,
+> DecoratorDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
-        d: &Decorator<'reg, 'rc>,
+        d: &Decorator<'rc>,
         reg: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
@@ -114,7 +114,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Decorator<'_, '_>,
+                |_: &Decorator<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>|
@@ -139,7 +139,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |_: &Decorator<'_, '_>,
+                |_: &Decorator<'_>,
                  _: &Registry<'_>,
                  ctx: &Context,
                  rc: &mut RenderContext<'_, '_>|
@@ -167,7 +167,7 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |d: &Decorator<'_, '_>,
+                |d: &Decorator<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  rc: &mut RenderContext<'_, '_>|
@@ -224,7 +224,7 @@ mod test {
         handlebars.register_helper(
             "distance",
             Box::new(
-                |h: &Helper<'_, '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,
@@ -245,7 +245,7 @@ mod test {
         handlebars.register_decorator(
             "foo",
             Box::new(
-                |d: &Decorator<'_, '_>,
+                |d: &Decorator<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  rc: &mut RenderContext<'_, '_>|
@@ -256,12 +256,12 @@ mod test {
                         .and_then(|v| as_string(v.value()))
                         .unwrap_or("")
                         .to_owned();
-                    let new_helper = move |h: &Helper<'_, '_>,
+                    let new_helper = move |h: &Helper<'_>,
                                            _: &Registry<'_>,
                                            _: &Context,
                                            _: &mut RenderContext<'_, '_>,
                                            out: &mut dyn Output|
-                          -> Result<(), RenderError> {
+                                           -> Result<(), RenderError> {
                         write!(
                             out,
                             "{}{}",
@@ -282,7 +282,7 @@ mod test {
         handlebars.register_decorator(
             "bar",
             Box::new(
-                |_: &Decorator<'_, '_>,
+                |_: &Decorator<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  rc: &mut RenderContext<'_, '_>|

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -68,13 +68,13 @@ pub trait DecoratorDef {
 
 /// Implement DecoratorDef for bare function so we can use function as decorator
 impl<
-    F: for<'reg, 'rc> Fn(
-        &Decorator<'rc>,
-        &'reg Registry<'reg>,
-        &'rc Context,
-        &mut RenderContext<'reg, 'rc>,
-    ) -> DecoratorResult,
-> DecoratorDef for F
+        F: for<'reg, 'rc> Fn(
+            &Decorator<'rc>,
+            &'reg Registry<'reg>,
+            &'rc Context,
+            &mut RenderContext<'reg, 'rc>,
+        ) -> DecoratorResult,
+    > DecoratorDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &'reg self,
@@ -261,7 +261,7 @@ mod test {
                                            _: &Context,
                                            _: &mut RenderContext<'_, '_>,
                                            out: &mut dyn Output|
-                                           -> Result<(), RenderError> {
+                          -> Result<(), RenderError> {
                         write!(
                             out,
                             "{}{}",

--- a/src/helpers/block_util.rs
+++ b/src/helpers/block_util.rs
@@ -1,9 +1,7 @@
 use crate::block::BlockContext;
 use crate::json::value::PathAndJson;
 
-pub(crate) fn create_block<'rc>(
-    param: &PathAndJson<'rc>,
-) -> BlockContext<'rc> {
+pub(crate) fn create_block<'rc>(param: &PathAndJson<'rc>) -> BlockContext<'rc> {
     let mut block = BlockContext::new();
 
     if let Some(new_path) = param.context_path() {

--- a/src/helpers/block_util.rs
+++ b/src/helpers/block_util.rs
@@ -1,9 +1,9 @@
 use crate::block::BlockContext;
 use crate::json::value::PathAndJson;
 
-pub(crate) fn create_block<'reg: 'rc, 'rc>(
-    param: &'rc PathAndJson<'reg, 'rc>,
-) -> BlockContext<'reg> {
+pub(crate) fn create_block<'rc>(
+    param: &'rc PathAndJson<'rc>,
+) -> BlockContext<'rc> {
     let mut block = BlockContext::new();
 
     if let Some(new_path) = param.context_path() {

--- a/src/helpers/block_util.rs
+++ b/src/helpers/block_util.rs
@@ -2,7 +2,7 @@ use crate::block::BlockContext;
 use crate::json::value::PathAndJson;
 
 pub(crate) fn create_block<'rc>(
-    param: &'rc PathAndJson<'rc>,
+    param: &PathAndJson<'rc>,
 ) -> BlockContext<'rc> {
     let mut block = BlockContext::new();
 

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -7,10 +7,10 @@ use crate::error::RenderError;
 use crate::helpers::{HelperDef, HelperResult};
 use crate::json::value::to_json;
 use crate::output::Output;
-use crate::PathAndJson;
 use crate::registry::Registry;
 use crate::render::{Helper, RenderContext, Renderable};
 use crate::util::copy_on_push_vec;
+use crate::PathAndJson;
 
 fn update_block_context<'reg>(
     block: &mut BlockContext<'reg>,
@@ -73,7 +73,7 @@ impl HelperDef for EachHelper {
         rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
-        let value : PathAndJson<'rc > = h
+        let value: PathAndJson<'rc> = h
             .param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?
             .clone();
@@ -83,65 +83,65 @@ impl HelperDef for EachHelper {
         match template {
             Some(t) => match *value.value() {
                 Json::Array(ref list)
-                if !list.is_empty() || (list.is_empty() && h.inverse().is_none()) =>
-                    {
-                        let block_context = create_block(&value);
-                        rc.push_block(block_context);
+                    if !list.is_empty() || (list.is_empty() && h.inverse().is_none()) =>
+                {
+                    let block_context = create_block(&value);
+                    rc.push_block(block_context);
 
-                        let len = list.len();
+                    let len = list.len();
 
-                        let array_path = value.context_path();
+                    let array_path = value.context_path();
 
-                        for (i, v) in list.iter().enumerate().take(len) {
-                            if let Some(ref mut block) = rc.block_mut() {
-                                let is_first = i == 0usize;
-                                let is_last = i == len - 1;
+                    for (i, v) in list.iter().enumerate().take(len) {
+                        if let Some(ref mut block) = rc.block_mut() {
+                            let is_first = i == 0usize;
+                            let is_last = i == len - 1;
 
-                                let index = to_json(i);
-                                block.set_local_var("first", to_json(is_first));
-                                block.set_local_var("last", to_json(is_last));
-                                block.set_local_var("index", index.clone());
+                            let index = to_json(i);
+                            block.set_local_var("first", to_json(is_first));
+                            block.set_local_var("last", to_json(is_last));
+                            block.set_local_var("index", index.clone());
 
-                                update_block_context(block, array_path, i.to_string(), is_first, v);
-                                set_block_param(block, h, array_path, &index, v)?;
-                            }
-
-                            t.render(r, ctx, rc, out)?;
+                            update_block_context(block, array_path, i.to_string(), is_first, v);
+                            set_block_param(block, h, array_path, &index, v)?;
                         }
 
-                        rc.pop_block();
-                        Ok(())
+                        t.render(r, ctx, rc, out)?;
                     }
+
+                    rc.pop_block();
+                    Ok(())
+                }
                 Json::Object(ref obj)
-                if !obj.is_empty() || (obj.is_empty() && h.inverse().is_none()) =>
-                    {
-                        let block_context = create_block(&value);
-                        rc.push_block(block_context);
+                    if !obj.is_empty() || (obj.is_empty() && h.inverse().is_none()) =>
+                {
+                    let block_context = create_block(&value);
+                    rc.push_block(block_context);
 
-                        let len = obj.len();
+                    let len = obj.len();
 
-                        let obj_path = value.context_path();
+                    let obj_path = value.context_path();
 
-                        for (i, (k, v)) in obj.iter().enumerate() {
-                            if let Some(ref mut block) = rc.block_mut() {
-                                let is_first = i == 0usize;
-                                let is_last = i == len - 1;
+                    for (i, (k, v)) in obj.iter().enumerate() {
+                        if let Some(ref mut block) = rc.block_mut() {
+                            let is_first = i == 0usize;
+                            let is_last = i == len - 1;
 
-                                let key = to_json(k);
-                                block.set_local_var("first", to_json(is_first));
-                                block.set_local_var("last", to_json(is_last));
-                                block.set_local_var("key", key.clone());
+                            let key = to_json(k);
+                            block.set_local_var("first", to_json(is_first));
+                            block.set_local_var("last", to_json(is_last));
+                            block.set_local_var("key", key.clone());
 
-                                update_block_context(block, obj_path, k.to_string(), is_first, v);
-                                set_block_param(block, h, obj_path, &key, v)?;
-                            }
-
-                            t.render(r, ctx, rc, out)?;
+                            update_block_context(block, obj_path, k.to_string(), is_first, v);
+                            set_block_param(block, h, obj_path, &key, v)?;
                         }
 
-                        rc.pop_block();
-                        Ok(())
+                        t.render(r, ctx, rc, out)?;
                     }
+
+                    rc.pop_block();
+                    Ok(())
+                }
                 _ => {
                     if let Some(else_template) = h.inverse() {
                         else_template.render(r, ctx, rc, out)

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -113,7 +113,7 @@ impl HelperDef for EachHelper {
                 Json::Object(ref obj)
                     if !obj.is_empty() || (obj.is_empty() && h.inverse().is_none()) =>
                 {
-                    let block_context = create_block(&value);
+                    let block_context = create_block(value);
                     rc.push_block(block_context);
 
                     let len = obj.len();

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -73,9 +73,10 @@ impl HelperDef for EachHelper {
         rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
-        let value : &PathAndJson<'rc > = h
+        let value : PathAndJson<'rc > = h
             .param(0)
-            .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?;
+            .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?
+            .clone();
 
         let template = h.template();
 
@@ -84,7 +85,7 @@ impl HelperDef for EachHelper {
                 Json::Array(ref list)
                 if !list.is_empty() || (list.is_empty() && h.inverse().is_none()) =>
                     {
-                        let block_context = create_block(value);
+                        let block_context = create_block(&value);
                         rc.push_block(block_context);
 
                         let len = list.len();
@@ -114,7 +115,7 @@ impl HelperDef for EachHelper {
                 Json::Object(ref obj)
                 if !obj.is_empty() || (obj.is_empty() && h.inverse().is_none()) =>
                     {
-                        let block_context = create_block(value);
+                        let block_context = create_block(&value);
                         rc.push_block(block_context);
 
                         let len = obj.len();

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -10,7 +10,6 @@ use crate::output::Output;
 use crate::registry::Registry;
 use crate::render::{Helper, RenderContext, Renderable};
 use crate::util::copy_on_push_vec;
-use crate::PathAndJson;
 
 fn update_block_context<'reg>(
     block: &mut BlockContext<'reg>,
@@ -73,10 +72,9 @@ impl HelperDef for EachHelper {
         rc: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
-        let value: PathAndJson<'rc> = h
+        let value = h
             .param(0)
-            .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?
-            .clone();
+            .ok_or_else(|| RenderError::new("Param not found for helper \"each\""))?;
 
         let template = h.template();
 
@@ -85,7 +83,7 @@ impl HelperDef for EachHelper {
                 Json::Array(ref list)
                     if !list.is_empty() || (list.is_empty() && h.inverse().is_none()) =>
                 {
-                    let block_context = create_block(&value);
+                    let block_context = create_block(value);
                     rc.push_block(block_context);
 
                     let len = list.len();

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -14,7 +14,7 @@ pub struct IfHelper {
 impl HelperDef for IfHelper {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -19,7 +19,7 @@ pub struct LogHelper;
 impl HelperDef for LogHelper {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         _: &'reg Registry<'reg>,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
@@ -59,7 +59,7 @@ impl HelperDef for LogHelper {
 impl HelperDef for LogHelper {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        _: &Helper<'reg, 'rc>,
+        _: &Helper<'rc>,
         _: &Registry<'reg>,
         _: &Context,
         _: &mut RenderContext<'reg, 'rc>,

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -13,11 +13,11 @@ pub struct LookupHelper;
 impl HelperDef for LookupHelper {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         let collection_value = h
             .param(0)
             .ok_or_else(|| RenderError::new("Param not found for helper \"lookup\""))?;

--- a/src/helpers/helper_raw.rs
+++ b/src/helpers/helper_raw.rs
@@ -10,7 +10,7 @@ pub struct RawHelper;
 impl HelperDef for RawHelper {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -14,7 +14,7 @@ pub struct WithHelper;
 impl HelperDef for WithHelper {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -144,14 +144,14 @@ pub trait HelperDef {
 
 /// implement HelperDef for bare function so we can use function as helper
 impl<
-    F: for<'reg, 'rc> Fn(
-        &Helper<'rc>,
-        &'reg Registry<'reg>,
-        &'rc Context,
-        &mut RenderContext<'reg, 'rc>,
-        &mut dyn Output,
-    ) -> HelperResult,
-> HelperDef for F
+        F: for<'reg, 'rc> Fn(
+            &Helper<'rc>,
+            &'reg Registry<'reg>,
+            &'rc Context,
+            &mut RenderContext<'reg, 'rc>,
+            &mut dyn Output,
+        ) -> HelperResult,
+    > HelperDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &self,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -32,7 +32,7 @@ pub type HelperResult = Result<(), RenderError>;
 /// ```
 /// use handlebars::*;
 ///
-/// fn upper(h: &Helper<'_, '_>, _: &Handlebars<'_>, _: &Context, rc:
+/// fn upper(h: &Helper< '_>, _: &Handlebars<'_>, _: &Context, rc:
 /// &mut RenderContext<'_, '_>, out: &mut dyn Output)
 ///     -> HelperResult {
 ///    // get parameter from helper or throw an error
@@ -50,7 +50,7 @@ pub type HelperResult = Result<(), RenderError>;
 /// use handlebars::*;
 ///
 /// fn dummy_block<'reg, 'rc>(
-///     h: &Helper<'reg, 'rc>,
+///     h: &Helper<'rc>,
 ///     r: &'reg Handlebars<'reg>,
 ///     ctx: &'rc Context,
 ///     rc: &mut RenderContext<'reg, 'rc>,
@@ -90,11 +90,11 @@ pub trait HelperDef {
     /// helpers like `if` and rendered as empty string.
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        _: &Helper<'reg, 'rc>,
+        _: &Helper<'rc>,
         _: &'reg Registry<'reg>,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         Err(RenderError::unimplemented())
     }
 
@@ -113,7 +113,7 @@ pub trait HelperDef {
     /// So it is not recommended to use these helpers in subexpression.
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
@@ -144,18 +144,18 @@ pub trait HelperDef {
 
 /// implement HelperDef for bare function so we can use function as helper
 impl<
-        F: for<'reg, 'rc> Fn(
-            &Helper<'reg, 'rc>,
-            &'reg Registry<'reg>,
-            &'rc Context,
-            &mut RenderContext<'reg, 'rc>,
-            &mut dyn Output,
-        ) -> HelperResult,
-    > HelperDef for F
+    F: for<'reg, 'rc> Fn(
+        &Helper<'rc>,
+        &'reg Registry<'reg>,
+        &'rc Context,
+        &mut RenderContext<'reg, 'rc>,
+        &mut dyn Output,
+    ) -> HelperResult,
+> HelperDef for F
 {
     fn call<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         r: &'reg Registry<'reg>,
         ctx: &'rc Context,
         rc: &mut RenderContext<'reg, 'rc>,
@@ -200,7 +200,7 @@ mod test {
     impl HelperDef for MetaHelper {
         fn call<'reg: 'rc, 'rc>(
             &self,
-            h: &Helper<'reg, 'rc>,
+            h: &Helper<'rc>,
             r: &'reg Registry<'reg>,
             ctx: &'rc Context,
             rc: &mut RenderContext<'reg, 'rc>,
@@ -248,7 +248,7 @@ mod test {
         handlebars.register_helper(
             "helperMissing",
             Box::new(
-                |h: &Helper<'_, '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,
@@ -262,7 +262,7 @@ mod test {
         handlebars.register_helper(
             "foo",
             Box::new(
-                |h: &Helper<'_, '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,

--- a/src/helpers/scripting.rs
+++ b/src/helpers/scripting.rs
@@ -18,11 +18,11 @@ pub(crate) struct ScriptHelper {
 
 #[inline]
 fn call_script_helper<'reg: 'rc, 'rc>(
-    params: &[PathAndJson<'reg, 'rc>],
-    hash: &BTreeMap<&'reg str, PathAndJson<'reg, 'rc>>,
+    params: &[PathAndJson<'rc>],
+    hash: &BTreeMap<&'reg str, PathAndJson<'rc>>,
     engine: &Engine,
     script: &AST,
-) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+) -> Result<ScopedJson<'rc>, RenderError> {
     let params: Dynamic = to_dynamic(params.iter().map(|p| p.value()).collect::<Vec<&Json>>())?;
 
     let hash: Dynamic = to_dynamic(
@@ -47,11 +47,11 @@ fn call_script_helper<'reg: 'rc, 'rc>(
 impl HelperDef for ScriptHelper {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         reg: &'reg Registry<'reg>,
         _ctx: &'rc Context,
         _rc: &mut RenderContext<'reg, 'rc>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         call_script_helper(h.params(), h.hash(), &reg.engine, &self.script)
     }
 }

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -10,15 +10,15 @@ pub(crate) static DEFAULT_VALUE: Json = Json::Null;
 /// * Derived:  the owned JSON value computed during rendering process
 ///
 #[derive(Debug)]
-pub enum ScopedJson<'reg: 'rc, 'rc> {
-    Constant(&'reg Json),
+pub enum ScopedJson<'rc> {
+    Constant(&'rc Json),
     Derived(Json),
     // represents a json reference to context value, its full path
     Context(&'rc Json, Vec<String>),
     Missing,
 }
 
-impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
+impl<'rc> ScopedJson<'rc> {
     /// get the JSON reference
     pub fn as_json(&self) -> &Json {
         match self {
@@ -37,7 +37,7 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
         matches!(self, ScopedJson::Missing)
     }
 
-    pub fn into_derived(self) -> ScopedJson<'reg, 'rc> {
+    pub fn into_derived(self) -> ScopedJson<'rc> {
         let v = self.as_json();
         ScopedJson::Derived(v.clone())
     }
@@ -50,8 +50,8 @@ impl<'reg: 'rc, 'rc> ScopedJson<'reg, 'rc> {
     }
 }
 
-impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'reg, 'rc> {
-    fn from(v: Json) -> ScopedJson<'reg, 'rc> {
+impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'rc> {
+    fn from(v: Json) -> ScopedJson<'rc> {
         ScopedJson::Derived(v)
     }
 }
@@ -59,16 +59,16 @@ impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'reg, 'rc> {
 /// Json wrapper that holds the Json value and reference path information
 ///
 #[derive(Debug)]
-pub struct PathAndJson<'reg, 'rc> {
+pub struct PathAndJson<'rc> {
     relative_path: Option<String>,
-    value: ScopedJson<'reg, 'rc>,
+    value: ScopedJson<'rc>,
 }
 
-impl<'reg: 'rc, 'rc> PathAndJson<'reg, 'rc> {
+impl<'rc> PathAndJson<'rc> {
     pub fn new(
         relative_path: Option<String>,
-        value: ScopedJson<'reg, 'rc>,
-    ) -> PathAndJson<'reg, 'rc> {
+        value: ScopedJson<'rc>,
+    ) -> PathAndJson<'rc> {
         PathAndJson {
             relative_path,
             value,
@@ -134,8 +134,8 @@ impl JsonRender for Json {
 
 /// Convert any serializable data into Serde Json type
 pub fn to_json<T>(src: T) -> Json
-where
-    T: Serialize,
+    where
+        T: Serialize,
 {
     to_value(src).unwrap_or_default()
 }

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -65,10 +65,7 @@ pub struct PathAndJson<'rc> {
 }
 
 impl<'rc> PathAndJson<'rc> {
-    pub fn new(
-        relative_path: Option<String>,
-        value: ScopedJson<'rc>,
-    ) -> PathAndJson<'rc> {
+    pub fn new(relative_path: Option<String>, value: ScopedJson<'rc>) -> PathAndJson<'rc> {
         PathAndJson {
             relative_path,
             value,
@@ -134,8 +131,8 @@ impl JsonRender for Json {
 
 /// Convert any serializable data into Serde Json type
 pub fn to_json<T>(src: T) -> Json
-    where
-        T: Serialize,
+where
+    T: Serialize,
 {
     to_value(src).unwrap_or_default()
 }

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -9,7 +9,7 @@ pub(crate) static DEFAULT_VALUE: Json = Json::Null;
 /// * Context:  the JSON value referenced in your provided data context
 /// * Derived:  the owned JSON value computed during rendering process
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ScopedJson<'rc> {
     Constant(&'rc Json),
     Derived(Json),
@@ -58,7 +58,7 @@ impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'rc> {
 
 /// Json wrapper that holds the Json value and reference path information
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PathAndJson<'rc> {
     relative_path: Option<String>,
     value: ScopedJson<'rc>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,11 +50,11 @@ macro_rules! handlebars_helper {
             #[allow(unused_assignments)]
             fn call_inner<'reg: 'rc, 'rc>(
                 &self,
-                h: &$crate::Helper<'reg, 'rc>,
+                h: &$crate::Helper<'rc>,
                 r: &'reg $crate::Handlebars<'reg>,
                 _: &'rc $crate::Context,
                 _: &mut $crate::RenderContext<'reg, 'rc>,
-            ) -> Result<$crate::ScopedJson<'reg, 'rc>, $crate::RenderError> {
+            ) -> Result<$crate::ScopedJson<'rc>, $crate::RenderError> {
                 let mut param_idx = 0;
 
                 $(

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -17,7 +17,7 @@ pub(crate) const PARTIAL_BLOCK: &str = "@partial-block";
 fn find_partial<'reg: 'rc, 'rc: 'a, 'a>(
     rc: &'a RenderContext<'reg, 'rc>,
     r: &'reg Registry<'reg>,
-    d: &Decorator<'reg, 'rc>,
+    d: &Decorator<'rc>,
     name: &str,
 ) -> Result<Option<Cow<'a, Template>>, RenderError> {
     if let Some(partial) = rc.get_partial(name) {
@@ -36,7 +36,7 @@ fn find_partial<'reg: 'rc, 'rc: 'a, 'a>(
 }
 
 pub fn expand_partial<'reg: 'rc, 'rc>(
-    d: &Decorator<'reg, 'rc>,
+    d: &Decorator<'rc>,
     r: &'reg Registry<'reg>,
     ctx: &'rc Context,
     rc: &mut RenderContext<'reg, 'rc>,
@@ -302,7 +302,7 @@ mod test {
         hbs.register_helper(
             "x",
             Box::new(
-                |_: &Helper<'_, '_>,
+                |_: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1021,7 +1021,7 @@ mod test {
         r.register_helper(
             "check_missing",
             Box::new(
-                |h: &Helper< '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -739,7 +739,7 @@ mod test {
     impl HelperDef for DummyHelper {
         fn call<'reg: 'rc, 'rc>(
             &self,
-            h: &Helper<'reg, 'rc>,
+            h: &Helper<'rc>,
             r: &'reg Registry<'reg>,
             ctx: &'rc Context,
             rc: &mut RenderContext<'reg, 'rc>,
@@ -1004,11 +1004,11 @@ mod test {
     impl HelperDef for GenMissingHelper {
         fn call_inner<'reg: 'rc, 'rc>(
             &self,
-            _: &Helper<'reg, 'rc>,
+            _: &Helper<'rc>,
             _: &'reg Registry<'reg>,
             _: &'rc Context,
             _: &mut RenderContext<'reg, 'rc>,
-        ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+        ) -> Result<ScopedJson<'rc>, RenderError> {
             Ok(ScopedJson::Missing)
         }
     }
@@ -1021,7 +1021,7 @@ mod test {
         r.register_helper(
             "check_missing",
             Box::new(
-                |h: &Helper<'_, '_>,
+                |h: &Helper< '_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,

--- a/src/render.rs
+++ b/src/render.rs
@@ -302,7 +302,7 @@ impl<'reg, 'rc> fmt::Debug for RenderContextInner<'reg, 'rc> {
 }
 
 /// Render-time Helper data when using in a helper definition
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Helper<'rc> {
     name: Cow<'rc, str>,
     params: Vec<PathAndJson<'rc>>,

--- a/src/render.rs
+++ b/src/render.rs
@@ -438,7 +438,7 @@ impl<'reg: 'rc, 'rc> Helper<'rc> {
     /// Return block param pair (for example |key, val|) if any
     pub fn block_param_pair(&self) -> Option<(&'rc str, &'rc str)> {
         if let Some(&BlockParam::Pair((Parameter::Name(ref s1), Parameter::Name(ref s2)))) =
-        self.block_param
+            self.block_param
         {
             Some((s1, s2))
         } else {
@@ -1012,7 +1012,7 @@ mod test {
         r.register_helper(
             "format",
             Box::new(
-                |h: &Helper< '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,
@@ -1107,7 +1107,7 @@ mod test {
         r.register_helper(
             "name",
             Box::new(
-                |_: &Helper< '_>,
+                |_: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,
@@ -1152,7 +1152,7 @@ mod test {
         r.register_helper(
             "helperMissing",
             Box::new(
-                |h: &Helper< '_>,
+                |h: &Helper<'_>,
                  _: &Registry<'_>,
                  _: &Context,
                  _: &mut RenderContext<'_, '_>,

--- a/tests/data_helper.rs
+++ b/tests/data_helper.rs
@@ -6,7 +6,7 @@ struct HelperWithBorrowedData<'a>(&'a String);
 impl<'a> HelperDef for HelperWithBorrowedData<'a> {
     fn call<'_reg: '_rc, '_rc>(
         &self,
-        _: &Helper<'_reg, '_rc>,
+        _: &Helper<'_rc>,
         _: &'_reg Handlebars,
         _: &Context,
         _: &mut RenderContext,

--- a/tests/embed.rs
+++ b/tests/embed.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate serde_json;
 
-use handlebars::Handlebars;
-
 #[test]
 #[cfg(feature = "rust-embed")]
 fn test_embed() {
@@ -13,7 +11,7 @@ fn test_embed() {
     #[include = "*.hbs"]
     struct Templates;
 
-    let mut hbs = Handlebars::new();
+    let mut hbs = handlebars::Handlebars::new();
     hbs.register_embed_templates::<Templates>().unwrap();
 
     assert_eq!(1, hbs.get_templates().len());

--- a/tests/helper_function_lifetime.rs
+++ b/tests/helper_function_lifetime.rs
@@ -1,7 +1,7 @@
 use handlebars::*;
 
 fn ifcond<'reg, 'rc>(
-    h: &Helper<'reg, 'rc>,
+    h: &Helper<'rc>,
     handle: &'reg Handlebars,
     ctx: &'rc Context,
     render_ctx: &mut RenderContext<'reg, 'rc>,

--- a/tests/helper_with_space.rs
+++ b/tests/helper_with_space.rs
@@ -2,7 +2,7 @@ use handlebars::*;
 use serde_json::json;
 
 fn dump<'reg, 'rc>(
-    h: &Helper<'reg, 'rc>,
+    h: &Helper<'rc>,
     _: &'reg Handlebars,
     _: &Context,
     _: &mut RenderContext,

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -89,11 +89,11 @@ struct MyHelper;
 impl HelperDef for MyHelper {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        _: &Helper<'reg, 'rc>,
+        _: &Helper<'rc>,
         _: &'reg Handlebars,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         Ok(ScopedJson::Derived(json!({
             "a": 1,
             "b": 2,
@@ -121,11 +121,11 @@ struct CallCounterHelper {
 impl HelperDef for CallCounterHelper {
     fn call_inner<'reg: 'rc, 'rc>(
         &self,
-        h: &Helper<'reg, 'rc>,
+        h: &Helper<'rc>,
         _: &'reg Handlebars,
         _: &'rc Context,
         _: &mut RenderContext<'reg, 'rc>,
-    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+    ) -> Result<ScopedJson<'rc>, RenderError> {
         // inc counter
         self.c.fetch_add(1, Ordering::SeqCst);
 


### PR DESCRIPTION
Only type annotations needed to be fixed, all the code actually already supported rendering shorter-lived templates.  

This fixes #529 

This is a breaking change, but it makes this API useful in more contexts, and even simplifies it a bit with fewer lifetime annotations, so I think it's worth it.

@sunng87 