### PR TITLE
expose DirectorySourceOptionsBuilder & added doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,9 +402,9 @@ pub use self::json::path::{Path, PathSeg};
 pub use self::json::value::{to_json, JsonRender, JsonTruthy, PathAndJson, ScopedJson};
 pub use self::local_vars::LocalVars;
 pub use self::output::{Output, StringOutput};
-#[cfg(feature = "dir_source")]
-pub use self::registry::DirectorySourceOptions;
 pub use self::registry::{html_escape, no_escape, EscapeFn, Registry as Handlebars};
+#[cfg(feature = "dir_source")]
+pub use self::registry::{DirectorySourceOptions, DirectorySourceOptionsBuilder};
 pub use self::render::{Decorator, Evaluable, Helper, RenderContext, Renderable};
 pub use self::template::Template;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -106,6 +106,7 @@ fn rhai_engine() -> Engine {
 /// Options for importing template files from a directory.
 #[non_exhaustive]
 #[derive(Builder)]
+#[builder(default)]
 #[cfg(feature = "dir_source")]
 pub struct DirectorySourceOptions {
     /// The name extension for template files
@@ -336,6 +337,19 @@ impl<'reg> Registry<'reg> {
     ///
     /// When dev_mode is enabled, like with `register_template_file`, templates are reloaded
     /// from the file system every time they're visited.
+    ///
+    /// ```rust
+    /// use handlebars::{Handlebars, DirectorySourceOptionsBuilder};
+    ///
+    /// let mut hbs = Handlebars::new();
+    /// hbs.register_templates_directory(
+    ///     "/path/to/templates",
+    ///     DirectorySourceOptionsBuilder::default()
+    ///         .tpl_extension("tmpl")
+    ///         .build()
+    ///         .unwrap(),
+    /// ).unwrap();
+    /// ```
     #[cfg(feature = "dir_source")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dir_source")))]
     pub fn register_templates_directory<P>(


### PR DESCRIPTION
DirectorySourceOptions is `#[non_exhaustive]` which means it cannot be created directly by users of the crate.

DirectorySourceOptions is `#[derive(Builder)]` but the resulting DirectorySourceOptionsBuilder is not exposed to users of the crate.

Because of this only `DirectorySourceOptions::default()` can be used and options cannot be set.

Exposing DirectorySourceOptionsBuilder allows users of this crate to build DirectorySourceOptions.