### PR TITLE
Re-export JsonTruthy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ pub use self::decorators::DecoratorDef;
 pub use self::error::{RenderError, RenderErrorReason, TemplateError, TemplateErrorReason};
 pub use self::helpers::{HelperDef, HelperResult};
 pub use self::json::path::Path;
-pub use self::json::value::{to_json, JsonRender, PathAndJson, ScopedJson};
+pub use self::json::value::{to_json, JsonRender, JsonTruthy, PathAndJson, ScopedJson};
 pub use self::local_vars::LocalVars;
 pub use self::output::{Output, StringOutput};
 #[cfg(feature = "dir_source")]


### PR DESCRIPTION
Or is there a specific reason why this is not done?