### PR TITLE
Zero alloc indent write

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -882,7 +882,7 @@ pub fn indent_aware_write(
     }
 
     if let Some(indent) = rc.get_indent_string() {
-        out.write(support::str::with_indent(v, indent).as_ref())?;
+        support::str::write_indented(v, indent, out)?;
     } else {
         out.write(v.as_ref())?;
     }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,6 +1,8 @@
 pub mod str {
     use std::io::{Result, Write};
 
+    use crate::Output;
+
     #[derive(Debug)]
     pub struct StringWriter {
         buf: Vec<u8>,
@@ -68,6 +70,24 @@ pub mod str {
         }
 
         output
+    }
+
+    /// like `with_indent`, but writing straight into the output
+    pub fn write_indented(s: &str, indent: &str, w: &mut dyn Output) -> std::io::Result<()> {
+        let mut i = 0;
+        let len = s.len();
+        loop {
+            let Some(next_newline) = s[i..].find('\n') else {
+                w.write(&s[i..])?;
+                return Ok(());
+            };
+            w.write(&s[i..i + next_newline + 1])?;
+            i += next_newline + 1;
+            if i == len {
+                return Ok(());
+            }
+            w.write(indent)?;
+        }
     }
 
     #[inline]


### PR DESCRIPTION
The current `with_indent` function allocates a string to render the content into for every single  `indent_aware_write`.
It also operates on a per char basis instead of processing full line slices at a time.
This PR fixes this by implementing an improved version that operates directly on the output stream.

In my testing this gives us about a 5 to 15% performance boost :rocket: ,
although the benchmarks are a bit flaky. I also added another benchmark with some 
more nested partials than in the others, which benefits the most from this change.

```
    Running benches/bench.rs (target/release/deps/bench-a2a79c58e18ef2a8)
parse_template          time:   [20.801 µs 20.830 µs 20.858 µs]
                        change: [-0.0628% +0.2014% +0.4363%] (p = 0.12 > 0.05)
                        No change in performance detected.

render_template         time:   [3.0293 µs 3.0355 µs 3.0433 µs]
                        change: [-9.4375% -8.9483% -8.4201%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  10 (10.00%) high severe

large_loop_helper       time:   [225.11 µs 225.64 µs 226.28 µs]
                        change: [-5.9605% -5.6607% -5.3786%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

large_loop_helper_with_context_creation
                        time:   [449.95 µs 450.37 µs 450.87 µs]
                        change: [-4.4517% -4.1931% -3.9515%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  12 (12.00%) high mild
  1 (1.00%) high severe

large_nested_loop       time:   [250.05 µs 250.35 µs 250.71 µs]
                        change: [-5.7467% -5.5139% -5.2769%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

deeply_nested_partial   time:   [235.92 µs 236.23 µs 236.59 µs]
                        change: [-17.574% -17.235% -16.747%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```