### PR TITLE
Fix parameter passing for single-quoted string literals

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -288,11 +288,24 @@ impl Template {
                 Parameter::Path(Path::new(param_span.as_str(), path_segs))
             }
             Rule::literal => {
-                let s = param_span.as_str();
-                if let Ok(json) = Json::from_str(s) {
-                    Parameter::Literal(json)
-                } else {
-                    Parameter::Name(s.to_owned())
+                // Parse the parameter as a JSON literal
+                let param_literal = it.next().unwrap();
+                match param_literal.as_rule() {
+                    Rule::string_literal if it.peek().unwrap().as_rule() == Rule::string_inner_single_quote => {
+                        // ...unless the parameter is a single-quoted string.
+                        // In that case, transform it to a double-quoted string
+                        // and then parse it as a JSON literal.
+                        let string_inner_single_quote = it.next().unwrap();
+                        let double_quoted = format!(
+                            "\"{}\"",
+                            string_inner_single_quote.as_str()
+                                .replace("\\'", "'")
+                                .replace("\"", "\\\""));
+                        Parameter::Literal(Json::from_str(&double_quoted).unwrap())
+                    }
+                    _ => {
+                        Parameter::Literal(Json::from_str(param_span.as_str()).unwrap())
+                    }
                 }
             }
             Rule::subexpression => {

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -27,17 +27,42 @@ fn test_string_no_escape_422() {
     handlebars_helper!(replace: |input: str, from: str, to: str| {
         input.replace(from, to)
     });
+    handlebars_helper!(echo: |input: str| {
+        input
+    });
     hbs.register_helper("replace", Box::new(replace));
+    hbs.register_helper("echo", Box::new(echo));
 
     assert_eq!(
         r#"some\ path"#,
         hbs.render_template(r#"{{replace "some/path" "/" "\\ " }}"#, &())
             .unwrap()
     );
+    assert_eq!(
+        r#"some\ path"#,
+        hbs.render_template(r#"{{replace 'some/path' '/' '\\ ' }}"#, &())
+            .unwrap()
+    );
 
     assert_eq!(
         r#"some\path"#,
         hbs.render_template(r#"{{replace "some/path" "/" "\\" }}"#, &())
+            .unwrap()
+    );
+    assert_eq!(
+        r#"some\path"#,
+        hbs.render_template(r#"{{replace 'some/path' '/' '\\' }}"#, &())
+            .unwrap()
+    );
+
+    assert_eq!(
+        r#"double-quoted \ &#x27;with&#x27; &quot;nesting&quot;"#,
+        hbs.render_template(r#"{{echo "double-quoted \\ 'with' \"nesting\""}}"#, &())
+            .unwrap()
+    );
+    assert_eq!(
+        r#"single-quoted \ &#x27;with&#x27; &quot;nesting&quot;"#,
+        hbs.render_template(r#"{{echo 'single-quoted \\ \'with\' "nesting"'}}"#, &())
             .unwrap()
     );
 }

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -100,5 +100,11 @@ fn test_macro_helper() {
         )
         .unwrap(),
         "false"
-    )
+    );
+
+    assert_eq!(
+        hbs.render_template("{{tag 'html'}}", &()).unwrap(),
+        "&lt;html&gt;"
+    );
+
 }


### PR DESCRIPTION
Addresses issue https://github.com/sunng87/handlebars-rust/issues/575.

I added some more checks to the `test_string_no_escape_422` function, because it seemed to be testing closely related behavior. But if you want I could put them in a new `575` function instead.