### PR TITLE
fix: improved number compare between different types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ pest = "2.1.0"
 pest_derive = "2.1.0"
 serde = "1.0.0"
 serde_json = "1.0.39"
+num-order = "1.2.0"
 walkdir = { version = "2.2.3", optional = true }
 rhai = { version = "1.16.1", optional = true, features = ["sync", "serde"] }
 rust-embed = { version = "8.0.0", optional = true, features = ["include-exclude"] }


### PR DESCRIPTION
Fixes #678 

Included a new dependency num-order to compare numbers of different types.