### PR TITLE
refactor: turn off pub access of chain in HelperTemplate

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -136,7 +136,7 @@ pub struct HelperTemplate {
     pub template: Option<Template>,
     pub inverse: Option<Template>,
     pub block: bool,
-    pub chain: bool,
+    chain: bool,
 }
 
 impl HelperTemplate {


### PR DESCRIPTION
Because `chain` is not used during rendering process, here I turned off pub access of this field for better compatibility.