### PR TITLE
improve error messages on parse errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,8 @@ pub enum TemplateErrorReason {
     MismatchingClosedHelper(String, String),
     #[error("decorator {0:?} was opened, but {1:?} is closing")]
     MismatchingClosedDecorator(String, String),
-    #[error("invalid handlebars syntax.")]
-    InvalidSyntax,
+    #[error("invalid handlebars syntax: {0}")]
+    InvalidSyntax(String),
     #[error("invalid parameter {0:?}")]
     InvalidParam(String),
     #[error("nested subexpression is not supported")]

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -43,66 +43,66 @@ reference = ${ path_inline }
 
 name = _{ subexpression | reference }
 
-param = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
-hash = { identifier ~ "=" ~ param }
+helper_parameter = { !(keywords ~ !symbol_char) ~ (literal | reference | subexpression) }
+hash = { identifier ~ "=" ~ helper_parameter }
 block_param = { "as" ~ "|" ~ identifier ~ identifier? ~ "|"}
-exp_line = _{ identifier ~ (hash|param)* ~ block_param?}
-partial_exp_line = _{ ((partial_identifier|name) ~ (hash|param)*) }
+exp_line = _{ identifier ~ (hash|helper_parameter)* ~ block_param?}
+partial_exp_line = _{ ((partial_identifier|name) ~ (hash|helper_parameter)*) }
 
-subexpression = { "(" ~ ((identifier ~ (hash|param)+) | reference)  ~ ")" }
+subexpression = { "(" ~ ((identifier ~ (hash|helper_parameter)+) | reference)  ~ ")" }
 
-pre_whitespace_omitter = { "~" }
-pro_whitespace_omitter = { "~" }
+leading_tilde_to_omit_whitespace = { "~" }
+trailing_tilde_to_omit_whitespace = { "~" }
 
-expression = { !(invert_tag|invert_chain_tag) ~ "{{" ~ pre_whitespace_omitter? ~
-              ((identifier ~ (hash|param)+) | name )
-              ~ pro_whitespace_omitter? ~ "}}" }
-html_expression_triple_bracket_legacy = _{ "{{{" ~ pre_whitespace_omitter? ~
-                                           ((identifier ~ (hash|param)+) | name ) ~
-                                           pro_whitespace_omitter? ~ "}}}" }
-html_expression_triple_bracket = _{ "{{" ~ pre_whitespace_omitter? ~ "{" ~
-                                              ((identifier ~ (hash|param)+) | name ) ~
-                                              "}" ~ pro_whitespace_omitter? ~ "}}" }
+expression = { !(invert_tag|invert_chain_tag) ~ "{{" ~ leading_tilde_to_omit_whitespace? ~
+              ((identifier ~ (hash|helper_parameter)+) | name )
+              ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
+html_expression_triple_bracket_legacy = _{ "{{{" ~ leading_tilde_to_omit_whitespace? ~
+                                           ((identifier ~ (hash|helper_parameter)+) | name ) ~
+                                           trailing_tilde_to_omit_whitespace? ~ "}}}" }
+html_expression_triple_bracket = _{ "{{" ~ leading_tilde_to_omit_whitespace? ~ "{" ~
+                                              ((identifier ~ (hash|helper_parameter)+) | name ) ~
+                                              "}" ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
 
-amp_expression = _{ "{{" ~ pre_whitespace_omitter? ~ "&" ~ name ~
-                       pro_whitespace_omitter? ~ "}}" }
+amp_expression = _{ "{{" ~ leading_tilde_to_omit_whitespace? ~ "&" ~ name ~
+                       trailing_tilde_to_omit_whitespace? ~ "}}" }
 html_expression = { (html_expression_triple_bracket_legacy | html_expression_triple_bracket)
                    | amp_expression }
 
-decorator_expression = { "{{" ~ pre_whitespace_omitter? ~ "*" ~ exp_line ~
-pro_whitespace_omitter? ~ "}}" }
-partial_expression = { "{{" ~ pre_whitespace_omitter? ~ ">" ~ partial_exp_line
-                     ~ pro_whitespace_omitter? ~ "}}" }
+decorator_expression = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "*" ~ exp_line ~
+trailing_tilde_to_omit_whitespace? ~ "}}" }
+partial_expression = { "{{" ~ leading_tilde_to_omit_whitespace? ~ ">" ~ partial_exp_line
+                     ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
 
 invert_tag_item = { "else"|"^" }
-invert_tag = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
-             ~ pro_whitespace_omitter? ~ "}}" }
-invert_chain_tag = { !escape ~ "{{" ~ pre_whitespace_omitter? ~ invert_tag_item
-                     ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-helper_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ exp_line ~
-                     pro_whitespace_omitter? ~ "}}" }
-helper_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                   pro_whitespace_omitter? ~ "}}" }
+invert_tag = { !escape ~ "{{" ~ leading_tilde_to_omit_whitespace? ~ invert_tag_item
+             ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
+invert_chain_tag = { !escape ~ "{{" ~ leading_tilde_to_omit_whitespace? ~ invert_tag_item
+                     ~ exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
+helper_block_start = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "#" ~ exp_line ~
+                     trailing_tilde_to_omit_whitespace? ~ "}}" }
+helper_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ identifier ~
+                   trailing_tilde_to_omit_whitespace? ~ "}}" }
 helper_block = _{ helper_block_start ~ template ~
                   (invert_chain_tag ~ template)* ~ (invert_tag ~ template)? ~ helper_block_end }
 
-decorator_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ "*"
-                        ~ exp_line ~ pro_whitespace_omitter? ~ "}}" }
-decorator_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                        pro_whitespace_omitter? ~ "}}" }
+decorator_block_start = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "#" ~ "*"
+                        ~ exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
+decorator_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ identifier ~
+                        trailing_tilde_to_omit_whitespace? ~ "}}" }
 decorator_block = _{ decorator_block_start ~ template ~
                      decorator_block_end }
 
-partial_block_start = { "{{" ~ pre_whitespace_omitter? ~ "#" ~ ">"
-                        ~ partial_exp_line ~ pro_whitespace_omitter? ~ "}}" }
-partial_block_end = { "{{" ~ pre_whitespace_omitter? ~ "/" ~ partial_identifier ~
-                      pro_whitespace_omitter? ~ "}}" }
+partial_block_start = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "#" ~ ">"
+                        ~ partial_exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
+partial_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ partial_identifier ~
+                      trailing_tilde_to_omit_whitespace? ~ "}}" }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 
-raw_block_start = { "{{{{" ~ pre_whitespace_omitter? ~ exp_line ~
-                    pro_whitespace_omitter? ~ "}}}}" }
-raw_block_end = { "{{{{" ~ pre_whitespace_omitter? ~ "/" ~ identifier ~
-                  pro_whitespace_omitter? ~ "}}}}" }
+raw_block_start = { "{{{{" ~ leading_tilde_to_omit_whitespace? ~ exp_line ~
+                    trailing_tilde_to_omit_whitespace? ~ "}}}}" }
+raw_block_end = { "{{{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ identifier ~
+                  trailing_tilde_to_omit_whitespace? ~ "}}}}" }
 raw_block = _{ raw_block_start ~ raw_block_text ~ raw_block_end }
 
 hbs_comment = { "{{!" ~ "--" ~ (!"--}}" ~ ANY)* ~ "--" ~ "}}" }
@@ -121,7 +121,7 @@ template = { (
             partial_expression |
             partial_block )* }
 
-parameter = _{ param ~ EOI }
+parameter = _{ helper_parameter ~ EOI }
 handlebars = _{ template ~ EOI }
 
 /// json path visitor

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -103,7 +103,7 @@ mod test {
     fn test_param() {
         let s = vec!["hello", "\"json literal\"", "nullable", "truestory"];
         for i in s.iter() {
-            assert_rule!(Rule::param, i);
+            assert_rule!(Rule::helper_parameter, i);
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -640,9 +640,11 @@ impl Template {
                 LineColLocation::Pos(line_col) => line_col,
                 LineColLocation::Span(line_col, _) => line_col,
             };
-            TemplateError::of(TemplateErrorReason::InvalidSyntax(e.variant.message().to_string()))
-                .at(source, line_no, col_no)
-                .in_template(options.name())
+            TemplateError::of(TemplateErrorReason::InvalidSyntax(
+                e.variant.message().to_string(),
+            ))
+            .at(source, line_no, col_no)
+            .in_template(options.name())
         })?;
 
         // dbg!(parser_queue.clone().flatten());
@@ -1133,7 +1135,10 @@ mod test {
 
         let terr = Template::compile(source).unwrap_err();
 
-        assert!(matches!(terr.reason(), TemplateErrorReason::InvalidSyntax(_)));
+        assert!(matches!(
+            terr.reason(),
+            TemplateErrorReason::InvalidSyntax(_)
+        ));
         assert_eq!(terr.pos(), Some((4, 5)));
     }
 
@@ -1253,7 +1258,11 @@ mod test {
                 TemplateErrorReason::InvalidSyntax(s) => s,
                 _ => panic!("InvalidSyntax expected"),
             };
-            assert!(syntax_error_msg.contains("expected identifier"), "{}", syntax_error_msg);
+            assert!(
+                syntax_error_msg.contains("expected identifier"),
+                "{}",
+                syntax_error_msg
+            );
         }
     }
 


### PR DESCRIPTION
I had an user report being unable to debug a template syntax error, because the error message just said "invalid handlebars syntax" without more details: https://github.com/lovasoa/SQLpage/discussions/275#discussion-6413288

This changes syntax error messages to include the precise source of the syntax error

this also renames some grammar rules to make them easier to understand
