### PR TITLE
feat: add preserve_json_order feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [Unreleased]
+
+* [Added] `preserve_json_order` feature flag that gates `serde_json`'s
+  `preserve_order` feature. Enabled by default to keep insertion-order key
+  iteration; disable with `default-features = false` to restore alphabetical
+  JSON object key ordering.
+
 ## [6.4.2](https://github.com/sunng87/handlebars-rust/compare/6.4.1...6.4.2) - 2026-06-24
 
 * [Fixed] Access to local variables like `@key`, `@index`, etc. in `#with` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ derive_builder = "0.20.2"
 pest = "2.2.0"
 pest_derive = "2.2.0"
 serde = "1.0.0"
-serde_json = { version = "1.0.39", features = ["preserve_order"] }
+serde_json = { version = "1.0.39" }
 num-order = "1.2.0"
 walkdir = { version = "2.2.3", optional = true }
 rhai = { version = "1.16.1", optional = true, features = ["sync", "serde"] }
@@ -46,8 +46,9 @@ pprof = { version = "0.15", features = ["flamegraph", "prost-codec"] }
 dir_source = ["walkdir"]
 script_helper = ["rhai"]
 no_logging = []
-default = []
+default = ["preserve_json_order"]
 string_helpers = ["heck"]
+preserve_json_order = ["serde_json/preserve_order"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,27 @@
 //!
 //! You will get a `RenderError` when accessing fields that do not exist.
 //!
+//! ### Preserving JSON object key order
+//!
+//! Internally handlebars uses `serde_json::Map` to represent JSON objects.
+//! By default `serde_json` sorts object keys alphabetically, which means
+//! iterating over an object with `{{#each}}` would yield keys in sorted
+//! order rather than the order they appear in your data.
+//!
+//! The `preserve_json_order` feature (enabled by default) turns on
+//! `serde_json`'s `preserve_order` feature, so that object keys keep their
+//! insertion order. This is particularly useful when iterating over objects
+//! with `{{#each}}`, where you usually expect keys to follow the order
+//! defined in the input data.
+//!
+//! If you prefer the alphabetical ordering behaviour, disable this feature
+//! by turning off default features:
+//!
+//! ```toml
+//! [dependencies]
+//! handlebars = { version = "6.4.2", default-features = false }
+//! ```
+//!
 //! ## Limitations
 //!
 //! ### Compatibility with original JavaScript version


### PR DESCRIPTION
## Summary

This makes `serde_json`'s `preserve_order` feature configurable via a new
`preserve_json_order` cargo feature flag, instead of being hard-coded on the
`serde_json` dependency.

- The feature is **enabled by default**, so existing behaviour is preserved:
  JSON object keys keep their insertion order when iterated (e.g. with
  `{{#each}}`), matching Handlebars.js semantics.
- Users who prefer alphabetical key ordering can now opt out with
  `default-features = false`.

## Changes

- `Cargo.toml`: move `preserve_order` from the hard-coded `serde_json`
  features into a new `preserve_json_order` feature
  (`preserve_json_order = ["serde_json/preserve_order"]`), added to `default`.
- `src/lib.rs`: document the feature under a new *Preserving JSON object key
  order* subsection, including how to disable it.
- `CHANGELOG.md`: add an *Unreleased* entry.

## Background

`6.4.2` enabled `serde_json`'s `preserve_order` unconditionally. While this is
the desired default (insertion-order iteration, matching Handlebars.js), it
also forced the extra `indexmap` dependency on every downstream user. Gating
it behind a (default-on) feature lets users opt out when they don't need it.