### PR TITLE
apply clippy fixes

### DIFF
--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -116,7 +116,7 @@ fn rank_helper(
     Ok(())
 }
 
-static TYPES: &'static str = "serde_json";
+static TYPES: &str = "serde_json";
 
 // define some data
 #[derive(Serialize)]
@@ -166,7 +166,7 @@ pub fn make_data() -> Map<String, Json> {
         },
     ];
 
-    data.insert("teams".to_string(), to_json(&teams));
+    data.insert("teams".to_string(), to_json(teams));
     data.insert("engine".to_string(), to_json(TYPES));
     data
 }

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
         .render_template("{{#if}}", &json!({}))
         .unwrap_err();
     let be1 = Box::new(e1);
-    println!("{}", be1);
+    println!("{be1}");
     println!("{}", be1.source().unwrap());
     println!("{:?}", be1.source().unwrap().source());
 
@@ -71,11 +71,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
         .render_template("{{err \"db\"}}", &json!({}))
         .unwrap_err();
     // get nested error to from `RenderError`
-    match e2.source().and_then(|e| e.downcast_ref::<HelperError>()) {
-        Some(HelperError::DbError) => {
-            println!("Detected error from helper: db error",)
-        }
-        _ => {}
+    if let Some(HelperError::DbError) = e2.source().and_then(|e| e.downcast_ref::<HelperError>()) {
+        println!("Detected error from helper: db error",);
     }
 
     Ok(())

--- a/examples/helper_macro.rs
+++ b/examples/helper_macro.rs
@@ -53,8 +53,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "{}",
         handlebars.render_template(
-            r#"{{isdefined a}} {{isdefined b}}
-{{#if (isdefined a)}}a{{/if}} {{#if (isdefined b)}}b{{/if}}"#,
+            r"{{isdefined a}} {{isdefined b}}
+{{#if (isdefined a)}}a{{/if}} {{#if (isdefined b)}}b{{/if}}",
             &json!({"a": 1})
         )?
     );

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -44,7 +44,7 @@ fn rank_helper(
         .param(1)
         .as_ref()
         .and_then(|v| v.value().as_array())
-        .map(|arr| arr.len())
+        .map(Vec::len)
         .ok_or(RenderErrorReason::ParamTypeMismatchForName(
             "rank",
             "1".to_string(),
@@ -60,7 +60,7 @@ fn rank_helper(
     Ok(())
 }
 
-static TYPES: &'static str = "serde_json";
+static TYPES: &str = "serde_json";
 
 // define some data
 #[derive(Serialize)]
@@ -110,7 +110,7 @@ pub fn make_data() -> Map<String, Json> {
         },
     ];
 
-    data.insert("teams".to_string(), to_json(&teams));
+    data.insert("teams".to_string(), to_json(teams));
     data.insert("engine".to_string(), to_json(TYPES));
     data
 }

--- a/examples/render_file.rs
+++ b/examples/render_file.rs
@@ -48,7 +48,7 @@ fn rank_helper(
         .param(1)
         .as_ref()
         .and_then(|v| v.value().as_array())
-        .map(|arr| arr.len())
+        .map(Vec::len)
         .ok_or(RenderErrorReason::ParamTypeMismatchForName(
             "rank",
             "1".to_string(),
@@ -64,7 +64,7 @@ fn rank_helper(
     Ok(())
 }
 
-static TYPES: &'static str = "serde_json";
+static TYPES: &str = "serde_json";
 
 // define some data
 #[derive(Serialize)]
@@ -114,7 +114,7 @@ pub fn make_data() -> Map<String, Json> {
         },
     ];
 
-    data.insert("teams".to_string(), to_json(&teams));
+    data.insert("teams".to_string(), to_json(teams));
     data.insert("engine".to_string(), to_json(TYPES));
     data
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -57,9 +57,9 @@ impl<'reg> BlockParams<'reg> {
 /// A data structure holds contextual data for current block scope.
 #[derive(Debug, Clone, Default)]
 pub struct BlockContext<'rc> {
-    /// the base_path of current block scope
+    /// the `base_path` of current block scope
     base_path: Vec<String>,
-    /// the base_value of current block scope, when the block is using a
+    /// the `base_value` of current block scope, when the block is using a
     /// constant or derived value as block base
     base_value: Option<Json>,
     /// current block context variables

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,9 +27,8 @@ fn parse_json(text: &str) -> Json {
 fn main() {
     let mut args = env::args();
     args.next(); // skip own filename
-    let (filename, json) = match (args.next(), args.next()) {
-        (Some(filename), Some(json)) => (filename, json),
-        _ => usage(),
+    let (Some(filename), Some(json)) = (args.next(), args.next()) else {
+        usage()
     };
     let data = parse_json(&json);
 

--- a/src/decorators/inline.rs
+++ b/src/decorators/inline.rs
@@ -14,7 +14,7 @@ fn get_name<'reg: 'rc, 'rc>(d: &Decorator<'rc>) -> Result<String, RenderError> {
         .and_then(|v| {
             v.value()
                 .as_str()
-                .map(|v| v.to_owned())
+                .map(std::borrow::ToOwned::to_owned)
                 .ok_or_else(|| RenderErrorReason::InvalidParamType("String").into())
         })
 }
@@ -60,6 +60,6 @@ mod test {
         let mut rc = RenderContext::new(None);
         t0.elements[0].eval(&hbs, &ctx, &mut rc).unwrap();
 
-        assert!(rc.get_partial(&"hello".to_owned()).is_some());
+        assert!(rc.get_partial("hello").is_some());
     }
 }

--- a/src/decorators/mod.rs
+++ b/src/decorators/mod.rs
@@ -66,7 +66,7 @@ pub trait DecoratorDef {
     ) -> DecoratorResult;
 }
 
-/// Implement DecoratorDef for bare function so we can use function as decorator
+/// Implement `DecoratorDef` for bare function so we can use function as decorator
 impl<
         F: for<'reg, 'rc> Fn(
             &Decorator<'rc>,
@@ -102,7 +102,7 @@ mod test {
     fn test_register_decorator() {
         let mut handlebars = Registry::new();
         handlebars
-            .register_template_string("t0", "{{*foo}}".to_string())
+            .register_template_string("t0", "{{*foo}}")
             .unwrap();
 
         let data = json!({
@@ -121,7 +121,7 @@ mod test {
                  -> Result<(), RenderError> { Ok(()) },
             ),
         );
-        assert_eq!(handlebars.render("t0", &data).ok().unwrap(), "".to_string());
+        assert_eq!(handlebars.render("t0", &data).ok().unwrap(), String::new());
     }
 
     // updating context data disabled for now
@@ -129,7 +129,7 @@ mod test {
     fn test_update_data_with_decorator() {
         let mut handlebars = Registry::new();
         handlebars
-            .register_template_string("t0", "{{hello}}{{*foo}}{{hello}}".to_string())
+            .register_template_string("t0", "{{hello}}{{*foo}}{{hello}}")
             .unwrap();
 
         let data = json!({
@@ -183,7 +183,7 @@ mod test {
             ),
         );
         handlebars
-            .register_template_string("t1", "{{this}}{{*bar 1}}{{this}}".to_string())
+            .register_template_string("t1", "{{this}}{{*bar 1}}{{this}}")
             .unwrap();
         assert_eq!(
             handlebars.render("t1", &data2).ok().unwrap(),
@@ -191,10 +191,7 @@ mod test {
         );
 
         handlebars
-            .register_template_string(
-                "t2",
-                "{{this}}{{*bar \"string_literal\"}}{{this}}".to_string(),
-            )
+            .register_template_string("t2", "{{this}}{{*bar \"string_literal\"}}{{this}}")
             .unwrap();
         assert_eq!(
             handlebars.render("t2", &data2).ok().unwrap(),
@@ -202,7 +199,7 @@ mod test {
         );
 
         handlebars
-            .register_template_string("t3", "{{this}}{{*bar}}{{this}}".to_string())
+            .register_template_string("t3", "{{this}}{{*bar}}{{this}}")
             .unwrap();
         assert_eq!(
             handlebars.render("t3", &data2).ok().unwrap(),
@@ -216,8 +213,7 @@ mod test {
         handlebars
             .register_template_string(
                 "t0",
-                "{{distance 4.5}},{{*foo \"miles\"}}{{distance 10.1}},{{*bar}}{{distance 3.4}}"
-                    .to_string(),
+                "{{distance 4.5}},{{*foo \"miles\"}}{{distance 10.1}},{{*bar}}{{distance 3.4}}",
             )
             .unwrap();
 
@@ -233,10 +229,7 @@ mod test {
                     write!(
                         out,
                         "{}m",
-                        h.param(0)
-                            .as_ref()
-                            .map(|v| v.value())
-                            .unwrap_or(&to_json(0))
+                        h.param(0).as_ref().map_or(&to_json(0), |v| v.value())
                     )?;
                     Ok(())
                 },
@@ -265,10 +258,7 @@ mod test {
                         write!(
                             out,
                             "{}{}",
-                            h.param(0)
-                                .as_ref()
-                                .map(|v| v.value())
-                                .unwrap_or(&to_json(0)),
+                            h.param(0).as_ref().map_or(&to_json(0), |v| v.value()),
                             new_unit
                         )?;
                         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::borrow::ToOwned;
 use std::error::Error as StdError;
 use std::fmt::{self, Write};
 use std::io::Error as IOError;
@@ -37,7 +38,7 @@ impl fmt::Display for RenderError {
                 col,
                 desc
             ),
-            _ => write!(f, "{}", desc),
+            _ => write!(f, "{desc}"),
         }
     }
 }
@@ -165,7 +166,7 @@ impl RenderError {
     }
 
     pub fn strict_error(path: Option<&String>) -> RenderError {
-        RenderErrorReason::MissingVariable(path.map(|p| p.to_owned())).into()
+        RenderErrorReason::MissingVariable(path.map(ToOwned::to_owned)).into()
     }
 
     #[deprecated(since = "5.0.0", note = "Use RenderErrorReason::NestedError instead")]

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -46,18 +46,18 @@ mod test {
 
     #[test]
     fn test_raw_text() {
-        let s = vec![
+        let s = [
             "<h1> helloworld </h1>    ",
             r"hello\{{world}}",
             r"hello\{{#if world}}nice\{{/if}}",
             r"hello \{{{{raw}}}}hello\{{{{/raw}}}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::raw_text, i);
         }
 
-        let s_not_escape = vec![r"\\{{hello}}"];
-        for i in s_not_escape.iter() {
+        let s_not_escape = [r"\\{{hello}}"];
+        for i in &s_not_escape {
             assert_not_rule!(Rule::raw_text, i);
         }
     }
@@ -86,43 +86,43 @@ mod test {
             "$id",
             "this.[null]",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::reference, i);
         }
     }
 
     #[test]
     fn test_name() {
-        let s = vec!["if", "(abc)"];
-        for i in s.iter() {
+        let s = ["if", "(abc)"];
+        for i in &s {
             assert_rule!(Rule::name, i);
         }
     }
 
     #[test]
     fn test_param() {
-        let s = vec!["hello", "\"json literal\"", "nullable", "truestory"];
-        for i in s.iter() {
+        let s = ["hello", "\"json literal\"", "nullable", "truestory"];
+        for i in &s {
             assert_rule!(Rule::helper_parameter, i);
         }
     }
 
     #[test]
     fn test_hash() {
-        let s = vec![
+        let s = [
             "hello=world",
             "hello=\"world\"",
             "hello=(world)",
             "hello=(world 0)",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::hash, i);
         }
     }
 
     #[test]
     fn test_json_literal() {
-        let s = vec![
+        let s = [
             "\"json string\"",
             "\"quot: \\\"\"",
             "[]",
@@ -133,31 +133,31 @@ mod test {
             "{\"a\":1, \"b\":2 }",
             "\"nullable\"",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::literal, i);
         }
     }
 
     #[test]
     fn test_comment() {
-        let s = vec!["{{!-- <hello {{ a-b c-d}} {{d-c}} ok --}}",
+        let s = ["{{!-- <hello {{ a-b c-d}} {{d-c}} ok --}}",
                  "{{!--
                     <li><a href=\"{{up-dir nest-count}}{{base-url}}index.html\">{{this.title}}</a></li>
                 --}}",
                      "{{!    -- good  --}}"];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::hbs_comment, i);
         }
-        let s2 = vec!["{{! hello }}", "{{! test me }}"];
-        for i in s2.iter() {
+        let s2 = ["{{! hello }}", "{{! test me }}"];
+        for i in &s2 {
             assert_rule!(Rule::hbs_comment_compact, i);
         }
     }
 
     #[test]
     fn test_subexpression() {
-        let s = vec!["(sub)", "(sub 0)", "(sub a=1)"];
-        for i in s.iter() {
+        let s = ["(sub)", "(sub 0)", "(sub a=1)"];
+        for i in &s {
             assert_rule!(Rule::subexpression, i);
         }
     }
@@ -186,22 +186,22 @@ mod test {
             "{{exp key=(sub 0)}}",
             "{{exp key=(sub 0 key=1)}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::expression, i);
         }
     }
 
     #[test]
     fn test_identifier_with_dash() {
-        let s = vec!["{{exp-foo}}"];
-        for i in s.iter() {
+        let s = ["{{exp-foo}}"];
+        for i in &s {
             assert_rule!(Rule::expression, i);
         }
     }
 
     #[test]
     fn test_html_expression() {
-        let s = vec![
+        let s = [
             "{{{html}}}",
             "{{{(html)}}}",
             "{{{(html)}}}",
@@ -215,14 +215,14 @@ mod test {
             "{{~{ html }}}",
             "{{{ html }~}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::html_expression, i);
         }
     }
 
     #[test]
     fn test_helper_start() {
-        let s = vec![
+        let s = [
             "{{#if hello}}",
             "{{#if (hello)}}",
             "{{#if hello=world}}",
@@ -235,22 +235,22 @@ mod test {
             "{{#each-obj obj as |val key|}}",
             "{{#each assets}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::helper_block_start, i);
         }
     }
 
     #[test]
     fn test_helper_end() {
-        let s = vec!["{{/if}}", "{{~/if}}", "{{~/if ~}}", "{{/if   ~}}"];
-        for i in s.iter() {
+        let s = ["{{/if}}", "{{~/if}}", "{{~/if ~}}", "{{/if   ~}}"];
+        for i in &s {
             assert_rule!(Rule::helper_block_end, i);
         }
     }
 
     #[test]
     fn test_helper_block() {
-        let s = vec![
+        let s = [
             "{{#if hello}}hello{{/if}}",
             "{{#if true}}hello{{/if}}",
             "{{#if nice ok=1}}hello{{/if}}",
@@ -263,26 +263,26 @@ mod test {
             "{{#if}}{{/if}}",
             "{{#if}}hello{{else if}}world{{else}}test{{/if}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::helper_block, i);
         }
     }
 
     #[test]
     fn test_raw_block() {
-        let s = vec![
+        let s = [
             "{{{{if hello}}}}good {{hello}}{{{{/if}}}}",
             "{{{{if hello}}}}{{#if nice}}{{/if}}{{{{/if}}}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::raw_block, i);
         }
     }
 
     #[test]
     fn test_block_param() {
-        let s = vec!["as |person|", "as |val key|"];
-        for i in s.iter() {
+        let s = ["as |person|", "as |val key|"];
+        for i in &s {
             assert_rule!(Rule::block_param, i);
         }
     }
@@ -310,34 +310,34 @@ mod test {
             "@root/a/b",
             "nullable",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule_match!(Rule::path, i);
         }
     }
 
     #[test]
     fn test_decorator_expression() {
-        let s = vec!["{{* ssh}}", "{{~* ssh}}"];
-        for i in s.iter() {
+        let s = ["{{* ssh}}", "{{~* ssh}}"];
+        for i in &s {
             assert_rule!(Rule::decorator_expression, i);
         }
     }
 
     #[test]
     fn test_decorator_block() {
-        let s = vec![
+        let s = [
             "{{#* inline}}something{{/inline}}",
             "{{~#* inline}}hello{{/inline}}",
             "{{#* inline \"partialname\"}}something{{/inline}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::decorator_block, i);
         }
     }
 
     #[test]
     fn test_partial_expression() {
-        let s = vec![
+        let s = [
             "{{> hello}}",
             "{{> (hello)}}",
             "{{~> hello a}}",
@@ -347,15 +347,15 @@ mod test {
             "{{> [a83?f4+.3]}}",
             "{{> 'anif?.bar'}}",
         ];
-        for i in s.iter() {
+        for i in &s {
             assert_rule!(Rule::partial_expression, i);
         }
     }
 
     #[test]
     fn test_partial_block() {
-        let s = vec!["{{#> hello}}nice{{/hello}}"];
-        for i in s.iter() {
+        let s = ["{{#> hello}}nice{{/hello}}"];
+        for i in &s {
             assert_rule!(Rule::partial_block, i);
         }
     }

--- a/src/helpers/block_util.rs
+++ b/src/helpers/block_util.rs
@@ -5,7 +5,7 @@ pub(crate) fn create_block<'rc>(param: &PathAndJson<'rc>) -> BlockContext<'rc> {
     let mut block = BlockContext::new();
 
     if let Some(new_path) = param.context_path() {
-        block.base_path_mut().clone_from(new_path)
+        block.base_path_mut().clone_from(new_path);
     } else {
         // use clone for now
         block.set_base_value(param.value().clone());

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -299,7 +299,7 @@ mod test {
             .unwrap();
 
         let mut r0_sp: Vec<_> = r0.split('\n').collect();
-        r0_sp.sort();
+        r0_sp.sort_unstable();
 
         assert_eq!(r0_sp, vec!["", "-baz", "foo-bar"]);
     }
@@ -593,17 +593,17 @@ mod test {
     fn newline_stripping_for_each() {
         let reg = Registry::new();
 
-        let tpl = r#"<ul>
+        let tpl = r"<ul>
   {{#each a}}
     {{!-- comment --}}
     <li>{{this}}</li>
   {{/each}}
-</ul>"#;
+</ul>";
         assert_eq!(
-            r#"<ul>
+            r"<ul>
     <li>0</li>
     <li>1</li>
-</ul>"#,
+</ul>",
             reg.render_template(tpl, &json!({"a": [0, 1]})).unwrap()
         );
     }

--- a/src/helpers/helper_extras.rs
+++ b/src/helpers/helper_extras.rs
@@ -28,10 +28,7 @@ mod test_conditions {
 
         let result = handlebars
             .render_template(
-                &format!(
-                    "{{{{#if {condition}}}}}lorem{{{{else}}}}ipsum{{{{/if}}}}",
-                    condition = condition
-                ),
+                &format!("{{{{#if {condition}}}}}lorem{{{{else}}}}ipsum{{{{/if}}}}"),
                 &json!({}),
             )
             .unwrap();
@@ -53,10 +50,10 @@ mod test_conditions {
         test_condition("(eq 5 6)", false);
         test_condition(r#"(eq "foo" "foo")"#, true);
         test_condition(r#"(eq "foo" "Foo")"#, false);
-        test_condition(r#"(eq [5] [5])"#, true);
-        test_condition(r#"(eq [5] [4])"#, false);
+        test_condition(r"(eq [5] [5])", true);
+        test_condition(r"(eq [5] [4])", false);
         test_condition(r#"(eq 5 "5")"#, false);
-        test_condition(r#"(eq 5 [5])"#, false);
+        test_condition(r"(eq 5 [5])", false);
     }
 
     #[test]

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -69,7 +69,7 @@ mod test {
         assert_eq!(r1.ok().unwrap(), "world".to_string());
 
         let r2 = handlebars.render("t0", &false);
-        assert_eq!(r2.ok().unwrap(), "".to_string());
+        assert_eq!(r2.ok().unwrap(), String::new());
     }
 
     #[test]
@@ -212,32 +212,32 @@ mod test {
         );
 
         assert_eq!(
-            r#"yes
+            r"yes
   foo
   bar
-  baz"#,
+  baz",
             hbs.render_template(
-                r#"yes
+                r"yes
   {{#if true}}
   foo
   bar
   {{/if}}
-  baz"#,
+  baz",
                 &json!({})
             )
             .unwrap()
         );
 
         assert_eq!(
-            r#"  foo
+            r"  foo
   bar
-  baz"#,
+  baz",
             hbs.render_template(
-                r#"  {{#if true}}
+                r"  {{#if true}}
   foo
   bar
   {{/if}}
-  baz"#,
+  baz",
                 &json!({})
             )
             .unwrap()

--- a/src/helpers/helper_log.rs
+++ b/src/helpers/helper_log.rs
@@ -29,8 +29,8 @@ impl HelperDef for LogHelper {
             .params()
             .iter()
             .map(|p| {
-                if let Some(ref relative_path) = p.relative_path() {
-                    format!("{}: {}", relative_path, p.value().render())
+                if let Some(relative_path) = p.relative_path() {
+                    format!("{}: {}", &relative_path, p.value().render())
                 } else {
                     p.value().render()
                 }
@@ -44,7 +44,7 @@ impl HelperDef for LogHelper {
             .unwrap_or("info");
 
         if let Ok(log_level) = Level::from_str(level) {
-            log!(log_level, "{}", param_to_log)
+            log!(log_level, "{}", param_to_log);
         } else {
             return Err(RenderErrorReason::InvalidLoggingLevel(level.to_string()).into());
         }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -25,7 +25,8 @@ pub type HelperResult = Result<(), RenderError>;
 /// * `&mut RenderContext`: you can access data or modify variables (starts with @)/partials in render context, for example, @index of #each. See its document for detail.
 /// * `&mut dyn Output`: where you write output to
 ///
-/// By default, you can use a bare function as a helper definition because we have supported unboxed_closure. If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
+/// By default, you can use a bare function as a helper definition because we have supported `unboxed_closure`.
+/// If you have stateful or configurable helper, you can create a struct to implement `HelperDef`.
 ///
 /// ## Define an inline helper
 ///
@@ -144,7 +145,7 @@ pub trait HelperDef {
     }
 }
 
-/// implement HelperDef for bare function so we can use function as helper
+/// implement `HelperDef` for bare function so we can use function as helper
 impl<
         F: for<'reg, 'rc> Fn(
             &Helper<'rc>,

--- a/src/json/path.rs
+++ b/src/json/path.rs
@@ -51,7 +51,7 @@ impl Path {
     }
 
     pub(crate) fn current() -> Path {
-        Path::Relative((Vec::with_capacity(0), "".to_owned()))
+        Path::Relative((Vec::with_capacity(0), String::new()))
     }
 
     // for test only

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -121,7 +121,7 @@ impl JsonRender for Json {
             Json::String(ref s) => s.to_string(),
             Json::Bool(i) => i.to_string(),
             Json::Number(ref n) => n.to_string(),
-            Json::Null => "".to_owned(),
+            Json::Null => String::new(),
             Json::Array(ref a) => {
                 let mut buf = String::new();
                 buf.push('[');
@@ -158,10 +158,10 @@ impl JsonTruthy for Json {
             Json::Bool(ref i) => *i,
             Json::Number(ref n) => {
                 if include_zero {
-                    n.as_f64().map(|f| !f.is_nan()).unwrap_or(false)
+                    n.as_f64().is_some_and(|f| !f.is_nan())
                 } else {
                     // there is no inifity in json/serde_json
-                    n.as_f64().map(|f| f.is_normal()).unwrap_or(false)
+                    n.as_f64().is_some_and(f64::is_normal)
                 }
             }
             Json::Null => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@
 //! ```
 //!
 //! Data available to helper can be found in [Helper](struct.Helper.html). And there are more
-//! examples in [HelperDef](trait.HelperDef.html) page.
+//! examples in [`HelperDef`](trait.HelperDef.html) page.
 //!
 //! You can learn more about helpers by looking into source code of built-in helpers.
 //!

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -79,7 +79,7 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
         if let Some(base_path) = d.param(0).and_then(|p| p.context_path()) {
             // path given, update base_path
             let mut block_inner = BlockContext::new();
-            *block_inner.base_path_mut() = base_path.to_vec();
+            base_path.clone_into(block_inner.base_path_mut());
 
             // because block is moved here, we need another bool variable to track
             // its status for later cleanup
@@ -356,13 +356,13 @@ mod test {
         let template3 = "{{#> t2 }}Hello{{/ t2 }}";
 
         handlebars
-            .register_template_string("t1", &template1)
+            .register_template_string("t1", template1)
             .unwrap();
         handlebars
-            .register_template_string("t2", &template2)
+            .register_template_string("t2", template2)
             .unwrap();
 
-        let page = handlebars.render_template(&template3, &json!({})).unwrap();
+        let page = handlebars.render_template(template3, &json!({})).unwrap();
         assert_eq!("<outer><inner>Hello</inner></outer>", page);
     }
 
@@ -397,22 +397,22 @@ mod test {
 
         let hbs = Registry::new();
         assert_eq!(
-            r#"foo
+            r"foo
 foo
 foo
-"#,
+",
             hbs.render_template(tpl0, &json!({})).unwrap()
         );
         assert_eq!(
-            r#"
-foofoofoo"#,
+            r"
+foofoofoo",
             hbs.render_template(tpl1, &json!({})).unwrap()
         );
     }
 
     #[test]
     fn test_partial_indent() {
-        let outer = r#"                {{> inner inner_solo}}
+        let outer = r"                {{> inner inner_solo}}
 
 {{#each inners}}
                 {{> inner}}
@@ -421,9 +421,9 @@ foofoofoo"#,
         {{#each inners}}
         {{> inner}}
         {{/each}}
-"#;
-        let inner = r#"name: {{name}}
-"#;
+";
+        let inner = r"name: {{name}}
+";
 
         let mut hbs = Registry::new();
 
@@ -445,21 +445,21 @@ foofoofoo"#,
 
         assert_eq!(
             result,
-            r#"                name: inner_solo
+            r"                name: inner_solo
 
                 name: hello
                 name: there
 
         name: hello
         name: there
-"#
+"
         );
     }
     // Rule::partial_expression should not trim leading indent  by default
 
     #[test]
     fn test_partial_prevent_indent() {
-        let outer = r#"                {{> inner inner_solo}}
+        let outer = r"                {{> inner inner_solo}}
 
 {{#each inners}}
                 {{> inner}}
@@ -468,9 +468,9 @@ foofoofoo"#,
         {{#each inners}}
         {{> inner}}
         {{/each}}
-"#;
-        let inner = r#"name: {{name}}
-"#;
+";
+        let inner = r"name: {{name}}
+";
 
         let mut hbs = Registry::new();
         hbs.set_prevent_indent(true);
@@ -493,14 +493,14 @@ foofoofoo"#,
 
         assert_eq!(
             result,
-            r#"                name: inner_solo
+            r"                name: inner_solo
 
                 name: hello
                 name: there
 
         name: hello
         name: there
-"#
+"
         );
     }
 
@@ -511,18 +511,18 @@ foofoofoo"#,
             .unwrap();
         hb.register_template_string(
             "index",
-            r#"{{#>partial}}
+            r"{{#>partial}}
     Yo
     {{#>partial}}
     Yo 2
     {{/partial}}
-{{/partial}}"#,
+{{/partial}}",
         )
         .unwrap();
         assert_eq!(
-            r#"    Yo
+            r"    Yo
     Yo 2
-"#,
+",
             hb.render("index", &()).unwrap()
         );
 
@@ -530,11 +530,11 @@ foofoofoo"#,
             .unwrap();
         let r2 = hb
             .render_template(
-                r#"{{#> partial}}
+                r"{{#> partial}}
 {{#> partial2}}
 :(
 {{/partial2}}
-{{/partial}}"#,
+{{/partial}}",
                 &(),
             )
             .unwrap();
@@ -573,11 +573,11 @@ Name:{{name}}
         });
 
         assert_eq!(
-            r#"Name:hudel
+            r"Name:hudel
 Template:hudel
 Name:test
 Template:test
-"#,
+",
             hb.render("t1", &data).unwrap()
         );
     }
@@ -597,9 +597,9 @@ outer third line"#,
         )
         .unwrap();
         assert_eq!(
-            r#"    inner first line
+            r"    inner first line
     inner second line
-outer third line"#,
+outer third line",
             hb.render("t1", &()).unwrap()
         );
 
@@ -613,9 +613,9 @@ outer third line"#,
         )
         .unwrap();
         assert_eq!(
-            r#"  inner first line
+            r"  inner first line
   inner second line
-outer third line"#,
+outer third line",
             hb.render("t2", &()).unwrap()
         );
 
@@ -627,9 +627,9 @@ outer third line"#,
         )
         .unwrap();
         assert_eq!(
-            r#"
+            r"
   inner first line
-  inner second lineouter third line"#,
+  inner second lineouter third line",
             hb.render("t3", &json!({"a": "inner first line\ninner second line"}))
                 .unwrap()
         );
@@ -645,9 +645,9 @@ outer third line"#,
         )
         .unwrap();
         assert_eq!(
-            r#"  inner first line
+            r"  inner first line
   inner second line
-outer third line"#,
+outer third line",
             hb.render("t4", &()).unwrap()
         );
 
@@ -665,11 +665,11 @@ outer third line"#,
         )
         .unwrap();
         assert_eq!(
-            r#"    inner first line
+            r"    inner first line
   inner second line
-outer third line"#,
+outer third line",
             hb2.render("t1", &()).unwrap()
-        )
+        );
     }
 
     #[test]
@@ -737,6 +737,6 @@ outer third line"#,
     fn test_partial_not_found() {
         let t1 = "{{> bar}}";
         let hbs = Registry::new();
-        assert!(hbs.render_template(&t1, &()).is_err());
+        assert!(hbs.render_template(t1, &()).is_err());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::convert::AsRef;
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Error as IoError, Write};
 use std::path::Path;
@@ -650,7 +651,7 @@ impl<'reg> Registry<'reg> {
         &self,
         name: &str,
     ) -> Option<&(dyn DecoratorDef + Send + Sync + 'reg)> {
-        self.decorators.get(name).map(|v| v.as_ref())
+        self.decorators.get(name).map(AsRef::as_ref)
     }
 
     /// Return all templates registered
@@ -1184,7 +1185,7 @@ mod test {
                 _ => unreachable!(),
             },
             "this.[3]"
-        )
+        );
     }
 
     use crate::json::value::ScopedJson;

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,7 +12,10 @@ use crate::grammar::{HandlebarsParser, Rule};
 use crate::json::path::{parse_json_path_from_iter, Path};
 use crate::support;
 
-use self::TemplateElement::*;
+use self::TemplateElement::{
+    Comment, DecoratorBlock, DecoratorExpression, Expression, HelperBlock, HtmlExpression,
+    PartialBlock, PartialExpression, RawString,
+};
 
 #[non_exhaustive]
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -35,10 +38,7 @@ pub(crate) struct TemplateOptions {
 
 impl TemplateOptions {
     fn name(&self) -> String {
-        self.name
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| "Unnamed".to_owned())
+        self.name.clone().unwrap_or_else(|| "Unnamed".to_owned())
     }
 }
 
@@ -679,7 +679,7 @@ impl Template {
         let mut end_pos: Option<Position<'_>> = None;
         loop {
             if let Some(pair) = it.next() {
-                let prev_end = end_pos.as_ref().map(|p| p.pos()).unwrap_or(0);
+                let prev_end = end_pos.as_ref().map_or(0, pest::Position::pos);
                 let rule = pair.as_rule();
                 let span = pair.as_span();
 
@@ -901,7 +901,7 @@ impl Template {
                                     exp.clone(),
                                     trim_line_required && !exp.omit_pre_ws,
                                 );
-                                decorator.indent = indent.map(|s| s.to_owned());
+                                decorator.indent = indent.map(std::borrow::ToOwned::to_owned);
 
                                 let el = if rule == Rule::decorator_expression {
                                     DecoratorExpression(Box::new(decorator))
@@ -1012,7 +1012,7 @@ impl Template {
                     end_pos = Some(span.end_pos());
                 }
             } else {
-                let prev_end = end_pos.as_ref().map(|e| e.pos()).unwrap_or(0);
+                let prev_end = end_pos.as_ref().map_or(0, pest::Position::pos);
                 if prev_end < source.len() {
                     let text = &source[prev_end..source.len()];
                     // is some called in if check
@@ -1074,7 +1074,7 @@ mod test {
         let t = Template::compile(source).ok().unwrap();
         assert_eq!(t.elements.len(), 1);
         assert_eq!(
-            *t.elements.get(0).unwrap(),
+            *t.elements.first().unwrap(),
             RawString("foo {{bar}}".to_string())
         );
     }
@@ -1084,7 +1084,7 @@ mod test {
         let source = r"\\\\";
         let t = Template::compile(source).ok().unwrap();
         assert_eq!(t.elements.len(), 1);
-        assert_eq!(*t.elements.get(0).unwrap(), RawString(source.to_string()));
+        assert_eq!(*t.elements.first().unwrap(), RawString(source.to_string()));
     }
 
     #[test]
@@ -1093,7 +1093,7 @@ mod test {
         let t = Template::compile(source).ok().unwrap();
         assert_eq!(t.elements.len(), 1);
         assert_eq!(
-            *t.elements.get(0).unwrap(),
+            *t.elements.first().unwrap(),
             RawString("{{{{foo}}}} bar".to_string())
         );
     }
@@ -1107,7 +1107,7 @@ mod test {
 
         assert_eq!(t.elements.len(), 10);
 
-        assert_eq!(*t.elements.get(0).unwrap(), RawString("<h1>".to_string()));
+        assert_eq!(*t.elements.first().unwrap(), RawString("<h1>".to_string()));
         assert_eq!(
             *t.elements.get(1).unwrap(),
             Expression(Box::new(HelperTemplate::with_path(Path::with_named_paths(
@@ -1138,9 +1138,9 @@ mod test {
                 assert_eq!(h.name.as_name().unwrap(), "foo".to_string());
                 assert_eq!(h.params.len(), 1);
                 assert_eq!(
-                    *(h.params.get(0).unwrap()),
+                    *(h.params.first().unwrap()),
                     Parameter::Path(Path::with_named_paths(&["bar"]))
-                )
+                );
             }
             _ => {
                 panic!("Helper expression here");
@@ -1185,11 +1185,11 @@ mod test {
         let t = Template::compile(source).ok().unwrap();
 
         assert_eq!(t.elements.len(), 4);
-        match *t.elements.get(0).unwrap() {
+        match *t.elements.first().unwrap() {
             Expression(ref h) => {
                 assert_eq!(h.name.as_name().unwrap(), "foo".to_owned());
                 assert_eq!(h.params.len(), 1);
-                if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
+                if let Parameter::Subexpression(t) = h.params.first().unwrap() {
                     assert_eq!(t.name(), "bar".to_owned());
                 } else {
                     panic!("Subexpression expected");
@@ -1204,9 +1204,9 @@ mod test {
             Expression(ref h) => {
                 assert_eq!(h.name.as_name().unwrap(), "foo".to_string());
                 assert_eq!(h.params.len(), 1);
-                if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
+                if let Parameter::Subexpression(t) = h.params.first().unwrap() {
                     assert_eq!(t.name(), "bar".to_owned());
-                    if let Some(Parameter::Path(p)) = t.params().unwrap().get(0) {
+                    if let Some(Parameter::Path(p)) = t.params().unwrap().first() {
                         assert_eq!(p, &Path::with_named_paths(&["baz"]));
                     } else {
                         panic!("non-empty param expected ");
@@ -1226,9 +1226,9 @@ mod test {
                 assert_eq!(h.params.len(), 1);
                 assert_eq!(h.hash.len(), 1);
 
-                if let &Parameter::Subexpression(ref t) = h.params.get(0).unwrap() {
+                if let Parameter::Subexpression(t) = h.params.first().unwrap() {
                     assert_eq!(t.name(), "baz".to_owned());
-                    if let Some(Parameter::Path(p)) = t.params().unwrap().get(0) {
+                    if let Some(Parameter::Path(p)) = t.params().unwrap().first() {
                         assert_eq!(p, &Path::with_named_paths(&["bar"]));
                     } else {
                         panic!("non-empty param expected ");
@@ -1237,7 +1237,7 @@ mod test {
                     panic!("Subexpression expected (baz bar)");
                 }
 
-                if let &Parameter::Subexpression(ref t) = h.hash.get("then").unwrap() {
+                if let Parameter::Subexpression(t) = h.hash.get("then").unwrap() {
                     assert_eq!(t.name(), "bar".to_owned());
                 } else {
                     panic!("Subexpression expected (bar)");
@@ -1287,7 +1287,7 @@ mod test {
     #[test]
     fn test_unclosed_expression() {
         let sources = ["{{invalid", "{{{invalid", "{{invalid}", "{{!hello"];
-        for s in sources.iter() {
+        for s in &sources {
             let result = Template::compile(s.to_owned());
             let err = result.expect_err("expected a syntax error");
             let syntax_error_msg = match err.reason() {
@@ -1316,7 +1316,7 @@ mod test {
                         if let Some(ref ht) = h.template {
                             assert_eq!(ht.elements.len(), 1);
                             assert_eq!(
-                                *ht.elements.get(0).unwrap(),
+                                *ht.elements.first().unwrap(),
                                 RawString("good{{night}}".to_owned())
                             );
                         } else {

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -107,13 +107,13 @@ fn test_referencing_block_param_from_upper_scope() {
 
 #[test]
 fn nested_path_lookup() {
-    let input = r#"
+    let input = r"
 {{#each bar as |x|}}
 {{#each ../foo as |y|}}
 {{../../foo.0}}: {{../x}}
 {{/each}}
 {{/each}}
-"#;
+";
     let output = "
 42: 1
 42: 2

--- a/tests/embed.rs
+++ b/tests/embed.rs
@@ -1,10 +1,8 @@
-#[macro_use]
-extern crate serde_json;
-
 #[test]
 #[cfg(feature = "rust-embed")]
 fn test_embed() {
     use rust_embed::RustEmbed;
+    use serde_json::json;
 
     #[derive(RustEmbed)]
     #[folder = "tests/templates/"]
@@ -30,6 +28,7 @@ fn test_embed() {
 #[cfg(feature = "rust-embed")]
 fn test_embed_with_extension() {
     use rust_embed::RustEmbed;
+    use serde_json::json;
 
     #[derive(RustEmbed)]
     #[folder = "tests/templates/"]
@@ -52,6 +51,7 @@ fn test_embed_with_extension() {
 #[cfg(feature = "rust-embed")]
 fn test_embed_with_extension_and_tests_struct_root() {
     use rust_embed::RustEmbed;
+    use serde_json::json;
 
     #[derive(RustEmbed)]
     #[folder = "tests/"]

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -34,34 +34,34 @@ fn test_string_no_escape_422() {
     hbs.register_helper("echo", Box::new(echo));
 
     assert_eq!(
-        r#"some\ path"#,
+        r"some\ path",
         hbs.render_template(r#"{{replace "some/path" "/" "\\ " }}"#, &())
             .unwrap()
     );
     assert_eq!(
-        r#"some\ path"#,
-        hbs.render_template(r#"{{replace 'some/path' '/' '\\ ' }}"#, &())
+        r"some\ path",
+        hbs.render_template(r"{{replace 'some/path' '/' '\\ ' }}", &())
             .unwrap()
     );
 
     assert_eq!(
-        r#"some\path"#,
+        r"some\path",
         hbs.render_template(r#"{{replace "some/path" "/" "\\" }}"#, &())
             .unwrap()
     );
     assert_eq!(
-        r#"some\path"#,
-        hbs.render_template(r#"{{replace 'some/path' '/' '\\' }}"#, &())
+        r"some\path",
+        hbs.render_template(r"{{replace 'some/path' '/' '\\' }}", &())
             .unwrap()
     );
 
     assert_eq!(
-        r#"double-quoted \ &#x27;with&#x27; &quot;nesting&quot;"#,
+        r"double-quoted \ &#x27;with&#x27; &quot;nesting&quot;",
         hbs.render_template(r#"{{echo "double-quoted \\ 'with' \"nesting\""}}"#, &())
             .unwrap()
     );
     assert_eq!(
-        r#"single-quoted \ &#x27;with&#x27; &quot;nesting&quot;"#,
+        r"single-quoted \ &#x27;with&#x27; &quot;nesting&quot;",
         hbs.render_template(r#"{{echo 'single-quoted \\ \'with\' "nesting"'}}"#, &())
             .unwrap()
     );
@@ -69,10 +69,10 @@ fn test_string_no_escape_422() {
 
 #[test]
 fn test_string_whitespace_467() {
-    const TEMPLATE_UNQUOTED: &str = r#"{{#each synonyms}}
+    const TEMPLATE_UNQUOTED: &str = r"{{#each synonyms}}
     {{this.name}} => '{{this.sym}}',
     {{/each}}
-"#;
+";
 
     let mut hbs = Handlebars::new();
     hbs.register_escape_fn(no_escape);
@@ -90,7 +90,7 @@ fn test_triple_bracket_expression_471() {
     let mut hbs = Handlebars::new();
 
     handlebars_helper!(replace: |input: str| {
-        input.replace("\n", "<br/>")
+        input.replace('\n', "<br/>")
     });
     hbs.register_helper("replace", Box::new(replace));
 

--- a/tests/helper_function_lifetime.rs
+++ b/tests/helper_function_lifetime.rs
@@ -7,9 +7,9 @@ fn ifcond<'reg, 'rc>(
     render_ctx: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,
 ) -> Result<(), RenderError> {
-    let cond = h.param(0).and_then(|ref v| v.value().as_bool()).ok_or(
+    let cond = h.param(0).and_then(|v| v.value().as_bool()).ok_or(
         RenderErrorReason::ParamTypeMismatchForName("ifcond", "0".to_owned(), "bool".to_owned()),
-    )? as bool;
+    )?;
     let temp = if cond { h.template() } else { h.inverse() };
     match temp {
         Some(t) => t.render(handle, ctx, render_ctx, out),

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -14,7 +14,7 @@ handlebars_helper!(money: |v: i64, {cur: str="$"}| format!("{}{}.00", cur, v));
 handlebars_helper!(all_hash: |{cur: str="$"}| cur);
 handlebars_helper!(nargs: |*args| args.len());
 handlebars_helper!(has_a: |{a:i64 = 99}, **kwargs|
-                   format!("{}, {}", a, kwargs.get("a").is_some()));
+                   format!("{}, {}", a, kwargs.contains_key("a")));
 handlebars_helper!(tag: |t: str| format!("<{}>", t));
 handlebars_helper!(date: |dt: OffsetDateTime| dt.format(&parse("[year]-[month]-[day]").unwrap()).unwrap());
 

--- a/tests/helper_with_space.rs
+++ b/tests/helper_with_space.rs
@@ -1,9 +1,9 @@
 use handlebars::*;
 use serde_json::json;
 
-fn dump<'reg, 'rc>(
-    h: &Helper<'rc>,
-    _: &'reg Handlebars,
+fn dump(
+    h: &Helper<'_>,
+    _: &Handlebars,
     _: &Context,
     _: &mut RenderContext,
     out: &mut dyn Output,
@@ -41,26 +41,26 @@ fn test_empty_lines_472() {
 
     r.register_template_string(
         "t1",
-        r#"{{#each routes}}
+        r"{{#each routes}}
 import { default as {{this.handler}} } from '{{this.file_path}}'
 {{/each}}
 
 addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
-})"#,
+})",
     )
     .unwrap();
 
     r.register_template_string(
         "t2",
-        r#"addEventListener('fetch', (event) => {
+        r"addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
 })
 
 {{#each routes}}
 import { default as {{this.handler}} } from '{{this.file_path}}'
 {{/each}}
-"#,
+",
     )
     .unwrap();
 
@@ -68,22 +68,22 @@ import { default as {{this.handler}} } from '{{this.file_path}}'
                                  {"handler": "__world_index_handler", "file_path": "./world/index.js"},
                                  {"handler": "__index_handler", "file_path": "./index.js"}]});
 
-    let exp1 = r#"import { default as __hello_handler } from './hello.js'
+    let exp1 = r"import { default as __hello_handler } from './hello.js'
 import { default as __world_index_handler } from './world/index.js'
 import { default as __index_handler } from './index.js'
 
 addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
-})"#;
+})";
 
-    let exp2 = r#"addEventListener('fetch', (event) => {
+    let exp2 = r"addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
 })
 
 import { default as __hello_handler } from './hello.js'
 import { default as __world_index_handler } from './world/index.js'
 import { default as __index_handler } from './index.js'
-"#;
+";
 
     assert_eq!(r.render("t1", &data).unwrap(), exp1);
     assert_eq!(r.render("t2", &data).unwrap(), exp2);

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -70,7 +70,7 @@ fn test_strict_mode() {
         .is_ok());
     assert!(hbs
         .render_template("{{#if (eq z 1)}}Success{{else}}Failed{{/if}}", &data)
-        .is_err())
+        .is_err());
 }
 
 #[test]
@@ -131,7 +131,7 @@ impl HelperDef for CallCounterHelper {
         // inc counter
         self.c.fetch_add(1, Ordering::SeqCst);
 
-        if let Some(_) = h.param(0) {
+        if h.param(0).is_some() {
             Ok(json!({
                 "a": 1,
             })


### PR DESCRIPTION
This fixes all 86 warnings that clippy currently generates on this project.
Most of these are in test code and don't really matter.
I still believe this is worth it because it makes the use of clippy viable when working on this project.
Currently you are quite likely to miss any issues you introduce because there's already so many warnings.

If you disagree, feel free to close this.

This was partially autogenerated using `cargo clippy --fix`, but manually reviewed & cleaned up.
Should hopfully be very easy to review, as nothing really happens.