### PR TITLE
fix: allow colons in identifier

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -33,7 +33,7 @@ array_literal = { "[" ~ literal? ~ ("," ~ literal)* ~ "]" }
 object_literal = { "{" ~ (string_literal ~ ":" ~ literal)?
                    ~ ("," ~ string_literal ~ ":" ~ literal)* ~ "}" }
 
-symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|"$"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
+symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|"$"|":"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
 partial_symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'|"/"|"."}
 path_char = _{ "/" }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -185,6 +185,7 @@ mod test {
             "{{exp key=(sub)}}",
             "{{exp key=(sub 0)}}",
             "{{exp key=(sub 0 key=1)}}",
+            "{{exp ns:key=0}}",
         ];
         for i in &s {
             assert_rule!(Rule::expression, i);


### PR DESCRIPTION
Fixes #701 

Add `:` in identifier characters