### PR TITLE
Fix indent after if

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -714,6 +714,13 @@ impl Template {
                 match rule {
                     Rule::template => {
                         template_stack.push_front(Template::new());
+                        if indent_template_begin {
+                            template_stack.front_mut().unwrap().push_element(
+                                TemplateElement::Indent,
+                                line_no,
+                                col_no,
+                            );
+                        }
                     }
                     Rule::raw_text => {
                         // leading space fix
@@ -737,10 +744,6 @@ impl Template {
                             // so we need to indent here too
                             emit_indent |= prev_rule == Some(Rule::helper_block_end);
                         }
-
-                        // if a helper template stars with an inline string, it will
-                        // need to be indented accordingly
-                        emit_indent |= prev_rule == Some(Rule::template) && indent_template_begin;
 
                         if emit_indent {
                             t.push_element(TemplateElement::Indent, line_no, col_no);

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -22,3 +22,32 @@ fn test_whitespaces_elision() {
             .unwrap()
     );
 }
+
+#[test]
+fn test_indent_after_if() {
+    let input = r#"
+{{#*inline "partial"}}
+<div>
+    {{#if foo}}
+    foobar
+    {{/if}}
+</div>
+{{/inline}}
+<div>
+    {{>partial}}
+</div>
+"#;
+    let output = "
+<div>
+    <div>
+        foobar
+    </div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": true})).unwrap(),
+        output
+    );
+}

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -51,3 +51,39 @@ fn test_indent_after_if() {
         output
     );
 }
+
+#[test]
+fn test_partial_inside_if() {
+    let input = r#"
+{{#*inline "nested_partial"}}
+<div>
+    foobar
+</div>
+{{/inline}}
+{{#*inline "partial"}}
+<div>
+    {{#if foo}}
+    {{> nested_partial}}
+    {{/if}}
+</div>
+{{/inline}}
+<div>
+    {{>partial}}
+</div>
+"#;
+    let output = "
+<div>
+    <div>
+        <div>
+            foobar
+        </div>
+    </div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": true})).unwrap(),
+        output
+    );
+}


### PR DESCRIPTION
Expands on #646 to fix indentation for `{{#if}}` blocks.

### Example Input
```
{{#*inline "partial"}}
<div>
    {{#if foo}}
    foobar
    {{/if}}
</div>
{{/inline}}

<div>
    {{>partial}}
</div>
```
### Output Before
```
<div>
    <div>
    foobar
</div>
</div>
```

### Output Now
```
<div>
    <div>
        foobar
    </div>
</div>
```