### PR TITLE
feat: correct implementation of partial block

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 
 use serde::Serialize;
 use serde_json::value::{to_value, Value as Json};
+use serde_json::Map;
 
 use crate::block::{BlockContext, BlockParamHolder};
 use crate::error::{RenderError, RenderErrorReason};
@@ -141,6 +142,38 @@ fn get_in_block_params<'a>(
     None
 }
 
+pub(crate) fn merge_json(base: &Json, addition: &HashMap<&str, &Json>) -> Json {
+    // if no addition json provided, just return the original one
+    if addition.is_empty() {
+        return base.clone();
+    }
+
+    let mut base_map = match base {
+        Json::Object(ref m) => m.clone(),
+        Json::Array(ref a) => {
+            let mut base_map = Map::new();
+            for (idx, value) in a.iter().enumerate() {
+                base_map.insert(idx.to_string(), value.clone());
+            }
+            base_map
+        }
+        Json::String(ref s) => {
+            let mut base_map = Map::new();
+            for (idx, value) in s.chars().enumerate() {
+                base_map.insert(idx.to_string(), Json::String(value.to_string()));
+            }
+            base_map
+        }
+        _ => Map::new(),
+    };
+
+    for (k, v) in addition {
+        base_map.insert((*k).to_string(), (*v).clone());
+    }
+
+    Json::Object(base_map)
+}
+
 impl Context {
     /// Create a context with null data
     pub fn null() -> Context {
@@ -214,13 +247,10 @@ impl From<Json> for Context {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockContext, BlockParams};
-    use crate::context::Context;
-    use crate::error::RenderError;
-    use crate::json::path::Path;
-    use crate::json::value::{self, ScopedJson};
-    use serde_json::value::Map;
-    use std::collections::VecDeque;
+    use crate::json::value;
+    use crate::{BlockParams, Path};
+
+    use super::*;
 
     fn navigate_from_root<'rc>(
         ctx: &'rc Context,
@@ -314,6 +344,64 @@ mod test {
         assert_eq!(
             navigate_from_root(&ctx2, "age").unwrap().render(),
             "4".to_owned()
+        );
+    }
+
+    #[test]
+    fn test_merge_json() {
+        let map = json!({ "age": 4 });
+        let s = "hello".to_owned();
+        let arr = json!(["a", "b"]);
+        let mut hash = HashMap::new();
+        let v = value::to_json("h1");
+        hash.insert("tag", &v);
+
+        let ctx_a1 = Context::wraps(merge_json(&map, &hash)).unwrap();
+        assert_eq!(
+            navigate_from_root(&ctx_a1, "age").unwrap().render(),
+            "4".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a1, "tag").unwrap().render(),
+            "h1".to_owned()
+        );
+
+        let ctx_a2 = Context::wraps(merge_json(&value::to_json(&s), &hash)).unwrap();
+        assert_eq!(
+            navigate_from_root(&ctx_a2, "this").unwrap().render(),
+            "[object]".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a2, "tag").unwrap().render(),
+            "h1".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a2, "0").unwrap().render(),
+            "h".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a2, "1").unwrap().render(),
+            "e".to_owned()
+        );
+
+        let ctx_a3 = Context::wraps(merge_json(&value::to_json(&arr), &hash)).unwrap();
+        assert_eq!(
+            navigate_from_root(&ctx_a3, "tag").unwrap().render(),
+            "h1".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a3, "0").unwrap().render(),
+            "a".to_owned()
+        );
+        assert_eq!(
+            navigate_from_root(&ctx_a3, "1").unwrap().render(),
+            "b".to_owned()
+        );
+
+        let ctx_a4 = Context::wraps(merge_json(&value::to_json(&s), &HashMap::new())).unwrap();
+        assert_eq!(
+            navigate_from_root(&ctx_a4, "this").unwrap().render(),
+            "hello".to_owned()
         );
     }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -729,14 +729,14 @@ outer third line",
 
         assert_eq!("hello world", hbs.render("t2", &()).unwrap());
 
-        let t1 = "{{a}}";
+        let t1 = "{{a}} {{[0]}} {{[1]}}";
         let t2 = "{{> t1 \"hello world\" a=1}}";
 
         let mut hbs = Registry::new();
         hbs.register_template_string("t1", t1).unwrap();
         hbs.register_template_string("t2", t2).unwrap();
 
-        assert_eq!("1", hbs.render("t2", &()).unwrap());
+        assert_eq!("1 h e", hbs.render("t2", &()).unwrap());
 
         let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
         let t2 = "{{> t1 a=1}}";
@@ -746,5 +746,23 @@ outer third line",
         hbs.register_template_string("t2", t2).unwrap();
 
         assert_eq!("a:1,", hbs.render("t2", &()).unwrap());
+
+        let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
+        let t2 = "{{> t1 a=1}}";
+
+        let mut hbs = Registry::new();
+        hbs.register_template_string("t1", t1).unwrap();
+        hbs.register_template_string("t2", t2).unwrap();
+
+        assert_eq!("a:1,b:2,", hbs.render("t2", &json!({"b": 2})).unwrap());
+
+        let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
+        let t2 = "{{> t1 b a=1}}";
+
+        let mut hbs = Registry::new();
+        hbs.register_template_string("t1", t1).unwrap();
+        hbs.register_template_string("t2", t2).unwrap();
+
+        assert_eq!("a:1,", hbs.render("t2", &json!({"b": 2})).unwrap());
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -102,6 +102,7 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
         self.blocks.pop_front();
     }
 
+    /// Remove all blocks
     pub(crate) fn clear_blocks(&mut self) {
         self.blocks.clear();
     }
@@ -115,6 +116,14 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
     /// modify some data.
     pub fn block_mut(&mut self) -> Option<&mut BlockContext<'rc>> {
         self.blocks.front_mut()
+    }
+
+    /// Replace blocks hold by render context and return the replaced blocks
+    pub fn replace_blocks(
+        &mut self,
+        blocks: VecDeque<BlockContext<'rc>>,
+    ) -> VecDeque<BlockContext<'rc>> {
+        std::mem::replace(&mut self.blocks, blocks)
     }
 
     /// Get the modified context data if any


### PR DESCRIPTION
Fixes #698 #696 

This patch finally reimplements partial's block context correctly. The key is to remove all previous blocks and use a separated one for partial.

It corrects behavior of partial parameter, hash and merge_json:
- if parameters is provided, either as path or literal, use it as base value; otherwise use `this` as base_value
- if hash is provided, always merge it with base value:
  - if base value is associative type: object, array, string, merge them as map
  - if base value is non-associative type, return hash
  otherwise, use base value directly


When partial is rendered, reset blocks.

Tests added.