### PR TITLE
Fix indent v2

### DIFF
--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -3,7 +3,7 @@ use crate::error::{RenderError, RenderErrorReason};
 use crate::json::value::ScopedJson;
 use crate::output::Output;
 use crate::registry::Registry;
-use crate::render::{do_escape, Helper, RenderContext};
+use crate::render::{do_escape, indent_aware_write, Helper, RenderContext};
 
 pub use self::helper_each::EACH_HELPER;
 pub use self::helper_if::{IF_HELPER, UNLESS_HELPER};
@@ -126,7 +126,9 @@ pub trait HelperDef {
                 } else {
                     // auto escape according to settings
                     let output = do_escape(r, rc, result.render());
-                    out.write(output.as_ref())?;
+
+                    indent_aware_write(&output, rc, out)?;
+
                     Ok(())
                 }
             }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -139,6 +139,8 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
 
         // cleanup
 
+        let trailing_newline = local_rc.get_trailine_newline();
+
         if block_created {
             local_rc.pop_block();
         }
@@ -146,6 +148,10 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
         if d.template().is_some() {
             local_rc.pop_partial_block();
         }
+
+        drop(local_rc);
+
+        rc.set_trailing_newline(trailing_newline);
 
         result
     } else {

--- a/src/render.rs
+++ b/src/render.rs
@@ -905,7 +905,9 @@ impl Renderable for TemplateElement {
             DecoratorExpression(_) | DecoratorBlock(_) => self.eval(registry, ctx, rc),
             PartialExpression(ref dt) | PartialBlock(ref dt) => {
                 let di = Decorator::try_from_template(dt, registry, ctx, rc)?;
-                rc.set_indent_before_write(dt.indent_before_write);
+                rc.set_indent_before_write(
+                    dt.indent_before_write && (rc.get_trailine_newline() || dt.indent.is_some()),
+                );
                 partial::expand_partial(&di, registry, ctx, rc, out)?;
                 rc.set_indent_before_write(rc.get_trailine_newline());
                 Ok(())

--- a/src/render.rs
+++ b/src/render.rs
@@ -14,6 +14,7 @@ use crate::json::value::{JsonRender, PathAndJson, ScopedJson};
 use crate::output::{Output, StringOutput};
 use crate::registry::Registry;
 use crate::support;
+use crate::support::str::newline_matcher;
 use crate::template::TemplateElement::*;
 use crate::template::{
     BlockParam, DecoratorTemplate, HelperTemplate, Parameter, Template, TemplateElement,
@@ -48,6 +49,11 @@ pub struct RenderContextInner<'reg: 'rc, 'rc> {
     /// root template name
     root_template: Option<&'reg String>,
     disable_escape: bool,
+    // whether the previous text that we rendered ended on a newline
+    // necessary to make indenting decisions after the end of partials
+    trailing_newline: bool,
+    // whether the previous text that we render should indent itself
+    indent_before_write: bool,
     indent_string: Option<Cow<'reg, str>>,
 }
 
@@ -62,6 +68,8 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
             current_template: None,
             root_template,
             disable_escape: false,
+            trailing_newline: false,
+            indent_before_write: false,
             indent_string: None,
         });
 
@@ -285,6 +293,33 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     /// When toggle is on, escape_fn will be called when rendering.
     pub fn set_disable_escape(&mut self, disable: bool) {
         self.inner_mut().disable_escape = disable
+    }
+
+    #[inline]
+    pub fn set_trailing_newline(&mut self, trailing_newline: bool) {
+        self.inner_mut().trailing_newline = trailing_newline;
+    }
+
+    #[inline]
+    pub fn get_trailine_newline(&self) -> bool {
+        self.inner().trailing_newline
+    }
+
+    #[inline]
+    pub fn set_indent_before_write(&mut self, indent_before_write: bool) {
+        self.inner_mut().indent_before_write = indent_before_write;
+    }
+
+    #[inline]
+    pub fn get_indent_before_write(&self) -> bool {
+        self.inner().indent_before_write
+    }
+
+    #[inline]
+    pub fn take_indent_before_write(&mut self) -> bool {
+        let res = self.get_indent_before_write();
+        self.set_indent_before_write(false);
+        res
     }
 }
 
@@ -704,6 +739,7 @@ impl Renderable for Template {
                 e
             })?;
         }
+
         Ok(())
     }
 }
@@ -757,8 +793,14 @@ fn render_helper<'reg: 'rc, 'rc>(
         h.params(),
         h.hash()
     );
+    let mut call_indent_aware = |helper_def: &dyn HelperDef, rc: &mut RenderContext<'reg, 'rc>| {
+        rc.set_indent_before_write(ht.indent_before_write);
+        helper_def.call(&h, registry, ctx, rc, out)?;
+        rc.set_indent_before_write(rc.get_trailine_newline());
+        Ok(())
+    };
     if let Some(ref d) = rc.get_local_helper(h.name()) {
-        d.call(&h, registry, ctx, rc, out)
+        call_indent_aware(&**d, rc)
     } else {
         let mut helper = registry.get_or_load_helper(h.name())?;
 
@@ -772,7 +814,7 @@ fn render_helper<'reg: 'rc, 'rc>(
 
         helper
             .ok_or_else(|| RenderErrorReason::HelperNotFound(h.name().to_owned()).into())
-            .and_then(|d| d.call(&h, registry, ctx, rc, out))
+            .and_then(|d| call_indent_aware(&*d, rc))
     }
 }
 
@@ -785,16 +827,25 @@ pub(crate) fn do_escape(r: &Registry<'_>, rc: &RenderContext<'_, '_>, content: S
 }
 
 #[inline]
-fn indent_aware_write(
+pub fn indent_aware_write(
     v: &str,
-    rc: &RenderContext<'_, '_>,
+    rc: &mut RenderContext<'_, '_>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
+    if v.is_empty() {
+        return Ok(());
+    }
+    if !v.starts_with(newline_matcher) && rc.take_indent_before_write() {
+        if let Some(indent) = rc.get_indent_string() {
+            out.write(indent)?;
+        }
+    }
     if let Some(indent) = rc.get_indent_string() {
         out.write(support::str::with_indent(v, indent).as_ref())?;
     } else {
         out.write(v.as_ref())?;
     }
+    rc.set_trailing_newline(v.ends_with(newline_matcher));
     Ok(())
 }
 
@@ -855,8 +906,10 @@ impl Renderable for TemplateElement {
             DecoratorExpression(_) | DecoratorBlock(_) => self.eval(registry, ctx, rc),
             PartialExpression(ref dt) | PartialBlock(ref dt) => {
                 let di = Decorator::try_from_template(dt, registry, ctx, rc)?;
-
-                partial::expand_partial(&di, registry, ctx, rc, out)
+                rc.set_indent_before_write(dt.indent_before_write);
+                partial::expand_partial(&di, registry, ctx, rc, out)?;
+                rc.set_indent_before_write(rc.get_trailine_newline());
+                Ok(())
             }
             _ => Ok(()),
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -314,13 +314,6 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     pub fn get_indent_before_write(&self) -> bool {
         self.inner().indent_before_write
     }
-
-    #[inline]
-    pub fn take_indent_before_write(&mut self) -> bool {
-        let res = self.get_indent_before_write();
-        self.set_indent_before_write(false);
-        res
-    }
 }
 
 impl<'reg, 'rc> fmt::Debug for RenderContextInner<'reg, 'rc> {
@@ -835,17 +828,23 @@ pub fn indent_aware_write(
     if v.is_empty() {
         return Ok(());
     }
-    if !v.starts_with(newline_matcher) && rc.take_indent_before_write() {
+
+    if !v.starts_with(newline_matcher) && rc.get_indent_before_write() {
         if let Some(indent) = rc.get_indent_string() {
             out.write(indent)?;
         }
     }
+
     if let Some(indent) = rc.get_indent_string() {
         out.write(support::str::with_indent(v, indent).as_ref())?;
     } else {
         out.write(v.as_ref())?;
     }
-    rc.set_trailing_newline(v.ends_with(newline_matcher));
+
+    let trailing_newline = v.ends_with(newline_matcher);
+    rc.set_trailing_newline(trailing_newline);
+    rc.set_indent_before_write(trailing_newline);
+
     Ok(())
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -787,7 +787,7 @@ fn render_helper<'reg: 'rc, 'rc>(
         h.hash()
     );
     let mut call_indent_aware = |helper_def: &dyn HelperDef, rc: &mut RenderContext<'reg, 'rc>| {
-        rc.set_indent_before_write(ht.indent_before_write);
+        rc.set_indent_before_write(ht.indent_before_write && rc.get_trailine_newline());
         helper_def.call(&h, registry, ctx, rc, out)?;
         rc.set_indent_before_write(rc.get_trailine_newline());
         Ok(())

--- a/src/render.rs
+++ b/src/render.rs
@@ -807,12 +807,6 @@ impl Renderable for TemplateElement {
         out: &mut dyn Output,
     ) -> Result<(), RenderError> {
         match self {
-            Indent => {
-                if let Some(indent) = rc.get_indent_string() {
-                    out.write(indent)?;
-                }
-                Ok(())
-            }
             RawString(ref v) => indent_aware_write(v.as_ref(), rc, out),
             Expression(ref ht) | HtmlExpression(ref ht) => {
                 let is_html_expression = matches!(self, HtmlExpression(_));

--- a/src/template.rs
+++ b/src/template.rs
@@ -642,7 +642,6 @@ impl Template {
         // this option is marked as true when standalone statement is detected
         // then the leading whitespaces and newline of next rawstring will be trimed
         let mut trim_line_required = false;
-        let mut prev_rule = None;
 
         let parser_queue = HandlebarsParser::parse(Rule::handlebars, source).map_err(|e| {
             let (line_no, col_no) = match e.line_col {
@@ -727,13 +726,6 @@ impl Template {
                         };
 
                         let t = template_stack.front_mut().unwrap();
-
-                        // If this text element is following a standalone partial, then
-                        // we trim the whitespace between. But we still want the following text
-                        // to be indented correctly, so we insert the special `Indent` element.
-                        if trim_line_required && prev_rule == Some(Rule::partial_expression) {
-                            t.push_element(TemplateElement::Indent, line_no, col_no);
-                        }
 
                         t.push_element(
                             Template::raw_string(
@@ -993,7 +985,6 @@ impl Template {
                 if rule != Rule::template {
                     end_pos = Some(span.end_pos());
                 }
-                prev_rule = Some(rule);
             } else {
                 let prev_end = end_pos.as_ref().map(|e| e.pos()).unwrap_or(0);
                 if prev_end < source.len() {
@@ -1035,7 +1026,6 @@ impl Template {
 #[non_exhaustive]
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum TemplateElement {
-    Indent,
     RawString(String),
     HtmlExpression(Box<HelperTemplate>),
     Expression(Box<HelperTemplate>),

--- a/src/template.rs
+++ b/src/template.rs
@@ -65,6 +65,7 @@ impl Subexpression {
                 block_param: None,
                 block: false,
                 chain: false,
+                indent_before_write: false,
             }))),
         }
     }
@@ -143,10 +144,11 @@ pub struct HelperTemplate {
     pub inverse: Option<Template>,
     pub block: bool,
     pub chain: bool,
+    pub indent_before_write: bool,
 }
 
 impl HelperTemplate {
-    pub fn new(exp: ExpressionSpec, block: bool) -> HelperTemplate {
+    pub fn new(exp: ExpressionSpec, block: bool, indent_before_write: bool) -> HelperTemplate {
         HelperTemplate {
             name: exp.name,
             params: exp.params,
@@ -156,10 +158,15 @@ impl HelperTemplate {
             template: None,
             inverse: None,
             chain: false,
+            indent_before_write,
         }
     }
 
-    pub fn new_chain(exp: ExpressionSpec, block: bool) -> HelperTemplate {
+    pub fn new_chain(
+        exp: ExpressionSpec,
+        block: bool,
+        indent_before_write: bool,
+    ) -> HelperTemplate {
         HelperTemplate {
             name: exp.name,
             params: exp.params,
@@ -169,6 +176,7 @@ impl HelperTemplate {
             template: None,
             inverse: None,
             chain: true,
+            indent_before_write,
         }
     }
 
@@ -183,6 +191,7 @@ impl HelperTemplate {
             inverse: None,
             block: false,
             chain: false,
+            indent_before_write: false,
         }
     }
 
@@ -275,16 +284,18 @@ pub struct DecoratorTemplate {
     pub template: Option<Template>,
     // for partial indent
     pub indent: Option<String>,
+    pub indent_before_write: bool,
 }
 
 impl DecoratorTemplate {
-    pub fn new(exp: ExpressionSpec) -> DecoratorTemplate {
+    pub fn new(exp: ExpressionSpec, indent_before_write: bool) -> DecoratorTemplate {
         DecoratorTemplate {
             name: exp.name,
             params: exp.params,
             hash: exp.hash,
             template: None,
             indent: None,
+            indent_before_write,
         }
     }
 }
@@ -747,18 +758,6 @@ impl Template {
                     | Rule::partial_block_start => {
                         let exp = Template::parse_expression(source, it.by_ref(), span.end())?;
 
-                        match rule {
-                            Rule::helper_block_start | Rule::raw_block_start => {
-                                let helper_template = HelperTemplate::new(exp.clone(), true);
-                                helper_stack.push_front(helper_template);
-                            }
-                            Rule::decorator_block_start | Rule::partial_block_start => {
-                                let decorator = DecoratorTemplate::new(exp.clone());
-                                decorator_stack.push_front(decorator);
-                            }
-                            _ => unreachable!(),
-                        }
-
                         if exp.omit_pre_ws {
                             Template::remove_previous_whitespace(&mut template_stack);
                         }
@@ -772,6 +771,22 @@ impl Template {
                             &span,
                             true,
                         );
+
+                        let indent_before_write = trim_line_required && !exp.omit_pre_ws;
+
+                        match rule {
+                            Rule::helper_block_start | Rule::raw_block_start => {
+                                let helper_template =
+                                    HelperTemplate::new(exp.clone(), true, indent_before_write);
+                                helper_stack.push_front(helper_template);
+                            }
+                            Rule::decorator_block_start | Rule::partial_block_start => {
+                                let decorator =
+                                    DecoratorTemplate::new(exp.clone(), indent_before_write);
+                                decorator_stack.push_front(decorator);
+                            }
+                            _ => unreachable!(),
+                        }
 
                         let t = template_stack.front_mut().unwrap();
                         t.mapping.push(TemplateMapping(line_no, col_no));
@@ -799,6 +814,8 @@ impl Template {
                             true,
                         );
 
+                        let indent_before_write = trim_line_required && !exp.omit_pre_ws;
+
                         let t = template_stack.pop_front().unwrap();
                         let h = helper_stack.front_mut().unwrap();
 
@@ -808,7 +825,11 @@ impl Template {
 
                         h.set_chain_template(Some(t));
                         if rule == Rule::invert_chain_tag {
-                            h.insert_inverse_node(Box::new(HelperTemplate::new_chain(exp, true)));
+                            h.insert_inverse_node(Box::new(HelperTemplate::new_chain(
+                                exp,
+                                true,
+                                indent_before_write,
+                            )));
                         }
                     }
 
@@ -843,7 +864,8 @@ impl Template {
 
                         match rule {
                             Rule::expression | Rule::html_expression => {
-                                let helper_template = HelperTemplate::new(exp.clone(), false);
+                                let helper_template =
+                                    HelperTemplate::new(exp.clone(), false, false);
                                 let el = if rule == Rule::expression {
                                     Expression(Box::new(helper_template))
                                 } else {
@@ -855,7 +877,8 @@ impl Template {
                             Rule::decorator_expression | Rule::partial_expression => {
                                 // do not auto trim ident spaces for
                                 // partial_expression(>)
-                                let prevent_indent = rule != Rule::partial_expression;
+                                let prevent_indent =
+                                    !(rule == Rule::partial_expression && options.prevent_indent);
                                 trim_line_required = Template::process_standalone_statement(
                                     &mut template_stack,
                                     source,
@@ -874,7 +897,10 @@ impl Template {
                                     );
                                 }
 
-                                let mut decorator = DecoratorTemplate::new(exp.clone());
+                                let mut decorator = DecoratorTemplate::new(
+                                    exp.clone(),
+                                    trim_line_required && !exp.omit_pre_ws,
+                                );
                                 decorator.indent = indent.map(|s| s.to_owned());
 
                                 let el = if rule == Rule::decorator_expression {
@@ -1453,6 +1479,6 @@ mod test {
         let s = "{{#>(X)}}{{/X}}";
         let result = Template::compile(s);
         assert!(result.is_err());
-        assert_eq!("decorator \"Subexpression(Subexpression { element: Expression(HelperTemplate { name: Path(Relative(([Named(\\\"X\\\")], \\\"X\\\"))), params: [], hash: {}, block_param: None, template: None, inverse: None, block: false, chain: false }) })\" was opened, but \"X\" is closing", format!("{}", result.unwrap_err().reason()));
+        assert_eq!("decorator \"Subexpression(Subexpression { element: Expression(HelperTemplate { name: Path(Relative(([Named(\\\"X\\\")], \\\"X\\\"))), params: [], hash: {}, block_param: None, template: None, inverse: None, block: false, chain: false, indent_before_write: false }) })\" was opened, but \"X\" is closing", format!("{}", result.unwrap_err().reason()));
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -144,7 +144,7 @@ pub struct HelperTemplate {
     pub inverse: Option<Template>,
     pub block: bool,
     pub chain: bool,
-    pub indent_before_write: bool,
+    pub(crate) indent_before_write: bool,
 }
 
 impl HelperTemplate {
@@ -284,7 +284,7 @@ pub struct DecoratorTemplate {
     pub template: Option<Template>,
     // for partial indent
     pub indent: Option<String>,
-    pub indent_before_write: bool,
+    pub(crate) indent_before_write: bool,
 }
 
 impl DecoratorTemplate {

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -216,20 +216,50 @@ fn test_indent_on_consecutive_dynamic_contents() {
 #[test]
 fn test_missing_newline_before_block_helper() {
     let input = r#"
-{{#*inline "dynamic_partial"}}{{content}}{{/inline}}
-{{#*inline "helper_in_partial"}}
+{{~#*inline "dynamic_partial"}}{{content}}{{/inline}}
+
+{{~#*inline "helper_in_partial"}}
 {{#if true}}
 foo
 {{/if}}
 {{/inline}}
-{{#*inline "wrapper_partial"}}
+
+{{~#*inline "wrapper_partial"}}
 {{>dynamic_partial}}
 {{>helper_in_partial}}
 {{/inline}}
+
     {{>wrapper_partial}}
 "#;
     let output = "
+    foofoo
+";
+    let hbs = Handlebars::new();
 
+    assert_eq!(
+        hbs.render_template(input, &json!({"content": "foo"}))
+            .unwrap(),
+        output
+    );
+}
+
+#[test]
+fn test_missing_newline_before_nested_partial() {
+    let input = r#"
+{{~#*inline "dynamic_partial"}}{{content}}{{/inline}}
+
+{{~#*inline "nested_partial"}}
+foo
+{{/inline}}
+
+{{~#*inline "wrapper_partial"}}
+{{>dynamic_partial}}
+{{>nested_partial}}
+{{/inline}}
+
+    {{>wrapper_partial}}
+"#;
+    let output = "
     foofoo
 ";
     let hbs = Handlebars::new();

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -22,3 +22,169 @@ fn test_whitespaces_elision() {
             .unwrap()
     );
 }
+
+#[test]
+fn test_indent_after_if() {
+    let input = r#"
+{{#*inline "partial"}}
+<div>
+    {{#if foo}}
+    foobar
+    {{/if}}
+</div>
+{{/inline}}
+<div>
+    {{>partial}}
+</div>
+"#;
+    let output = "
+<div>
+    <div>
+        foobar
+    </div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": true})).unwrap(),
+        output
+    );
+}
+
+#[test]
+fn test_partial_inside_if() {
+    let input = r#"
+{{#*inline "nested_partial"}}
+<div>
+    foobar
+</div>
+{{/inline}}
+{{#*inline "partial"}}
+<div>
+    {{#if foo}}
+    {{> nested_partial}}
+    {{/if}}
+</div>
+{{/inline}}
+<div>
+    {{>partial}}
+</div>
+"#;
+    let output = "
+<div>
+    <div>
+        <div>
+            foobar
+        </div>
+    </div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": true})).unwrap(),
+        output
+    );
+}
+
+#[test]
+fn test_partial_inside_double_if() {
+    let input = r#"
+{{#*inline "nested_partial"}}
+<div>
+    foobar
+</div>
+{{/inline}}
+{{#*inline "partial"}}
+<div>
+    {{#if foo}}
+    {{#if foo}}
+    {{> nested_partial}}
+    {{/if}}
+    {{/if}}
+</div>
+{{/inline}}
+<div>
+    {{>partial}}
+</div>
+"#;
+    let output = "
+<div>
+    <div>
+        <div>
+            foobar
+        </div>
+    </div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"foo": true})).unwrap(),
+        output
+    );
+}
+
+#[test]
+fn test_empty_partial() {
+    let input = r#"
+{{#*inline "empty_partial"}}{{/inline}}
+<div>
+    {{> empty_partial}}
+</div>
+"#;
+    let output = "
+
+<div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(hbs.render_template(input, &()).unwrap(), output);
+}
+
+#[test]
+fn test_partial_pasting_empty_dynamic_content() {
+    let input = r#"
+{{#*inline "empty_partial"}}{{input}}{{/inline}}
+<div>
+    {{> empty_partial}}
+</div>
+"#;
+    let output = "
+
+<div>
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"input": ""})).unwrap(),
+        output
+    );
+}
+
+#[test]
+fn test_partial_pasting_dynamic_content_with_newlines() {
+    let input = r#"
+{{#*inline "dynamic_partial"}}{{input}}{{/inline}}
+<div>
+    {{> dynamic_partial}}
+</div>
+"#;
+    let output = "
+
+<div>
+    foo
+    bar
+    baz</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"input": "foo\nbar\nbaz"}))
+            .unwrap(),
+        output
+    );
+}

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -188,3 +188,27 @@ fn test_partial_pasting_dynamic_content_with_newlines() {
         output
     );
 }
+
+#[test]
+fn test_indent_on_consecutive_dynamic_contents() {
+    let input = r#"
+{{#*inline "dynamic_partial"}}{{a}}{{b}}{{c}}{{/inline}}
+<div>
+    {{> dynamic_partial}}
+</div>
+"#;
+    let output = "
+
+<div>
+    foo
+    barbaz
+</div>
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"a": "foo\n", "b": "bar", "c": "baz\n"}))
+            .unwrap(),
+        output
+    );
+}

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -212,3 +212,31 @@ fn test_indent_on_consecutive_dynamic_contents() {
         output
     );
 }
+
+#[test]
+fn test_missing_newline_before_block_helper() {
+    let input = r#"
+{{#*inline "dynamic_partial"}}{{content}}{{/inline}}
+{{#*inline "helper_in_partial"}}
+{{#if true}}
+foo
+{{/if}}
+{{/inline}}
+{{#*inline "wrapper_partial"}}
+{{>dynamic_partial}}
+{{>helper_in_partial}}
+{{/inline}}
+    {{>wrapper_partial}}
+"#;
+    let output = "
+
+    foofoo
+";
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"content": "foo"}))
+            .unwrap(),
+        output
+    );
+}


### PR DESCRIPTION
This is my second attempt at fixing the more involved indenting issues first brought up in #650 .

It turns out that the `Indent` node is simply not powerful enough to handle all cases :(.

We will unfortunately have to dynamically track whether a partial ended on a newline or not.
This PR does exactly that.

Here are some of the more difficult edge cases that this solves:

### Input
```
{{#*inline "empty_partial"}}{{/inline}}
<div>
    {{> empty_partial}}
</div>
```

### Output
```
<div>
</div>
``` 
---


### Input
```
{{#*inline "partial"}}foo{{/inline}}
<div>
    {{> partial}}
</div>
```

### Output 
```
<div>
    foo</div>
```
(yes, this is indeed correct according to [handlebars js](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23*inline%20%5C%22partial%5C%22%7D%7Dfoo%7B%7B%2Finline%7D%7D%5Cn%3Cdiv%3E%5Cn%20%20%20%20%7B%7B%3E%20partial%7D%7D%5Cn%3C%2Fdiv%3E%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%7D%5Cn%22%2C%22output%22%3A%22%5Cn%3Cdiv%3E%5Cn%20%20%20%20foo%3C%2Fdiv%3E%22%2C%22preparationScript%22%3A%22%22%2C%22handlebarsVersion%22%3A%224.7.8%22%7D))

---
### Input
Json Input: `{"a": "line\ndynamic_trailing_newline\n"}`
```
{{#*inline "dynamic_partial"}}{{a}}{{/inline}}
<div>
    {{> dynamic_partial}}
</div>
```
### Output
```
<div>
    line
    dynamic_trailing_newline
</div>
```
