### PR TITLE
Fix Nested path lookup bug

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -37,7 +37,7 @@ fn parse_json_visitor<'a>(
     block_contexts: &'a VecDeque<BlockContext<'_>>,
     always_for_absolute_path: bool,
 ) -> ResolvedPath<'a> {
-    let mut path_context_depth: i64 = 0;
+    let mut path_context_depth: usize = 0;
     let mut with_block_param = None;
     let mut from_root = false;
 
@@ -64,7 +64,7 @@ fn parse_json_visitor<'a>(
     let mut path_stack = Vec::with_capacity(relative_path.len() + 5);
     match with_block_param {
         Some((BlockParamHolder::Value(ref value), _)) => {
-            merge_json_path(&mut path_stack, &relative_path[1..]);
+            merge_json_path(&mut path_stack, &relative_path[(path_context_depth + 1)..]);
             ResolvedPath::BlockParamValue(path_stack, value)
         }
         Some((BlockParamHolder::Path(ref paths), base_path)) => {
@@ -72,14 +72,14 @@ fn parse_json_visitor<'a>(
             if !paths.is_empty() {
                 extend(&mut path_stack, paths);
             }
-            merge_json_path(&mut path_stack, &relative_path[1..]);
+            merge_json_path(&mut path_stack, &relative_path[(path_context_depth + 1)..]);
 
             ResolvedPath::AbsolutePath(path_stack)
         }
         None => {
             if path_context_depth > 0 {
                 let blk = block_contexts
-                    .get(path_context_depth as usize)
+                    .get(path_context_depth)
                     .or_else(|| block_contexts.front());
 
                 if let Some(base_value) = blk.and_then(|blk| blk.base_value()) {

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -104,3 +104,26 @@ fn test_referencing_block_param_from_upper_scope() {
         "false|1;false|2;true|3;true|4;"
     );
 }
+
+#[test]
+fn nested_path_lookup() {
+    let input = r#"
+{{#each bar as |x|}}
+{{#each ../foo as |y|}}
+{{../../foo.0}}: {{../x}}
+{{/each}}
+{{/each}}
+"#;
+    let output = "
+42: 1
+42: 2
+42: 3
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": [42], "bar": [1,2,3]}))
+            .unwrap(),
+        output
+    );
+}


### PR DESCRIPTION
Fixes a simple bug in path lookup.

## Testcase 
(input: `{"foo": [42], "bar": [1,2,3]}`)
```
let input = r#"
{{#each bar as |x|}}
{{#each ../foo as |y|}}
{{../../foo.0}}: {{../x}}
{{/each}}
{{/each}}
"#;
```
## Output Before
```
42: 
42: 
42: 
```
## Output After
```
42: 1
42: 2
42: 3
```