### PR TITLE
Add hidden flag to control when hidden files are ignored

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -850,7 +850,8 @@ mod test {
             let mut file4: File = File::create(&file4_path).unwrap();
             writeln!(file4, "<h1>Hallo {{world}}!</h1>").unwrap();
 
-            r.register_templates_directory(".hbs", dir.path(), false).unwrap();
+            r.register_templates_directory(".hbs", dir.path(), false)
+                .unwrap();
 
             assert_eq!(r.templates.len(), 3);
             assert_eq!(r.templates.contains_key("t1"), true);
@@ -880,7 +881,8 @@ mod test {
             let mut file3: File = File::create(&file3_path).unwrap();
             writeln!(file3, "<h1>Hello world!</h1>").unwrap();
 
-            r.register_templates_directory(".hbs", dir.path(), false).unwrap();
+            r.register_templates_directory(".hbs", dir.path(), false)
+                .unwrap();
 
             assert_eq!(r.templates.len(), 4);
             assert_eq!(r.templates.contains_key("t4"), true);
@@ -915,7 +917,8 @@ mod test {
             let mut file3: File = File::create(&file3_path).unwrap();
             writeln!(file3, "<h1>Ciao {{world}}!</h1>").unwrap();
 
-            r.register_templates_directory(".hbs", dir.path(), false).unwrap();
+            r.register_templates_directory(".hbs", dir.path(), false)
+                .unwrap();
 
             assert_eq!(r.templates.len(), 7);
             assert_eq!(r.templates.contains_key("french/t7"), true);
@@ -943,7 +946,8 @@ mod test {
             if !dir_path.ends_with("/") {
                 dir_path.push('/');
             }
-            r.register_templates_directory(".hbs", dir_path, false).unwrap();
+            r.register_templates_directory(".hbs", dir_path, false)
+                .unwrap();
 
             assert_eq!(r.templates.len(), 8);
             assert_eq!(r.templates.contains_key("t10"), true);
@@ -987,7 +991,8 @@ mod test {
             let mut file1: File = File::create(&file1_path).unwrap();
             writeln!(file1, "<h1>Hello {{world}}!</h1>").unwrap();
 
-            r.register_templates_directory(".hbs", dir.path(), true).unwrap();
+            r.register_templates_directory(".hbs", dir.path(), true)
+                .unwrap();
 
             assert_eq!(r.templates.len(), 1);
             assert_eq!(r.templates.contains_key(".t12"), true);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -337,8 +337,7 @@ impl<'reg> Registry<'reg> {
                     .file_stem()
                     .map(|stem| stem.to_string_lossy())
                     .map(|stem| {
-                        !((!options.hidden && stem.starts_with('.'))
-                            || !options.temporary && stem.starts_with('#'))
+                        (!stem.starts_with('#') || options.temporary) && (!stem.starts_with('.') || options.hidden)
                     })
                     .unwrap_or(false)
             })

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -337,7 +337,8 @@ impl<'reg> Registry<'reg> {
                     .file_stem()
                     .map(|stem| stem.to_string_lossy())
                     .map(|stem| {
-                        (!stem.starts_with('#') || options.temporary) && (!stem.starts_with('.') || options.hidden)
+                        (!stem.starts_with('#') || options.temporary)
+                            && (!stem.starts_with('.') || options.hidden)
                     })
                     .unwrap_or(false)
             })

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -298,16 +298,16 @@ impl<'reg> Registry<'reg> {
     /// * `dir_path`: the path of directory
     ///
     /// Hidden files and tempfile (starts with `#`) will be ignored by default.
-    /// Set `hidden` to `true` to avoid ignoring hidden files.
-    /// All registered will use their relative name as template name.
-    /// For example, when `dir_path` is `templates/` and `tpl_extension` is `.hbs`, the file
+    /// Set `DirectorySourceOptions` to something other than `DirectorySourceOptions::default()` to adjust this.
+    /// All registered templates will use their relative path to determine their template name.
+    /// For example, when `dir_path` is `templates/` and `DirectorySourceOptions.tpl_extension` is `.hbs`, the file
     /// `templates/some/path/file.hbs` will be registered as `some/path/file`.
     ///
     /// This method is not available by default.
     /// You will need to enable the `dir_source` feature to use it.
     ///
-    /// When dev_mode enabled, like `register_template_file`, templates is reloaded
-    /// from file system everytime it's visied.
+    /// When dev_mode is enabled, like with `register_template_file`, templates are reloaded
+    /// from the file system every time they're visited.
     #[cfg(feature = "dir_source")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dir_source")))]
     pub fn register_templates_directory<P>(


### PR DESCRIPTION
Would you be willing to accept this adjustment to allow for an additional `hidden` parameter to be passed into `register_templates_directory` to control whether hidden files are ignored?

This would allow for template directories that contained hidden files which should be registered.