### PR TITLE
feat: reimplement partial block and drop stack based implementation

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -4,6 +4,7 @@ use serde_json::value::Value as Json;
 
 use crate::error::RenderError;
 use crate::local_vars::LocalVars;
+use crate::Template;
 
 #[derive(Clone, Debug)]
 pub enum BlockParamHolder {
@@ -66,6 +67,8 @@ pub struct BlockContext<'rc> {
     block_params: BlockParams<'rc>,
     /// local variables in current context
     local_variables: LocalVars,
+    /// partial block inner template, access with `{{> @partial-block}}`
+    partial_block: Option<&'rc Template>,
 }
 
 impl<'rc> BlockContext<'rc> {
@@ -132,5 +135,15 @@ impl<'rc> BlockContext<'rc> {
     /// Set a block parameter into this block.
     pub fn set_block_param(&mut self, key: &'rc str, value: BlockParamHolder) {
         self.block_params.data.insert(key, value);
+    }
+
+    /// Set partial block
+    pub fn set_partial_block(&mut self, partial_block: Option<&'rc Template>) {
+        self.partial_block = partial_block;
+    }
+
+    /// Get partial block template stored for current context
+    pub fn get_partial_block(&self) -> Option<&'rc Template> {
+        self.partial_block
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,8 @@ pub enum RenderErrorReason {
     ),
     #[error("Nested error: {0}")]
     NestedError(#[source] Box<dyn StdError + Send + Sync + 'static>),
+    #[error("Partial block could not be found")]
+    PartialBlockNotFound,
     #[cfg(feature = "script_helper")]
     #[error("Cannot convert data to Rhai dynamic: {0}")]
     ScriptValueError(

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,8 +121,6 @@ pub enum RenderErrorReason {
     ),
     #[error("Nested error: {0}")]
     NestedError(#[source] Box<dyn StdError + Send + Sync + 'static>),
-    #[error("Partial block could not be found")]
-    PartialBlockNotFound,
     #[cfg(feature = "script_helper")]
     #[error("Cannot convert data to Rhai dynamic: {0}")]
     ScriptValueError(


### PR DESCRIPTION
Fixes #697 

Our previous stack based implementation of `@partial-block` has its limitation for nested scenarios. This patch attempts to redo it with blockcontext.