### PR TITLE
Allow users to set single block params.

### DIFF
--- a/examples/block_helper_macro_let.rs
+++ b/examples/block_helper_macro_let.rs
@@ -16,7 +16,7 @@ pub fn helper_let<'reg, 'rc>(
         .param(0)
         .ok_or_else(|| RenderErrorReason::ParamNotFoundForIndex("let", 0))?;
 
-    let handlebars::ScopedJson::Constant(Value::String(name_constant)) = name_param.value else {
+    let Some(Value::String(name_constant)) = name_param.try_get_constant_value() else {
         return Err(RenderErrorReason::ParamTypeMismatchForName(
             "let",
             "0".to_string(),

--- a/examples/block_helper_macro_let.rs
+++ b/examples/block_helper_macro_let.rs
@@ -1,0 +1,65 @@
+use handlebars::{
+    BlockParamHolder, Context, Handlebars, Helper, Output, RenderContext, RenderError,
+    RenderErrorReason,
+};
+use serde_json::{json, Value};
+
+// a custom block helper to bind a variable name to a value
+pub fn helper_let<'reg, 'rc>(
+    h: &Helper<'rc>,
+    _r: &'reg Handlebars<'reg>,
+    _ctx: &'rc Context,
+    rc: &mut RenderContext<'reg, 'rc>,
+    _out: &mut dyn Output,
+) -> Result<(), RenderError> {
+    let name_param = h
+        .param(0)
+        .ok_or_else(|| RenderErrorReason::ParamNotFoundForIndex("let", 0))?;
+
+    let handlebars::ScopedJson::Constant(Value::String(name_constant)) = name_param.value else {
+        return Err(RenderErrorReason::ParamTypeMismatchForName(
+            "let",
+            "0".to_string(),
+            "constant string".to_string(),
+        )
+        .into());
+    };
+
+    let value = h
+        .param(1)
+        .as_ref()
+        .map(|v| v.value().to_owned())
+        .ok_or_else(|| RenderErrorReason::ParamNotFoundForIndex("let", 2))?;
+
+    let block = rc.block_mut().unwrap();
+
+    block.set_block_param(name_constant, BlockParamHolder::Value(value));
+
+    Ok(())
+}
+
+fn main() -> Result<(), RenderError> {
+    // create the handlebars registry
+    let mut handlebars = Handlebars::new();
+
+    handlebars.register_helper("let", Box::new(helper_let));
+
+    let input = r#"
+{{#if foo}}
+{{let "mixin_classes" "foo-bar baz"}}
+{{else}}
+{{let "mixin_classes" "quux"}}
+{{/if}}
+
+<div class="content-main {{mixin_classes}}">
+    <p> content </p>
+</div>
+"#;
+
+    println!(
+        "{}",
+        handlebars.render_template(input, &json!({"foo": true}))?
+    );
+
+    Ok(())
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -124,8 +124,13 @@ impl<'rc> BlockContext<'rc> {
         self.block_params.get(block_param_name)
     }
 
-    /// Set a block parameter into this block.
+    /// Reassign the block parameters for this block.
     pub fn set_block_params(&mut self, block_params: BlockParams<'rc>) {
         self.block_params = block_params;
+    }
+
+    /// Set a block parameter into this block.
+    pub fn set_block_param(&mut self, key: &'rc str, value: BlockParamHolder) {
+        self.block_params.data.insert(key, value);
     }
 }

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -92,8 +92,7 @@ impl<'rc> PathAndJson<'rc> {
     pub fn try_get_constant_value(&self) -> Option<&'rc Json> {
         match &self.value {
             ScopedJson::Constant(value) => Some(*value),
-            ScopedJson::Context(value, _) => Some(*value),
-            ScopedJson::Derived(_) | ScopedJson::Missing => None,
+            ScopedJson::Context(_, _) | ScopedJson::Derived(_) | ScopedJson::Missing => None,
         }
     }
 

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -60,8 +60,8 @@ impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'rc> {
 ///
 #[derive(Debug, Clone)]
 pub struct PathAndJson<'rc> {
-    relative_path: Option<String>,
-    value: ScopedJson<'rc>,
+    pub relative_path: Option<String>,
+    pub value: ScopedJson<'rc>,
 }
 
 impl<'rc> PathAndJson<'rc> {

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -60,8 +60,8 @@ impl<'reg: 'rc, 'rc> From<Json> for ScopedJson<'rc> {
 ///
 #[derive(Debug, Clone)]
 pub struct PathAndJson<'rc> {
-    pub relative_path: Option<String>,
-    pub value: ScopedJson<'rc>,
+    relative_path: Option<String>,
+    value: ScopedJson<'rc>,
 }
 
 impl<'rc> PathAndJson<'rc> {
@@ -86,6 +86,15 @@ impl<'rc> PathAndJson<'rc> {
     /// Returns the value
     pub fn value(&self) -> &Json {
         self.value.as_json()
+    }
+
+    /// Returns the value, if it is a constant. Otherwise returns None.
+    pub fn try_get_constant_value(&self) -> Option<&'rc Json> {
+        match &self.value {
+            ScopedJson::Constant(value) => Some(*value),
+            ScopedJson::Context(value, _) => Some(*value),
+            ScopedJson::Derived(_) | ScopedJson::Missing => None,
+        }
     }
 
     /// Test if value is missing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-pub use self::block::{BlockContext, BlockParams};
+pub use self::block::{BlockContext, BlockParamHolder, BlockParams};
 pub use self::context::Context;
 pub use self::decorators::DecoratorDef;
 pub use self::error::{RenderError, RenderErrorReason, TemplateError, TemplateErrorReason};


### PR DESCRIPTION
This just adds a simple method: `set_block_param` to the `BlockContext`.
It also makes the members of the (already public) `PathAndJson` struct public
so you can make effective use of it.

The existing `set_block_params` only allows replacing all block parameters.
Because there also is no `get_block_params`, this makes it impossible for a helper to
edit the block parameters effectively.

My usecase was to be able to write a helper that binds a variable to a name.
That helper is so useful that I added it to the examples aswell.

