### PR TITLE
Fix #611

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -272,6 +272,7 @@ impl<'reg> Registry<'reg> {
             tpl_str.as_ref(),
             TemplateOptions {
                 name: Some(name.to_owned()),
+                is_partial: false,
                 prevent_indent: self.prevent_indent,
             },
         )?;
@@ -593,6 +594,7 @@ impl<'reg> Registry<'reg> {
                         TemplateOptions {
                             name: Some(name.to_owned()),
                             prevent_indent: self.prevent_indent,
+                            is_partial: false,
                         },
                     )
                 })

--- a/src/template.rs
+++ b/src/template.rs
@@ -30,6 +30,7 @@ pub struct Template {
 #[derive(Default)]
 pub(crate) struct TemplateOptions {
     pub(crate) prevent_indent: bool,
+    pub(crate) is_partial: bool,
     pub(crate) name: Option<String>,
 }
 
@@ -570,9 +571,15 @@ impl Template {
         source: &str,
         current_span: &Span<'_>,
         prevent_indent: bool,
+        is_partial: bool,
     ) -> bool {
-        let with_trailing_newline =
-            support::str::starts_with_empty_line(&source[current_span.end()..]);
+        let continuation = &source[current_span.end()..];
+
+        let mut with_trailing_newline = support::str::starts_with_empty_line(continuation);
+
+        // For full templates, we behave as if there was a trailing newline if we encounter
+        // the end of input. See #611.
+        with_trailing_newline |= !is_partial && continuation.is_empty();
 
         if with_trailing_newline {
             let with_leading_newline =
@@ -770,6 +777,7 @@ impl Template {
                             source,
                             &span,
                             true,
+                            options.is_partial,
                         );
 
                         let indent_before_write = trim_line_required && !exp.omit_pre_ws;
@@ -812,6 +820,7 @@ impl Template {
                             source,
                             &span,
                             true,
+                            options.is_partial,
                         );
 
                         let indent_before_write = trim_line_required && !exp.omit_pre_ws;
@@ -884,6 +893,7 @@ impl Template {
                                     source,
                                     &span,
                                     prevent_indent,
+                                    options.is_partial,
                                 );
 
                                 // indent for partial expression >
@@ -919,6 +929,7 @@ impl Template {
                                     source,
                                     &span,
                                     true,
+                                    options.is_partial,
                                 );
 
                                 let mut h = helper_stack.pop_front().unwrap();
@@ -948,6 +959,7 @@ impl Template {
                                     source,
                                     &span,
                                     true,
+                                    options.is_partial,
                                 );
 
                                 let mut d = decorator_stack.pop_front().unwrap();
@@ -981,6 +993,7 @@ impl Template {
                             source,
                             &span,
                             true,
+                            options.is_partial,
                         );
 
                         let text = span
@@ -996,6 +1009,7 @@ impl Template {
                             source,
                             &span,
                             true,
+                            options.is_partial,
                         );
 
                         let text = span

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -270,3 +270,25 @@ foo
         output
     );
 }
+
+//regression test for #611
+#[test]
+fn tag_before_eof_becomes_standalone_in_full_template() {
+    let input = r#"<ul>
+  {{#each a}}
+    {{!-- comment --}}
+    <li>{{this}}</li>
+  {{/each}}"#;
+    let output = r#"<ul>
+    <li>1</li>
+    <li>2</li>
+    <li>3</li>
+"#;
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"a": [1, 2, 3]}))
+            .unwrap(),
+        output
+    );
+}

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -292,3 +292,27 @@ fn tag_before_eof_becomes_standalone_in_full_template() {
         output
     );
 }
+
+#[test]
+fn tag_before_eof_does_not_become_standalone_in_partial() {
+    let input = r#"{{#*inline "partial"}}
+<ul>
+  {{#each a}}
+    <li>{{this}}</li>
+  {{/each}}{{/inline}}
+{{> partial}}"#;
+
+    let output = r#"
+<ul>
+    <li>1</li>
+      <li>2</li>
+      <li>3</li>
+  "#;
+    let hbs = Handlebars::new();
+
+    assert_eq!(
+        hbs.render_template(input, &json!({"a": [1, 2, 3]}))
+            .unwrap(),
+        output
+    );
+}


### PR DESCRIPTION
This resolves #611, as promised.

The issue seems to be that handlebars-js behaves differently for inline partials and full templates.
For full templates they treat a closing tag as standalone even if there is no trailing newline, but for inline partials they don't. 
Handlebars-rs on the other hand was consistent, and always behaved the same for both cases (no trailing newline assumed).

For reference, if we wrap the example from #611 in an empty partial, both our and their output become identical, and consistent with our current version without the partial ( [demo](
https://sunng87.github.io/handlebars-rust/?tpl=%7B%7B%23*inline%20%22partial%22%7D%7D%0A%3Cul%3E%0A%20%20%7B%7B%23each%20a%7D%7D%0A%20%20%20%20%3Cli%3E%7B%7Bthis%7D%7D%3C%2Fli%3E%0A%20%20%7B%7B%2Feach%7D%7Dfoo%7B%7B%2Finline%7D%7D%0A%7B%7B%3E%20partial%7D%7D&data=%7B%22a%22%3A%20%5B1%2C%202%5D%7D) ).


This PR changes our behavior to be in line with handlebars-js, at the cost of introducing a difference between partials
and full templates. 
 