### PR TITLE
Allow public access to local variables

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -79,6 +79,11 @@ impl<'rc> BlockContext<'rc> {
         self.local_variables.put(name, value);
     }
 
+    /// Get mutable access to the local variables
+    pub fn local_variables_mut(&mut self) -> &mut LocalVars {
+        &mut self.local_variables
+    }
+
     /// get a local variable from current scope
     pub fn get_local_var(&self, name: &str) -> Option<&Json> {
         self.local_variables.get(name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,11 +394,11 @@ pub use self::error::{RenderError, TemplateError};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::json::path::Path;
 pub use self::json::value::{to_json, JsonRender, PathAndJson, ScopedJson};
+pub use self::local_vars::LocalVars;
 pub use self::output::{Output, StringOutput};
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
 pub use self::render::{Decorator, Evaluable, Helper, RenderContext, Renderable};
 pub use self::template::Template;
-pub use self::local_vars::LocalVars;
 
 #[doc(hidden)]
 pub use self::serde_json::Value as JsonValue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,7 @@ pub use self::output::{Output, StringOutput};
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
 pub use self::render::{Decorator, Evaluable, Helper, RenderContext, Renderable};
 pub use self::template::Template;
+pub use self::local_vars::LocalVars;
 
 #[doc(hidden)]
 pub use self::serde_json::Value as JsonValue;

--- a/src/local_vars.rs
+++ b/src/local_vars.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::value::Value as Json;
 
 #[derive(Default, Debug, Clone)]
-pub(crate) struct LocalVars {
+pub struct LocalVars {
     first: Option<Json>,
     last: Option<Json>,
     index: Option<Json>,


### PR DESCRIPTION
This makes LocalVars public and gives mutable access to it from BlockContext. I need this for [SQLPage](https://github.com/lovasoa/SQLpage)