### PR TITLE
Render arrays without trailing commas

### DIFF
--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -513,6 +513,16 @@ mod test {
     }
 
     #[test]
+    fn test_render_array_without_trailig_commas() {
+        let reg = Registry::new();
+        let template = "Array: {{array}}";
+        let input = json!({"array": [1, 2, 3]});
+        let rendered = reg.render_template(template, &input);
+
+        assert_eq!("Array: [1, 2, 3]", rendered.unwrap());
+    }
+
+    #[test]
     fn test_recursion() {
         let mut reg = Registry::new();
         assert!(reg
@@ -534,15 +544,15 @@ mod test {
             "string": "hi"
         });
         let expected_output = "(\
-            array: [42, [object], [[], ], ] (\
+            array: [42, [object], [[]]] (\
                 0: 42 (), \
                 1: [object] (wow: cool (), ), \
-                2: [[], ] (0: [] (), ), \
+                2: [[]] (0: [] (), ), \
             ), \
             object: [object] (\
                 a: [object] (\
                     b: c (), \
-                    d: [e, ] (0: e (), ), \
+                    d: [e] (0: e (), ), \
                 ), \
             ), \
             string: hi (), \

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -117,9 +117,12 @@ impl JsonRender for Json {
             Json::Array(ref a) => {
                 let mut buf = String::new();
                 buf.push('[');
-                for i in a.iter() {
-                    buf.push_str(i.render().as_ref());
-                    buf.push_str(", ");
+                for (i, value) in a.iter().enumerate() {
+                    buf.push_str(value.render().as_ref());
+
+                    if i < a.len() - 1 {
+                        buf.push_str(", ");
+                    }
                 }
                 buf.push(']');
                 buf


### PR DESCRIPTION
## Problem
Arrays are being rendered with trailing commas
Related to #587 

## Solution
Verify when rendering an array that last element being rendered does not include a comma and space

## Added tests ✅ 