### PR TITLE
Add a failing test for a partial containing a block

### DIFF
--- a/src/partial.rs
+++ b/src/partial.rs
@@ -448,6 +448,40 @@ foofoofoo"#,
 "#
         );
     }
+
+    #[test]
+    fn test_partial_indent_with_block() {
+        let mut hb = Registry::new();
+
+        hb.register_template_string(
+            "inner",
+            r#"partial first line
+{{#if true}}
+    partial second line
+{{/if}}
+partial third line
+"#,
+        )
+        .unwrap();
+
+        hb.register_template_string(
+            "outer",
+            r#"before partial
+    {{> inner}}
+after partial"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            r#"before partial
+    partial first line
+        partial second line
+    partial third line
+after partial"#,
+            hb.render("outer", &()).unwrap()
+        );
+    }
+
     // Rule::partial_expression should not trim leading indent  by default
 
     #[test]


### PR DESCRIPTION
Here is a failing test for a partial containing a block. This is in response to @sunng87's request: https://github.com/sunng87/handlebars-rust/issues/504#issuecomment-1504382091.

For comparison, here is how handlebars.js handles this situation:

https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23*inline%20%5C%22thepartial%5C%22%7D%7D%5Cnpartial%20first%20line%5Cn%7B%7B%23if%20true%7D%7D%5Cn%20%20%20%20partial%20second%20line%5Cn%7B%7B%2Fif%7D%7D%5Cnpartial%20third%20line%5Cn%7B%7B%2Finline%7D%7D%5Cnbefore%20partial%5Cn%20%20%20%20%7B%7B%3E%20thepartial%7D%7D%5Cnafter%20partial%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%7D%22%2C%22output%22%3A%22before%20partial%5Cn%20%20%20%20partial%20first%20line%5Cn%20%20%20%20%20%20%20%20partial%20second%20line%5Cn%20%20%20%20partial%20third%20line%5Cnafter%20partial%22%2C%22preparationScript%22%3A%22%22%2C%22handlebarsVersion%22%3A%224.7.7%22%7D

It's also worth noting that the bug does not occur if the inline partial is defined with similar indentation but without using a block. It seems to really be an issue about blocks within partials. Some examples:

Indentation is processed correctly:
```
{{#*inline "thepartial"}}
partial first line
    partial second line
partial third line
{{/inline}}
```

Indentation is not processed correctly:
```
{{#*inline "thepartial"}}
partial first line
{{#if true}}
    partial second line
{{/if}}
partial third line
{{/inline}}
```

Indentation is also not processed correctly:
```
{{#*inline "thepartial"}}
partial first line
{{#if true}}    partial second line{{/if}}
partial third line
{{/inline}}
```