### PR TITLE
fix: handle leading tilde on `else if` chain tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+* [Fixed] Panic when using whitespace omission (`~`) on an `else if`
+  chain tag, e.g. `{{~else if cond}}`. The leading tilde is now handled
+  consistently with `{{~else}}` [#766]
+
 ## [6.4.2](https://github.com/sunng87/handlebars-rust/compare/6.4.1...6.4.2) - 2026-06-24
 
 * [Fixed] Access to local variables like `@key`, `@index`, etc. in `#with` and

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -261,6 +261,9 @@ mod test {
             "{{#if}}hello{{~else}}world{{/if}}",
             "{{#if}}hello{{else~}}world{{/if}}",
             "{{#if}}hello{{~^~}}world{{/if}}",
+            "{{#if}}hello{{~else if foo}}world{{/if}}",
+            "{{#if}}hello{{else if foo~}}world{{/if}}",
+            "{{#if}}hello{{~else if foo~}}world{{/if}}",
             "{{#if}}{{/if}}",
             "{{#if}}hello{{else if}}world{{else}}test{{/if}}",
         ];

--- a/src/template.rs
+++ b/src/template.rs
@@ -814,10 +814,27 @@ impl Template {
                         // hack: invert_tag structure is similar to ExpressionSpec, so I
                         // use it here to represent the data
 
+                        // For invert_chain_tag the optional leading tilde precedes
+                        // invert_tag_item and is therefore not part of exp_line, so
+                        // parse_expression (called below) never sees it. Consume it
+                        // here before parse_name, otherwise parse_name hits the
+                        // leading_tilde_to_omit_whitespace pair and panics.
+                        // https://github.com/sunng87/handlebars-rust/issues/766
+                        let mut invert_omit_pre_ws = false;
                         if rule == Rule::invert_chain_tag {
+                            if it.peek().unwrap().as_rule()
+                                == Rule::leading_tilde_to_omit_whitespace
+                            {
+                                invert_omit_pre_ws = true;
+                                it.next();
+                            }
                             let _ = Template::parse_name(source, &mut it, span.end())?;
                         }
-                        let exp = Template::parse_expression(source, it.by_ref(), span.end())?;
+                        let mut exp = Template::parse_expression(source, it.by_ref(), span.end())?;
+
+                        if invert_omit_pre_ws {
+                            exp.omit_pre_ws = true;
+                        }
 
                         if exp.omit_pre_ws {
                             Template::remove_previous_whitespace(&mut template_stack);
@@ -1523,5 +1540,15 @@ mod test {
             "decorator \"Subexpression(Subexpression { element: Expression(HelperTemplate { name: Path(Relative(([Named(\\\"X\\\")], \\\"X\\\"))), params: [], hash: {}, block_param: None, template: None, inverse: None, block: false, chain: false, indent_before_write: false }) })\" was opened, but \"X\" is closing",
             format!("{}", result.unwrap_err().reason())
         );
+    }
+
+    // https://github.com/sunng87/handlebars-rust/issues/766
+    #[test]
+    fn test_invert_chain_tag_with_leading_tilde() {
+        // `{{~else if ...}}` previously panicked in parse_name with
+        // `unreachable: leading_tilde_to_omit_whitespace`.
+        let s = "{{#if 1}}\n{{~else if 0 }}\n{{/if}}";
+        let result = Template::compile(s);
+        assert!(result.is_ok(), "failed to compile: {:?}", result.err());
     }
 }

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -364,3 +364,43 @@ fn tag_before_eof_does_not_become_standalone_in_partial() {
         output
     );
 }
+
+// Regression test for https://github.com/sunng87/handlebars-rust/issues/766
+// `{{~else if ...}}` previously panicked during template compilation.
+#[test]
+fn test_else_if_with_whitespace_omission() {
+    let hbs = Handlebars::new();
+
+    // Leading tilde on `else if` should strip preceding whitespace, mirroring
+    // the behaviour of `{{~else}}`.
+    let leading = "{{#if x}}\nA\n   {{~else if y}}\nB\n{{/if}}";
+    assert_eq!(
+        "B\n",
+        hbs.render_template(leading, &json!({"x": false, "y": true}))
+            .unwrap()
+    );
+
+    // Trailing tilde on `else if` should strip following whitespace.
+    let trailing = "{{#if x}}\nA\n{{else if y ~}}   \nB\n{{/if}}";
+    assert_eq!(
+        "B\n",
+        hbs.render_template(trailing, &json!({"x": false, "y": true}))
+            .unwrap()
+    );
+
+    // Both tildes.
+    let both = "{{#if x}}\nA\n   {{~else if y~}}   \nB\n{{/if}}";
+    assert_eq!(
+        "B\n",
+        hbs.render_template(both, &json!({"x": false, "y": true}))
+            .unwrap()
+    );
+
+    // And the falsy fallback when no chain matches.
+    let fallback = "{{#if x}}\nA\n   {{~else if y}}\nB\n{{else}}\nC\n{{/if}}";
+    assert_eq!(
+        "C\n",
+        hbs.render_template(fallback, &json!({"x": false, "y": false}))
+            .unwrap()
+    );
+}


### PR DESCRIPTION
Fixes #766.

## Summary

`{{~else if cond}}` panicked during template compilation:

```
thread 'main' panicked at src/template.rs:389:22:
internal error: entered unreachable code: leading_tilde_to_omit_whitespace
```

## Root cause

The grammar places the optional leading tilde of `invert_chain_tag`
*before* `invert_tag_item`:

```pest
invert_chain_tag = { !escape ~ "{{" ~ leading_tilde_to_omit_whitespace? ~ invert_tag_item
                     ~ exp_line ~ trailing_tilde_to_omit_whitespace? ~ "}}" }
```

But the compile code called `parse_name` (to consume `invert_tag_item`)
*before* `parse_expression`, so when a leading `~` was present it was
handed to `parse_name`, which only expects `identifier` /
`invert_tag_item` / `reference` / `subexpression` — hence the
`unreachable!` arm.

The plain `{{~else}}` (`invert_tag`) case already worked, because it
skips `parse_name` and goes straight to `parse_expression`, which
handles the leading tilde itself. Only `invert_chain_tag` with a
**leading** tilde was broken (trailing tildes worked, since
`parse_expression`'s loop consumes them).

## Fix

Consume the optional leading tilde *before* `parse_name` for
`invert_chain_tag`, and fold its `omit_pre_ws` semantics into the
parsed expression so preceding whitespace is stripped consistently
with `{{~else}}`.

```rust
let mut invert_omit_pre_ws = false;
if rule == Rule::invert_chain_tag {
    if it.peek().unwrap().as_rule() == Rule::leading_tilde_to_omit_whitespace {
        invert_omit_pre_ws = true;
        it.next();
    }
    let _ = Template::parse_name(source, &mut it, span.end())?;
}
let mut exp = Template::parse_expression(source, it.by_ref(), span.end())?;
if invert_omit_pre_ws {
    exp.omit_pre_ws = true;
}
```

## Tests

- `src/grammar.rs`: grammar acceptance cases for `{{~else if foo}}`,
  `{{else if foo~}}`, `{{~else if foo~}}`.
- `src/template.rs`: unit test reproducing the original panic.
- `tests/whitespace.rs`: rendering tests for leading / trailing / both
  tildes and the falsy fallback, confirming behaviour matches `{{~else}}`.

All existing tests, `cargo fmt --check`, and `cargo clippy --tests` pass.