### PR TITLE
Added dev mode and extension filter for RustEmbed

### DIFF
--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufReader, Error as IOError, Read};
+use std::io::{BufReader, Error as IOError, ErrorKind, Read};
 use std::path::PathBuf;
 
 pub(crate) trait Source {
@@ -30,5 +30,24 @@ impl Source for FileSource {
         reader.read_to_string(&mut buf)?;
 
         Ok(buf)
+    }
+}
+
+pub(crate) struct LazySource<F: Fn() -> Option<String>> {
+    loader: F,
+}
+
+impl<F: Fn() -> Option<String>> LazySource<F> {
+    pub(crate) fn new(loader: F) -> LazySource<F> {
+        LazySource { loader }
+    }
+}
+
+impl<F: Fn() -> Option<String>> Source for LazySource<F> {
+    type Item = String;
+    type Error = IOError;
+
+    fn load(&self) -> Result<Self::Item, Self::Error> {
+        (self.loader)().ok_or(IOError::new(ErrorKind::Other, "Source load error"))
     }
 }

--- a/tests/embed.rs
+++ b/tests/embed.rs
@@ -25,3 +25,50 @@ fn test_embed() {
         "Hello, Andy"
     );
 }
+
+#[test]
+#[cfg(feature = "rust-embed")]
+fn test_embed_with_extension() {
+    use rust_embed::RustEmbed;
+
+    #[derive(RustEmbed)]
+    #[folder = "tests/templates/"]
+    struct Templates;
+
+    let mut hbs = handlebars::Handlebars::new();
+    hbs.register_embed_templates_with_extension::<Templates>(".hbs")
+        .unwrap();
+
+    assert_eq!(1, hbs.get_templates().len());
+
+    let data = json!({
+        "name": "Andy"
+    });
+
+    assert_eq!(hbs.render("hello", &data).unwrap().trim(), "Hello, Andy");
+}
+
+#[test]
+#[cfg(feature = "rust-embed")]
+fn test_embed_with_extension_and_tests_struct_root() {
+    use rust_embed::RustEmbed;
+
+    #[derive(RustEmbed)]
+    #[folder = "tests/"]
+    struct Templates;
+
+    let mut hbs = handlebars::Handlebars::new();
+    hbs.register_embed_templates_with_extension::<Templates>(".hbs")
+        .unwrap();
+
+    assert_eq!(1, hbs.get_templates().len());
+
+    let data = json!({
+        "name": "Andy"
+    });
+
+    assert_eq!(
+        hbs.render("templates/hello", &data).unwrap().trim(),
+        "Hello, Andy"
+    );
+}


### PR DESCRIPTION
Hi! 

Thanks for the library! 
I have a problem while working with RustEmbed struct. I want a live reload, but now it is implemented only for file register, so i used workaround by iterating struct and register using filenames from it, but i  would like to have it implemented by [handlebars-rust](https://github.com/sunng87/handlebars-rust)

This PR adds dev mode for RustEmbed,  [_which if built not in release mode, reads from the file system on each call_](https://github.com/pyrossh/rust-embed#getfile_path-str---optionrust_embedembeddedfile).
Also added method which names templates and filters files like register_templates_directory does.
