### PR TITLE
Added TemplateErrorReason to exported types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ extern crate serde_json;
 pub use self::block::{BlockContext, BlockParams};
 pub use self::context::Context;
 pub use self::decorators::DecoratorDef;
-pub use self::error::{RenderError, RenderErrorReason, TemplateError};
+pub use self::error::{RenderError, RenderErrorReason, TemplateError, TemplateErrorReason};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::json::path::Path;
 pub use self::json::value::{to_json, JsonRender, PathAndJson, ScopedJson};


### PR DESCRIPTION
Currently, TemplateErrorReason is not being exported, while RenderErrorReason is.
This PR fixes this inconsistency by exporting TemplateErrorReason.