### PR TITLE
fix: inherit @key/@index/@first/@last into partials and #with

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -87,6 +87,11 @@ impl<'rc> BlockContext<'rc> {
         &mut self.local_variables
     }
 
+    /// borrow the local variables
+    pub fn local_variables(&self) -> &LocalVars {
+        &self.local_variables
+    }
+
     /// get a local variable from current scope
     pub fn get_local_var(&self, name: &str) -> Option<&Json> {
         self.local_variables.get(name)

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -28,6 +28,15 @@ impl HelperDef for WithHelper {
         if param.value().is_truthy(false) {
             let mut block = create_block(param);
 
+            // inherit local variables (@key/@index/@first/@last) from the
+            // enclosing block so they remain accessible inside `#with`,
+            // matching Handlebars.js (see issue #592).
+            if let Some(parent) = rc.block() {
+                block
+                    .local_variables_mut()
+                    .clone_from(parent.local_variables());
+            }
+
             if let Some(block_param) = h.block_param() {
                 let mut params = BlockParams::new();
                 if param.context_path().is_some() {
@@ -224,6 +233,33 @@ mod test {
 
         let r2 = handlebars.render("t2", &people);
         assert_eq!(r2.ok().unwrap(), "01".to_string());
+    }
+
+    #[test]
+    fn test_with_in_each_inherits_key_and_index() {
+        // Regression for #592: `@key`/`@index` from an enclosing `{{#each}}`
+        // must remain accessible inside `{{#with}}`, matching Handlebars.js.
+        let mut handlebars = Registry::new();
+
+        let template_obj = "{{#each this}}{{#with this}}{{@key}}={{this}}|{{/with}}{{/each}}";
+        handlebars
+            .register_template_string("obj", template_obj)
+            .unwrap();
+        let r_obj = handlebars.render(
+            "obj",
+            &json!({
+                "ftp": 21,
+                "http": 80,
+            }),
+        );
+        assert_eq!(r_obj.unwrap(), "ftp=21|http=80|".to_string());
+
+        let template_arr = "{{#each this}}{{#with this}}{{@index}}={{this}}|{{/with}}{{/each}}";
+        handlebars
+            .register_template_string("arr", template_arr)
+            .unwrap();
+        let r_arr = handlebars.render("arr", &json!([10, 20]));
+        assert_eq!(r_arr.unwrap(), "0=10|1=20|".to_string());
     }
 
     #[test]

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -90,6 +90,18 @@ pub fn expand_partial<'reg: 'rc, 'rc>(
                 .set_block_param(name, crate::BlockParamHolder::Value((*value).clone()));
         }
 
+        // inherit local variables (@key/@index/@first/@last) from the
+        // enclosing block so they remain accessible inside the partial.
+        // This matches Handlebars.js, where the implicit data variables of
+        // an enclosing `{{#each}}`/`{{#with}}` are inherited across the
+        // partial boundary. Block params (`as |v k|`) are deliberately NOT
+        // inherited, as they are scoped to their block.
+        if let Some(parent) = rc.block() {
+            partial_include_block
+                .local_variables_mut()
+                .clone_from(parent.local_variables());
+        }
+
         // evaluate context for partial
         let merged_context = if let Some(p) = d.param(0) {
             if let Some(relative_path) = p.relative_path() {

--- a/tests/issue_756.rs
+++ b/tests/issue_756.rs
@@ -1,0 +1,93 @@
+use handlebars::Handlebars;
+use serde_json::json;
+
+// Regression test for https://github.com/sunng87/handlebars-rust/issues/756
+// `@key`/`@index`/`@first`/`@last` were not available inside a partial
+// rendered in a `{{#each}}` loop because the partial pushed a fresh
+// BlockContext whose empty local variables shadowed the enclosing each's.
+
+#[test]
+fn test_key_in_partial_in_each() {
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "{{@key}}: {{this}}\n")
+        .unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
+        .unwrap();
+    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
+    assert_eq!("foo: bar\n", r);
+}
+
+#[test]
+fn test_index_in_partial_in_each() {
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "{{@index}}: {{this}}\n")
+        .unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
+        .unwrap();
+    let r = hbs.render("t", &json!(["bar"])).unwrap();
+    assert_eq!("0: bar\n", r);
+}
+
+#[test]
+fn test_first_last_index_in_partial_in_each() {
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "[{{@first}}/{{@last}}/{{@index}}]")
+        .unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
+        .unwrap();
+    let r = hbs.render("t", &json!(["a", "b", "c"])).unwrap();
+    assert_eq!("[true/false/0][false/false/1][false/true/2]", r);
+}
+
+#[test]
+fn test_key_in_partial_still_inherited_with_hash() {
+    // Passing a hash to the partial must not prevent `@key` from being
+    // inherited from the enclosing each. (The hash becomes a block param /
+    // merges into the partial context, but should not wipe the implicit
+    // data variables.)
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "{{@key}}").unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p myvar=\"x\"}}{{/each}}")
+        .unwrap();
+    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
+    assert_eq!("foo", r);
+}
+
+#[test]
+fn test_each_inside_partial_resets_key() {
+    // Inheriting locals must not leak: a nested `{{#each}}` inside the
+    // partial should set its own `@key`/`@index`, not the outer ones.
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "{{#each this}}{{@key}}={{this}};{{/each}}")
+        .unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
+        .unwrap();
+    let r = hbs
+        .render("t", &json!({"outer": {"inner_a": 1, "inner_b": 2}}))
+        .unwrap();
+    assert_eq!("inner_a=1;inner_b=2;", r);
+}
+
+#[test]
+fn test_key_in_nested_partial() {
+    // Local inheritance should chain across multiple partial boundaries.
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p2", "{{@key}}").unwrap();
+    hbs.register_template_string("p1", "{{> p2}}").unwrap();
+    hbs.register_template_string("t", "{{#each this}}{{> p1}}{{/each}}")
+        .unwrap();
+    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
+    assert_eq!("foo", r);
+}
+
+#[test]
+fn test_key_in_partial_not_inside_each_is_empty() {
+    // Outside of any each/with, `@key` should remain empty (no leak of a
+    // phantom value), as the root block has no local vars.
+    let mut hbs = Handlebars::new();
+    hbs.register_template_string("p", "{{@key}}:{{this}}")
+        .unwrap();
+    hbs.register_template_string("t", "{{> p}}").unwrap();
+    let r = hbs.render("t", &json!("hello")).unwrap();
+    assert_eq!(":hello", r);
+}


### PR DESCRIPTION
The implicit data variables (`@key`, `@index`, `@first`, `@last`) set by an enclosing {{#each}} were not accessible inside a partial (or {{#with}}), because entering those scopes pushed a fresh BlockContext whose empty local variables shadowed the enclosing each's. This diverged from Handlebars.js, where data variables are inherited across these boundaries.

Resolve by inheriting the parent block's local variables into the new block when:

  * expanding a partial (src/partial.rs)  -- fixes #756
  * entering a {{#with}} block (src/helpers/helper_with.rs)  -- fixes #592

Block params declared with `as |v k|` are deliberately NOT inherited, as they are scoped to their block (matching Handlebars.js). A nested {{#each}} inside a partial still sets its own @key/@index, so there is no leak.

Add an immutable getter BlockContext::local_variables() to enable the clone. Add regression tests covering object/array iteration, @first/ @last/@index, nested each resetting key, chained partials, and the no-leak case outside any loop.