### PR TITLE
fix: indent for partials contain block

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -66,12 +66,21 @@ pub struct BlockContext<'rc> {
     block_params: BlockParams<'rc>,
     /// local variables in current context
     local_variables: LocalVars,
+    /// the block is a partial include
+    partial: bool,
 }
 
 impl<'rc> BlockContext<'rc> {
     /// create a new `BlockContext` with default data
     pub fn new() -> BlockContext<'rc> {
         BlockContext::default()
+    }
+
+    /// Copy everything from parent except partial
+    pub fn clone_from_parent(parent: &BlockContext<'rc>) -> BlockContext<'rc> {
+        let mut child = parent.clone();
+        child.partial = false;
+        child
     }
 
     /// set a local variable into current scope
@@ -127,5 +136,15 @@ impl<'rc> BlockContext<'rc> {
     /// Set a block parameter into this block.
     pub fn set_block_params(&mut self, block_params: BlockParams<'rc>) {
         self.block_params = block_params;
+    }
+
+    /// Set the block as a partial block
+    pub fn set_partial(&mut self, partial: bool) {
+        self.partial = partial;
+    }
+
+    /// Test if the block is a partial block
+    pub fn is_partial(&self) -> bool {
+        self.partial
     }
 }

--- a/src/decorators/inline.rs
+++ b/src/decorators/inline.rs
@@ -57,7 +57,7 @@ mod test {
 
         let ctx = Context::null();
         let mut rc = RenderContext::new(None);
-        t0.elements[0].eval(&hbs, &ctx, &mut rc).unwrap();
+        t0.eval(&hbs, &ctx, &mut rc).unwrap();
 
         assert!(rc.get_partial(&"hello".to_owned()).is_some());
     }

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -46,7 +46,7 @@ impl HelperDef for LogHelper {
         if let Ok(log_level) = Level::from_str(level) {
             log!(log_level, "{}", param_to_log)
         } else {
-            return Err(RenderError::new(&format!(
+            return Err(RenderError::new(format!(
                 "Unsupported logging level {}",
                 level
             )));

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -423,6 +423,7 @@ foofoofoo"#,
         hbs.register_template_string("inner", inner).unwrap();
         hbs.register_template_string("outer", outer).unwrap();
 
+        dbg!(hbs.get_template("inner"));
         let result = hbs
             .render(
                 "outer",
@@ -623,6 +624,7 @@ Template:test
 outer third line"#,
         )
         .unwrap();
+
         assert_eq!(
             r#"    inner first line
     inner second line

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -423,7 +423,6 @@ foofoofoo"#,
         hbs.register_template_string("inner", inner).unwrap();
         hbs.register_template_string("outer", outer).unwrap();
 
-        dbg!(hbs.get_template("inner"));
         let result = hbs
             .render(
                 "outer",
@@ -624,7 +623,6 @@ Template:test
 outer third line"#,
         )
         .unwrap();
-
         assert_eq!(
             r#"    inner first line
     inner second line

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -448,6 +448,40 @@ foofoofoo"#,
 "#
         );
     }
+
+    #[test]
+    fn test_partial_indent_with_block() {
+        let mut hb = Registry::new();
+
+        hb.register_template_string(
+            "inner",
+            r#"partial first line
+{{#if true}}
+    partial second line
+{{/if}}
+partial third line
+"#,
+        )
+        .unwrap();
+
+        hb.register_template_string(
+            "outer",
+            r#"before partial
+    {{> inner}}
+after partial"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            r#"before partial
+    partial first line
+        partial second line
+    partial third line
+after partial"#,
+            hb.render("outer", &()).unwrap()
+        );
+    }
+
     // Rule::partial_expression should not trim leading indent  by default
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -775,11 +775,12 @@ pub(crate) fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: S
 #[inline]
 fn indent_aware_write(
     v: &str,
+    initial_indent: bool,
     rc: &mut RenderContext<'_, '_>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     if let Some(indent) = rc.get_indent_string() {
-        out.write(support::str::with_indent(v, indent).as_ref())?;
+        out.write(support::str::with_indent(v, indent, initial_indent).as_ref())?;
     } else {
         out.write(v.as_ref())?;
     }
@@ -795,7 +796,8 @@ impl Renderable for TemplateElement {
         out: &mut dyn Output,
     ) -> Result<(), RenderError> {
         match self {
-            RawString(ref v) => indent_aware_write(v.as_ref(), rc, out),
+            // FIXME: set initial_indent to true when it starts a newline
+            RawString(ref v) => indent_aware_write(v.as_ref(), true, rc, out),
             Expression(ref ht) | HtmlExpression(ref ht) => {
                 let is_html_expression = matches!(self, HtmlExpression(_));
                 if is_html_expression {
@@ -825,7 +827,7 @@ impl Renderable for TemplateElement {
                         } else {
                             let rendered = context_json.value().render();
                             let output = do_escape(registry, rc, rendered);
-                            indent_aware_write(output.as_ref(), rc, out)
+                            indent_aware_write(output.as_ref(), false, rc, out)
                         }
                     }
                 } else {

--- a/src/render.rs
+++ b/src/render.rs
@@ -775,12 +775,11 @@ pub(crate) fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: S
 #[inline]
 fn indent_aware_write(
     v: &str,
-    initial_indent: bool,
     rc: &mut RenderContext<'_, '_>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     if let Some(indent) = rc.get_indent_string() {
-        out.write(support::str::with_indent(v, indent, initial_indent).as_ref())?;
+        out.write(support::str::with_indent(v, indent).as_ref())?;
     } else {
         out.write(v.as_ref())?;
     }
@@ -796,8 +795,7 @@ impl Renderable for TemplateElement {
         out: &mut dyn Output,
     ) -> Result<(), RenderError> {
         match self {
-            // FIXME: set initial_indent to true when it starts a newline
-            RawString(ref v) => indent_aware_write(v.as_ref(), true, rc, out),
+            RawString(ref v) => indent_aware_write(v.as_ref(), rc, out),
             Expression(ref ht) | HtmlExpression(ref ht) => {
                 let is_html_expression = matches!(self, HtmlExpression(_));
                 if is_html_expression {
@@ -827,7 +825,7 @@ impl Renderable for TemplateElement {
                         } else {
                             let rendered = context_json.value().render();
                             let output = do_escape(registry, rc, rendered);
-                            indent_aware_write(output.as_ref(), false, rc, out)
+                            indent_aware_write(output.as_ref(), rc, out)
                         }
                     }
                 } else {

--- a/src/support.rs
+++ b/src/support.rs
@@ -58,15 +58,15 @@ pub mod str {
     }
 
     /// add indent for lines but last
-    pub fn with_indent(s: &str, indent: &str) -> String {
+    pub fn with_indent(s: &str, indent: &str, skip_last: bool) -> String {
         let mut output = String::new();
 
         let mut it = s.chars().peekable();
         while let Some(c) = it.next() {
             output.push(c);
-            // check if c is not the last character, we don't append
-            // indent for last line break
-            if c == '\n' && it.peek().is_some() {
+            // check if c is not the last character of last element, we don't
+            // append indent
+            if c == '\n' && (it.peek().is_some() || !skip_last) {
                 output.push_str(indent);
             }
         }

--- a/src/support.rs
+++ b/src/support.rs
@@ -57,13 +57,9 @@ pub mod str {
         output
     }
 
-    /// Add indent for lines but last
-    pub fn with_indent(s: &str, indent: &str, initial_indent: bool) -> String {
-        let mut output = if initial_indent {
-            indent.to_string()
-        } else {
-            String::new()
-        };
+    /// add indent for lines but last
+    pub fn with_indent(s: &str, indent: &str) -> String {
+        let mut output = String::new();
 
         let mut it = s.chars().peekable();
         while let Some(c) = it.next() {
@@ -99,12 +95,12 @@ pub mod str {
         }
     }
 
-    pub(crate) fn find_trailing_indent(s: &str) -> Option<&str> {
+    pub(crate) fn find_trailing_whitespace_chars(s: &str) -> Option<&str> {
         let trimmed = s.trim_end_matches(whitespace_matcher);
-        if trimmed.ends_with(newline_matcher) && trimmed.len() < s.len() {
-            Some(&s[trimmed.len()..])
-        } else {
+        if trimmed.len() == s.len() {
             None
+        } else {
+            Some(&s[trimmed.len()..])
         }
     }
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -57,9 +57,13 @@ pub mod str {
         output
     }
 
-    /// add indent for lines but last
-    pub fn with_indent(s: &str, indent: &str) -> String {
-        let mut output = String::new();
+    /// Add indent for lines but last
+    pub fn with_indent(s: &str, indent: &str, initial_indent: bool) -> String {
+        let mut output = if initial_indent {
+            indent.to_string()
+        } else {
+            String::new()
+        };
 
         let mut it = s.chars().peekable();
         while let Some(c) = it.next() {
@@ -95,12 +99,12 @@ pub mod str {
         }
     }
 
-    pub(crate) fn find_trailing_whitespace_chars(s: &str) -> Option<&str> {
+    pub(crate) fn find_trailing_indent(s: &str) -> Option<&str> {
         let trimmed = s.trim_end_matches(whitespace_matcher);
-        if trimmed.len() == s.len() {
-            None
-        } else {
+        if trimmed.ends_with(newline_matcher) && trimmed.len() < s.len() {
             Some(&s[trimmed.len()..])
+        } else {
+            None
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -427,15 +427,6 @@ impl Template {
         }
     }
 
-    fn remove_previous_indent(template_stack: &mut VecDeque<Template>) {
-        let t = template_stack.front_mut().unwrap();
-        if let Some(RawString(ref mut text)) = t.elements.last_mut() {
-            *text = text
-                .trim_end_matches(support::str::whitespace_matcher)
-                .to_owned();
-        }
-    }
-
     // in handlebars, the whitespaces around statement are
     // automatically trimed.
     // this function checks if current span has both leading and
@@ -735,19 +726,19 @@ impl Template {
                                     prevent_indent,
                                 );
 
-                                let mut decorator = DecoratorTemplate::new(exp.clone());
+                                // indent for partial expression >
+                                let mut indent = None;
                                 if rule == Rule::partial_expression
                                     && !options.prevent_indent
                                     && !exp.omit_pre_ws
                                 {
-                                    // indent for partial expression >
-                                    if let Some(indent) =
-                                        support::str::find_trailing_indent(&source[..span.start()])
-                                    {
-                                        decorator.indent = Some(indent.to_owned());
-                                        Template::remove_previous_indent(&mut template_stack);
-                                    }
+                                    indent = support::str::find_trailing_whitespace_chars(
+                                        &source[..span.start()],
+                                    );
                                 }
+
+                                let mut decorator = DecoratorTemplate::new(exp.clone());
+                                decorator.indent = indent.map(|s| s.to_owned());
 
                                 let el = if rule == Rule::decorator_expression {
                                     DecoratorExpression(Box::new(decorator))


### PR DESCRIPTION
Fixes #573 

Our previous implementation of partial indent assumes the partial has only `RawString` or `Expression` so that we can check line endings easier. But with blocks included in partial, it doesn't work for lack of information about *last line* of the partial. 

This patch is seeking a solution for that