### PR TITLE
fix: allow block include for partial-block

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -34,7 +34,7 @@ object_literal = { "{" ~ (string_literal ~ ":" ~ literal)?
                    ~ ("," ~ string_literal ~ ":" ~ literal)* ~ "}" }
 
 symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|"$"|":"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'}
-partial_symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'|"/"|"."}
+partial_symbol_char = _{ASCII_ALPHANUMERIC|"-"|"_"|"@"|'\u{80}'..'\u{7ff}'|'\u{800}'..'\u{ffff}'|'\u{10000}'..'\u{10ffff}'|"/"|"."}
 path_char = _{ "/" }
 
 identifier = @{ symbol_char+ }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -897,14 +897,14 @@ outer third line",
         let mut hb = Registry::new();
         hb.register_template_string(
             "some_partial",
-            "before {{#> @partial-block}}{{/@partial-block}} after",
+            "before {{#> @partial-block}}DEFAULT{{/@partial-block}} after",
         )
         .unwrap();
 
         let r1 = hb
             .render_template("{{> some_partial}}", &json!({}))
             .unwrap();
-        assert_eq!(r1, "before  after");
+        assert_eq!(r1, "before DEFAULT after");
 
         let r2 = hb
             .render_template("{{#> some_partial}}CONTENT{{/some_partial}}", &json!({}))
@@ -926,10 +926,7 @@ outer third line",
         assert_eq!(r1, "[DEFAULT] ok");
 
         let r2 = hb
-            .render_template(
-                "{{#> wrapper}}CUSTOM{{/wrapper}}",
-                &json!({}),
-            )
+            .render_template("{{#> wrapper}}CUSTOM{{/wrapper}}", &json!({}))
             .unwrap();
         assert_eq!(r2, "[CUSTOM] ok");
     }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -56,7 +56,10 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
             Ok(())
         } else if let Some(fallback) = d.template() {
             // no partial_block for this scope, render fallback from block syntax
-            fallback.render(r, ctx, rc, out)
+            let result = fallback.render(r, ctx, rc, out);
+            rc.set_current_template_name(current_template_before);
+            rc.set_indent_string(indent_before);
+            result
         } else {
             // no partial_block for this scope
             Err(RenderErrorReason::PartialBlockNotFound.into())
@@ -907,6 +910,46 @@ outer third line",
             .render_template("{{#> some_partial}}CONTENT{{/some_partial}}", &json!({}))
             .unwrap();
         assert_eq!(r2, "before CONTENT after");
+    }
+
+    #[test]
+    fn test_partial_block_fallback_restores_state() {
+        let mut hb = Registry::new();
+        hb.register_template_string(
+            "wrapper",
+            "[{{#> @partial-block}}DEFAULT{{/@partial-block}}] {{> inner}}",
+        )
+        .unwrap();
+        hb.register_template_string("inner", "ok").unwrap();
+
+        let r1 = hb.render_template("{{> wrapper}}", &json!({})).unwrap();
+        assert_eq!(r1, "[DEFAULT] ok");
+
+        let r2 = hb
+            .render_template(
+                "{{#> wrapper}}CUSTOM{{/wrapper}}",
+                &json!({}),
+            )
+            .unwrap();
+        assert_eq!(r2, "[CUSTOM] ok");
+    }
+
+    #[test]
+    fn test_partial_block_fallback_restores_template_name() {
+        let mut hb = Registry::new();
+        hb.register_template_string(
+            "self_ref",
+            "{{#> @partial-block}}DEFAULT{{/@partial-block}}{{> self_ref}}",
+        )
+        .unwrap();
+
+        let result = hb.render_template("{{> self_ref}}", &json!({}));
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("include current template"),
+            "expected self-inclusion error, got: {msg}"
+        );
     }
 
     #[test]

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -54,6 +54,9 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
         if let Some(Some(content)) = rc.peek_partial_block() {
             out.write(content.as_str())?;
             Ok(())
+        } else if let Some(fallback) = d.template() {
+            // no partial_block for this scope, render fallback from block syntax
+            fallback.render(r, ctx, rc, out)
         } else {
             // no partial_block for this scope
             Err(RenderErrorReason::PartialBlockNotFound.into())
@@ -884,6 +887,26 @@ outer third line",
             .unwrap();
 
         assert_eq!(hs.render("current", &()).unwrap(), "Not a Bug");
+    }
+
+    #[test]
+    fn test_partial_block_syntax_for_at_partial_block() {
+        let mut hb = Registry::new();
+        hb.register_template_string(
+            "some_partial",
+            "before {{#> @partial-block}}{{/@partial-block}} after",
+        )
+        .unwrap();
+
+        let r1 = hb
+            .render_template("{{> some_partial}}", &json!({}))
+            .unwrap();
+        assert_eq!(r1, "before  after");
+
+        let r2 = hb
+            .render_template("{{#> some_partial}}CONTENT{{/some_partial}}", &json!({}))
+            .unwrap();
+        assert_eq!(r2, "before CONTENT after");
     }
 
     #[test]


### PR DESCRIPTION
Address issue reported in https://github.com/sunng87/handlebars-rust/issues/726#issuecomment-4456142984

This allow usage of `@partial-block` in `{{#> ...}}{/...}}`