### PR TITLE
Fix nested partial indenting

### DIFF
--- a/src/partial.rs
+++ b/src/partial.rs
@@ -667,6 +667,48 @@ outer third line"#,
     }
 
     #[test]
+    fn test_indent_level_on_nested_partials() {
+        let nested_partial = "
+<div>
+    content
+</div>
+";
+        let partial = "
+<div>
+    {{>nested_partial}}
+</div>
+";
+
+        let partial_indented = "
+<div>
+    {{>partial}}
+</div>
+";
+
+        let result = "
+<div>
+    <div>
+        <div>
+            content
+        </div>
+    </div>
+</div>
+";
+
+        let mut hb = Registry::new();
+        hb.register_template_string("nested_partial", nested_partial.trim_start())
+            .unwrap();
+        hb.register_template_string("partial", partial.trim_start())
+            .unwrap();
+        hb.register_template_string("partial_indented", partial_indented.trim_start())
+            .unwrap();
+
+        let s = hb.render("partial_indented", &()).unwrap();
+
+        assert_eq!(&s, result.trim_start());
+    }
+
+    #[test]
     fn test_issue_534() {
         let t1 = "{{title}}";
         let t2 = "{{#each modules}}{{> (lookup this \"module\") content name=0}}{{/each}}";

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -133,11 +133,12 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
         }
 
         // indent
-        local_rc.set_indent_string(d.indent());
+        local_rc.set_indent_string(d.indent().cloned());
 
         let result = t.render(r, ctx, &mut local_rc, out);
 
         // cleanup
+
         if block_created {
             local_rc.pop_block();
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -807,6 +807,12 @@ impl Renderable for TemplateElement {
         out: &mut dyn Output,
     ) -> Result<(), RenderError> {
         match self {
+            Indent => {
+                if let Some(indent) = rc.get_indent_string() {
+                    out.write(indent)?;
+                }
+                Ok(())
+            }
             RawString(ref v) => indent_aware_write(v.as_ref(), rc, out),
             Expression(ref ht) | HtmlExpression(ref ht) => {
                 let is_html_expression = matches!(self, HtmlExpression(_));


### PR DESCRIPTION
Currently, nested partials don't indent correctly.
This is due to two problems:
- The `indent` in `RenderContextInner` is not built up correctly
- After a stanalone partial, the next raw text is trimmed, so it will not be indented (no leading newline),
  causing it to be misindented.
  
This PR addresses both issues, causing a simple nested [example](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23*inline%20%5C%22nested_partial%5C%22%7D%7D%5Cn%3Cdiv%3E%5Cn%5Ctcontent%5Cn%3C%2Fdiv%3E%5Cn%7B%7B%2Finline%7D%7D%5Cn%7B%7B%23*inline%20%5C%22partial%5C%22%7D%7D%5Cn%3Cdiv%3E%5Cn%5Ct%7B%7B%3Enested_partial%7D%7D%5Cn%3C%2Fdiv%3E%5Cn%7B%7B%2Finline%7D%7D%5Cn%3Cdiv%3E%5Cn%5Ct%7B%7B%3E%20partial%20%7D%7D%5Cn%3C%2Fdiv%3E%5Cn%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%7D%5Cn%22%2C%22output%22%3A%22%3Cdiv%3E%5Cn%5Ct%3Cdiv%3E%5Cn%5Ct%5Ct%3Cdiv%3E%5Cn%5Ct%5Ct%5Ctcontent%5Cn%5Ct%5Ct%3C%2Fdiv%3E%5Cn%5Ct%3C%2Fdiv%3E%5Cn%3C%2Fdiv%3E%5Cn%22%2C%22preparationScript%22%3A%22%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.8%22%7D) (that was also added as a test case) to be indented correctly.

## Example Input
```
{{#*inline "nested_partial"}}
<div>
    content
</div>
{{/inline}}

{{#*inline "partial"}}
<div>
    {{>nested_partial}}
</div>
{{/inline}}

<div>
    {{> partial }}
</div>
```
### Output Before
```
<div>
    <div>
        <div>
        content
    </div>
</div>
</div>
```

### Output After
```
<div>
    <div>
        <div>
            content
        </div>
    </div>
</div>
```