### PR TITLE
fix: use std::result::Result instead of Result in handlebar_helper!() macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! handlebars_helper {
                 r: &'reg $crate::Handlebars<'reg>,
                 _: &'rc $crate::Context,
                 _: &mut $crate::RenderContext<'reg, 'rc>,
-            ) -> Result<$crate::ScopedJson<'rc>, $crate::RenderError> {
+            ) -> std::result::Result<$crate::ScopedJson<'rc>, $crate::RenderError> {
                 let mut param_idx = 0;
 
                 $(


### PR DESCRIPTION
It is often customary to define a crate wide `Error` and `Result` type. Something like:

```
type Error = ...
type Result<T> = std::result::Result<T, Error>
```

If such `Result<T>` type is in scope when calling the `handlebar_helper!()` macro, compilation fails as the number of template argument does not match.

This commit modified macro to rely explicitely on `std::result::Result<>` instead of the whatever Result type is in scope when the macro is invoked.