### PR TITLE
chore: drop pprof dev-dependency to remove vulnerable quick-xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [Unreleased]
+
+* [Changed] Drop the `pprof` dev-dependency (and its `inferno` /
+  `quick-xml` transitive deps) from benchmarks. This removes the vulnerable
+  `quick-xml` 0.26 transitive dependency ([#764], [#765]); the upgrade was
+  blocked upstream because `pprof` pins `inferno` 0.11. Benchmarks now use
+  plain criterion without in-repo flamegraph generation.
+
 ## [6.4.2](https://github.com/sunng87/handlebars-rust/compare/6.4.1...6.4.2) - 2026-06-24
 
 * [Fixed] Access to local variables like `@key`, `@index`, etc. in `#with` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ criterion = "0.8"
 tiny_http = "0.12"
 time = { version = "0.3.47", features = ["serde", "formatting", "parsing"]}
 
-[target.'cfg(unix)'.dev-dependencies]
-pprof = { version = "0.15", features = ["flamegraph", "prost-codec"] }
-
 [features]
 dir_source = ["walkdir"]
 script_helper = ["rhai"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,59 +9,6 @@ use serde_json::json;
 use serde_json::value::Value as Json;
 use std::collections::BTreeMap;
 
-#[cfg(unix)]
-use criterion::profiler::Profiler;
-#[cfg(unix)]
-use pprof::ProfilerGuard;
-#[cfg(unix)]
-use pprof::protos::Message;
-
-#[cfg(unix)]
-use std::fs::{File, create_dir_all};
-#[cfg(unix)]
-use std::io::Write;
-#[cfg(unix)]
-use std::path::Path;
-
-#[cfg(unix)]
-#[derive(Default)]
-struct CpuProfiler<'a> {
-    guard: Option<ProfilerGuard<'a>>,
-}
-
-#[cfg(unix)]
-impl Profiler for CpuProfiler<'_> {
-    fn start_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
-        create_dir_all(benchmark_dir).unwrap();
-
-        let guard = ProfilerGuard::new(100).unwrap();
-        self.guard = Some(guard);
-    }
-
-    fn stop_profiling(&mut self, benchmark_id: &str, benchmark_dir: &Path) {
-        if let Ok(ref report) = self.guard.as_ref().unwrap().report().build() {
-            let fg_file_name = benchmark_dir.join(format!("{benchmark_id}.svg"));
-            let fg_file = File::create(fg_file_name).unwrap();
-            report.flamegraph(fg_file).unwrap();
-
-            let pb_file_name = benchmark_dir.join(format!("{benchmark_id}.pb"));
-            let mut pb_file = File::create(pb_file_name).unwrap();
-            let profile = report.pprof().unwrap();
-
-            let mut content = Vec::new();
-            profile.encode(&mut content).unwrap();
-            pb_file.write_all(&content).unwrap();
-        };
-
-        self.guard = None;
-    }
-}
-
-#[cfg(unix)]
-fn profiled() -> Criterion {
-    Criterion::default().with_profiler(CpuProfiler::default())
-}
-
 #[derive(Serialize)]
 struct DataWrapper {
     v: String,
@@ -265,15 +212,6 @@ fn deeply_nested_partial(c: &mut Criterion) {
     });
 }
 
-#[cfg(unix)]
-criterion_group!(
-    name = benches;
-    config = profiled();
-    targets = parse_template, render_template, large_loop_helper, large_loop_helper_with_context_creation,
-    large_nested_loop, deeply_nested_partial
-);
-
-#[cfg(not(unix))]
 criterion_group!(
     benches,
     parse_template,


### PR DESCRIPTION
Fixes #764.
Fixes #765.

## Summary

Drops the `pprof` dev-dependency, which transitively pulled in
`inferno 0.11` → `quick-xml 0.26.0` — the subject of two RUSTSEC
advisories:

- **#764 / RUSTSEC-2026-0194** — quadratic duplicate-attribute check
- **#765 / RUSTSEC-2026-0195** — unbounded namespace-declaration allocation

## Why drop instead of upgrade

The patched `quick-xml` is `>=0.41.0`, which requires `inferno 0.12`.
But `pprof 0.15.0` (the latest release) pins `inferno ^0.11`, so the
upgrade is **blocked upstream** — confirmed by:

```
$ cargo update -p inferno --precise 0.12.7
error: failed to select a version for the requirement `inferno = "^0.11"`
candidate versions found which didn't match: 0.12.7
required by package `pprof v0.15.0`
```

No pprof release supports inferno 0.12, and there is no upstream issue
tracking it.

## Impact

`pprof` was a **dev-dependency only** (`[target.'cfg(unix)'.dev-dependencies]`),
used solely for flamegraph generation in `benches/bench.rs`. It had **zero
impact on the published `handlebars` crate** — none of the runtime
dependencies pull `quick-xml`, and the vulnerable code paths (untrusted XML
attribute / namespace parsing) are never exercised. Removing it eliminates
the advisories from the audited dependency tree while benchmarks keep
running under plain criterion.

## Changes

- `Cargo.toml`: remove the `[target.'cfg(unix)'.dev-dependencies]` pprof entry.
- `benches/bench.rs`: remove the `CpuProfiler` / `pprof` flamegraph glue and
  unify the two `cfg(unix)`/`cfg(not(unix))` `criterion_group!` macros into one.
- `CHANGELOG.md`: Unreleased entry.

## Verification

A freshly generated `Cargo.lock` no longer contains `pprof`, `inferno`,
`quick-xml`, or `proc-macro-error2`. `cargo build --all-features`,
`cargo test --all-features`, `cargo bench --no-run`, `cargo fmt --check`,
and `cargo clippy --all-features --tests --benches` all pass.