### PR TITLE
feat: Added dynamic partial blocks by adding support for empty block closing tags

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -88,14 +88,14 @@ helper_block = _{ helper_block_start ~ template ~
 
 decorator_block_start = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "#" ~ "*"
                         ~ exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
-decorator_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ identifier ~
+decorator_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ identifier? ~
                         trailing_tilde_to_omit_whitespace? ~ "}}" }
 decorator_block = _{ decorator_block_start ~ template ~
                      decorator_block_end }
 
 partial_block_start = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "#" ~ ">"
                         ~ partial_exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
-partial_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ partial_identifier ~
+partial_block_end = { "{{" ~ leading_tilde_to_omit_whitespace? ~ "/" ~ partial_identifier? ~
                       trailing_tilde_to_omit_whitespace? ~ "}}" }
 partial_block = _{ partial_block_start ~ template ~ partial_block_end }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -355,7 +355,11 @@ mod test {
 
     #[test]
     fn test_partial_block() {
-        let s = ["{{#> hello}}nice{{/hello}}"];
+        let s = [
+            "{{#> hello}}nice{{/hello}}",
+            "{{#> hello}}nice{{/}}",
+            "{{#> (hello)}}nice{{/}}",
+        ];
         for i in &s {
             assert_rule!(Rule::partial_block, i);
         }

--- a/src/template.rs
+++ b/src/template.rs
@@ -377,6 +377,7 @@ impl Template {
             Rule::identifier | Rule::partial_identifier | Rule::invert_tag_item => {
                 Ok(Parameter::Name(name_span.as_str().to_owned()))
             }
+            Rule::EOI => Ok(Parameter::Name(String::new())),
             Rule::reference => {
                 let paths = parse_json_path_from_iter(it, name_span.end());
                 Ok(Parameter::Path(Path::new(name_span.as_str(), paths)))
@@ -384,7 +385,7 @@ impl Template {
             Rule::subexpression => {
                 Template::parse_subexpression(source, it.by_ref(), name_span.end())
             }
-            _ => unreachable!(),
+            other => unreachable!("{other:?}"),
         }
     }
 
@@ -973,7 +974,10 @@ impl Template {
 
                                 let mut d = decorator_stack.pop_front().unwrap();
                                 let close_tag_name = exp.name.as_name();
-                                if d.name.as_name() == close_tag_name {
+                                let empty_close_tag = close_tag_name
+                                    .map(|name| name.is_empty())
+                                    .unwrap_or_default();
+                                if empty_close_tag || d.name.as_name() == close_tag_name {
                                     let prev_t = template_stack.pop_front().unwrap();
                                     d.template = Some(prev_t);
                                     let t = template_stack.front_mut().unwrap();
@@ -1186,6 +1190,18 @@ mod test {
     fn test_parse_block_partial_path_identifier() {
         let source = "{{#> foo/bar}}{{/foo/bar}}";
         assert!(Template::compile(source).is_ok());
+    }
+
+    #[test]
+    fn test_parse_block_empty_end() {
+        let source = "{{#> foo/bar}}{{/}}";
+        Template::compile(source).unwrap();
+    }
+
+    #[test]
+    fn test_parse_dynamic_block() {
+        let source = "{{#> (foo)}}{{/}}";
+        Template::compile(source).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
This PR implements a feature that has been historically lacking from the original Handlebars: dynamic partial blocks. https://github.com/handlebars-lang/handlebars-parser/issues/9

Handlebars syntax allows users to create both dynamic partials:
```handlebars
{{> (snake_case 'MyPartial') }}
```

And partial blocks:
```handlebars
{{#> my_partial }}
    Hello
{{/my_partial}}
```

In theory, one should be able to use both features at the same time since there's no conflict whatsoever betwen them. In practice though, this turns out to be impossible due to a funny oversight in the syntax:
```handlebars
{{> (snake_case 'MyPartial') }}
    Hello
{{/ ??? }}
what goes here?
```

I have fixed this issue by making the explicit name in the closing tag optional, which I consider the most obvious change to the syntax. So, this is now possible:
```handlebars
{{> (snake_case 'MyPartial') }}
    Hello, this works now!
{{/}}
```

And as a bonus, it's also possible in general:
```
{{> my_partial }}
    {{#*inline foo }}
        some inline stuff
    {{/}}
{{/}}
```