### PR TITLE
impl From<RenderError> for RenderErrorReason

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -150,6 +150,12 @@ impl From<RenderErrorReason> for RenderError {
     }
 }
 
+impl From<RenderError> for RenderErrorReason {
+    fn from(e: RenderError) -> Self {
+        *e.reason
+    }
+}
+
 impl RenderError {
     #[deprecated(since = "5.0.0", note = "Use RenderErrorReason instead")]
     pub fn new<T: AsRef<str>>(desc: T) -> RenderError {


### PR DESCRIPTION
This just allows one to get the `RenderErrorReason` out of a `RenderError` **by value**.
The current `reason()` function only gives a reference, and the `reason` member is not `pub` (presumably for good reason).

My usecase for this is that I am using `render_to_write` with known, good data.
So the only possible error is an `std::io::Error` from the underlying writer, so I want to return that.
Unfortunately, `std::io::Error` isn't `Clone` so I can't get it out of the `&RenderErrorReason` that I'm currently getting.

I figured this was simple enough to not require a huge discussion in an issue first, but I'll gladly implement a different solution for this usecase if this conversion function is not acceptable for some reason.

Cheers and thank you for the awesome library.