### PR TITLE
feat: add PathSeg to public API

### DIFF
--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -8,6 +8,7 @@ use crate::grammar::{HandlebarsParser, Rule};
 use crate::RenderErrorReason;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
 pub enum PathSeg {
     Named(String),
     Ruled(Rule),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ pub use self::context::Context;
 pub use self::decorators::DecoratorDef;
 pub use self::error::{RenderError, RenderErrorReason, TemplateError, TemplateErrorReason};
 pub use self::helpers::{HelperDef, HelperResult};
-pub use self::json::path::Path;
+pub use self::json::path::{Path, PathSeg};
 pub use self::json::value::{to_json, JsonRender, JsonTruthy, PathAndJson, ScopedJson};
 pub use self::local_vars::LocalVars;
 pub use self::output::{Output, StringOutput};


### PR DESCRIPTION
### Rationale:
I'm doing a bit of code generation from the parsed template, and in order to generate based on:
```rust
Path(
    Relative(
        ( 
            [Named("visibility")],
            "visibility",
        ),
    ),
),
```
I've been using the following workaround, which is far from ideal:
```rust
fn path_to_string(path: &Path) -> String {
    let raw_path = format!("{:?}", path);
    let regex = regex::Regex::new(r#"(?:"|\\")([^\\"]+)(?:"|\\")"#).unwrap();
    if let Some(captures) = regex.captures(&raw_path) {
        captures.get(1).unwrap().as_str().to_string()
    } else {
        raw_path
    }
}
```
Making `PathSeg` part of the public API allows for cleaner and more direct usage, eliminating the need for such workarounds.

Thank you for your consideration.

