### PR TITLE
Implement block-scoped inline partials

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -4,6 +4,7 @@ use serde_json::value::Value as Json;
 
 use crate::error::RenderError;
 use crate::local_vars::LocalVars;
+use crate::Template;
 
 #[derive(Clone, Debug)]
 pub enum BlockParamHolder {
@@ -64,6 +65,8 @@ pub struct BlockContext<'rc> {
     base_value: Option<Json>,
     /// current block context variables
     block_params: BlockParams<'rc>,
+    /// the partials available in this block
+    block_partials: BTreeMap<String, &'rc Template>,
     /// local variables in current context
     local_variables: LocalVars,
 }
@@ -108,6 +111,14 @@ impl<'rc> BlockContext<'rc> {
     /// set the base value
     pub fn set_base_value(&mut self, value: Json) {
         self.base_value = Some(value);
+    }
+
+    pub fn get_local_partial(&self, name: &str) -> Option<&'rc Template> {
+        self.block_partials.get(name).map(|v| &**v)
+    }
+
+    pub fn set_local_partial(&mut self, name: String, template: &'rc Template) {
+        self.block_partials.insert(name, template);
     }
 
     /// Get a block parameter from this block.

--- a/src/decorators/inline.rs
+++ b/src/decorators/inline.rs
@@ -33,7 +33,14 @@ impl DecoratorDef for InlineDecorator {
             .template()
             .ok_or(RenderErrorReason::BlockContentRequired)?;
 
+        if let Some(block) = rc.block_mut() {
+            block.set_local_partial(name, template);
+
+            return Ok(());
+        }
+
         rc.set_partial(name, template);
+
         Ok(())
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -173,6 +173,13 @@ impl<'reg: 'rc, 'rc> RenderContext<'reg, 'rc> {
                 .get(self.partial_block_depth as usize)
                 .copied();
         }
+
+        for block in &self.blocks {
+            if let Some(partial) = block.get_local_partial(name) {
+                return Some(partial);
+            }
+        }
+
         self.partials.get(name).copied()
     }
 

--- a/tests/scoped_inline.rs
+++ b/tests/scoped_inline.rs
@@ -1,0 +1,25 @@
+use handlebars::Handlebars;
+
+#[test]
+fn test_inline_scope() {
+    let mut hbs = Handlebars::new();
+    hbs.register_partial(
+        "test_partial",
+        r#"{{#>nested_partial}}Inner Content{{/nested_partial}}"#,
+    )
+    .unwrap();
+    let output = hbs
+        .render_template(
+            r#"{{>test_partial}}
+
+{{#>test_partial}}
+{{#*inline "nested_partial"}}Overwrite{{/inline}}
+{{/test_partial}}
+
+{{>test_partial}}"#,
+            &(),
+        )
+        .unwrap();
+
+    assert_eq!("Inner Content\nOverwrite\nInner Content", output);
+}


### PR DESCRIPTION
This is my attempt in fixing #704. 

My attempt definitely opened #495 and #693 again, but copying the `hash_ctx` to the `block_params` worked around this. I'm not sure if the performance hit is acceptable, but at least it fixes a scoping issue.

`cargo bench` with the change

```
parse_template          time:   [49.531 µs 49.542 µs 49.553 µs]
                        change: [+1.7350% +2.2424% +2.5788%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

render_template         time:   [5.5300 µs 5.5320 µs 5.5342 µs]
                        change: [+1.4191% +1.4921% +1.5621%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe

large_loop_helper       time:   [393.91 µs 394.10 µs 394.31 µs]
                        change: [+1.3439% +1.4332% +1.5314%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

large_loop_helper_with_context_creation
                        time:   [921.40 µs 921.64 µs 921.85 µs]
                        change: [-0.5717% -0.5299% -0.4944%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  6 (6.00%) low mild
  1 (1.00%) high severe

large_nested_loop       time:   [442.45 µs 442.65 µs 442.85 µs]
                        change: [+0.4180% +1.0867% +1.5428%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild

deeply_nested_partial   time:   [566.47 µs 566.61 µs 566.76 µs]
                        change: [-1.3247% -1.2691% -1.2158%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

`cargo bench` before the change

```
parse_template          time:   [48.279 µs 48.432 µs 48.695 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

render_template         time:   [5.4495 µs 5.4524 µs 5.4561 µs]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

large_loop_helper       time:   [388.87 µs 389.04 µs 389.24 µs]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

large_loop_helper_with_context_creation
                        time:   [926.07 µs 926.30 µs 926.58 µs]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) low mild
  3 (3.00%) high severe

large_nested_loop       time:   [435.40 µs 437.35 µs 439.82 µs]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

deeply_nested_partial   time:   [573.57 µs 573.75 µs 573.96 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```