### PR TITLE
test: add shared TestHandlebars helpers and adopt across render tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ rust-embed = { version = "8.0.0", optional = true, features = ["include-exclude"
 heck = { version = "0.5", optional = true }
 
 [dev-dependencies]
+# Self-reference: enables the internal `testing` feature so the
+# `handlebars::testing` module is compiled for our own tests, examples, and
+# benchmarks. Downstream users opt in with `features = ["testing"]`.
+handlebars = { path = ".", features = ["testing"] }
 env_logger = "0.11"
 serde_derive = "1.0.75"
 tempfile = "3.0.0"
@@ -46,6 +50,9 @@ no_logging = []
 default = ["preserve_json_order"]
 string_helpers = ["heck"]
 preserve_json_order = ["serde_json/preserve_order"]
+# Exposes `handlebars::testing` (render-test helpers). Off by default so it
+# never ships in a normal build of the library.
+testing = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/helpers/helper_each.rs
+++ b/src/helpers/helper_each.rs
@@ -162,6 +162,7 @@ pub static EACH_HELPER: EachHelper = EachHelper;
 #[cfg(test)]
 mod test {
     use crate::registry::Registry;
+    use crate::testing::TestHandlebars;
     use serde_json::value::Value as Json;
     use std::collections::BTreeMap;
     use std::str::FromStr;
@@ -175,44 +176,35 @@ mod test {
             "a": [ ],
         });
 
-        let template = "{{#each a}}each{{/each}}";
-        assert_eq!(hbs.render_template(template, &data).unwrap(), "");
+        hbs.assert_render_template("{{#each a}}each{{/each}}", &data, "");
     }
 
     #[test]
     fn test_each() {
-        let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#each this}}{{@first}}|{{@last}}|{{@index}}:{{this}}|{{/each}}",
-                )
-                .is_ok()
+        let mut hbs = Registry::new();
+        hbs.register(
+            "t0",
+            "{{#each this}}{{@first}}|{{@last}}|{{@index}}:{{this}}|{{/each}}",
         );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t1",
-                    "{{#each this}}{{@first}}|{{@last}}|{{@key}}:{{this}}|{{@index}}|{{/each}}",
-                )
-                .is_ok()
+        hbs.register(
+            "t1",
+            "{{#each this}}{{@first}}|{{@last}}|{{@key}}:{{this}}|{{@index}}|{{/each}}",
         );
 
-        let r0 = handlebars.render("t0", &vec![1u16, 2u16, 3u16]);
-        assert_eq!(
-            r0.ok().unwrap(),
-            "true|false|0:1|false|false|1:2|false|true|2:3|".to_string()
+        hbs.assert_render(
+            "t0",
+            &vec![1u16, 2u16, 3u16],
+            "true|false|0:1|false|false|1:2|false|true|2:3|",
         );
 
         let mut m: BTreeMap<String, u16> = BTreeMap::new();
         m.insert("ftp".to_string(), 21);
         m.insert("gopher".to_string(), 70);
         m.insert("http".to_string(), 80);
-        let r1 = handlebars.render("t1", &m);
-        assert_eq!(
-            r1.ok().unwrap(),
-            "true|false|ftp:21|0|false|false|gopher:70|1|false|true|http:80|2|".to_string()
+        hbs.assert_render(
+            "t1",
+            &m,
+            "true|false|ftp:21|0|false|false|gopher:70|1|false|true|http:80|2|",
         );
     }
 
@@ -221,20 +213,13 @@ mod test {
         let json_str = r#"{"a":{"a":99,"c":[{"d":100},{"d":200}]}}"#;
 
         let data = Json::from_str(json_str).unwrap();
-        // println!("data: {}", data);
         let mut handlebars = Registry::new();
 
         // previously, to access the parent in an each block,
         // a user would need to specify ../../b, as the path
         // that is computed includes the array index: ./a.c.[0]
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each a.c}} d={{d}} b={{../a.a}} {{/each}}")
-                .is_ok()
-        );
-
-        let r1 = handlebars.render("t0", &data);
-        assert_eq!(r1.ok().unwrap(), " d=100 b=99  d=200 b=99 ".to_string());
+        handlebars.register("t0", "{{#each a.c}} d={{d}} b={{../a.a}} {{/each}}");
+        handlebars.assert_render("t0", &data, " d=100 b=99  d=200 b=99 ");
     }
 
     #[test]
@@ -243,17 +228,11 @@ mod test {
 
         let data = Json::from_str(json_str).unwrap();
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#each a}}{{#each b}}{{d}}:{{../c}}{{/each}}{{/each}}",
-                )
-                .is_ok()
+        handlebars.register(
+            "t0",
+            "{{#each a}}{{#each b}}{{d}}:{{../c}}{{/each}}{{/each}}",
         );
-
-        let r1 = handlebars.render("t0", &data);
-        assert_eq!(r1.ok().unwrap(), "100:200".to_string());
+        handlebars.assert_render("t0", &data, "100:200");
     }
 
     #[test]
@@ -263,41 +242,24 @@ mod test {
         let data = Json::from_str(json_str).unwrap();
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#each b}}{{#if ../a}}{{#each this}}{{this}}{{/each}}{{/if}}{{/each}}",
-                )
-                .is_ok()
+        handlebars.register(
+            "t0",
+            "{{#each b}}{{#if ../a}}{{#each this}}{{this}}{{/each}}{{/if}}{{/each}}",
         );
-
-        let r1 = handlebars.render("t0", &data);
-        assert_eq!(r1.ok().unwrap(), "12345".to_string());
+        handlebars.assert_render("t0", &data, "12345");
     }
 
     #[test]
     fn test_nested_array() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each this.[0]}}{{this}}{{/each}}")
-                .is_ok()
-        );
-
-        let r0 = handlebars.render("t0", &(vec![vec![1, 2, 3]]));
-
-        assert_eq!(r0.ok().unwrap(), "123".to_string());
+        handlebars.register("t0", "{{#each this.[0]}}{{this}}{{/each}}");
+        handlebars.assert_render("t0", &(vec![vec![1, 2, 3]]), "123");
     }
 
     #[test]
     fn test_empty_key() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each this}}{{@key}}-{{value}}\n{{/each}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#each this}}{{@key}}-{{value}}\n{{/each}}");
 
         let r0 = handlebars
             .render(
@@ -322,37 +284,16 @@ mod test {
     #[test]
     fn test_each_else() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each a}}1{{else}}empty{{/each}}")
-                .is_ok()
-        );
-        let m1 = json!({
-            "a": []
-        });
-        let r0 = handlebars.render("t0", &m1).unwrap();
-        assert_eq!(r0, "empty");
-
-        let m2 = json!({
-            "b": []
-        });
-        let r1 = handlebars.render("t0", &m2).unwrap();
-        assert_eq!(r1, "empty");
+        handlebars.register("t0", "{{#each a}}1{{else}}empty{{/each}}");
+        handlebars.assert_render("t0", &json!({"a": []}), "empty");
+        handlebars.assert_render("t0", &json!({"b": []}), "empty");
     }
 
     #[test]
     fn test_block_param() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each a as |i|}}{{i}}{{/each}}")
-                .is_ok()
-        );
-        let m1 = json!({
-            "a": [1,2,3,4,5]
-        });
-        let r0 = handlebars.render("t0", &m1).unwrap();
-        assert_eq!(r0, "12345");
+        handlebars.register("t0", "{{#each a as |i|}}{{i}}{{/each}}");
+        handlebars.assert_render("t0", &json!({"a": [1,2,3,4,5]}), "12345");
     }
 
     #[test]
@@ -361,14 +302,8 @@ mod test {
         let template = "{{#each this as |v k|}}\
                         {{#with k as |inner_k|}}{{inner_k}}{{/with}}:{{v}}|\
                         {{/each}}";
-        assert!(handlebars.register_template_string("t0", template).is_ok());
-
-        let m = json!({
-            "ftp": 21,
-            "http": 80
-        });
-        let r0 = handlebars.render("t0", &m);
-        assert_eq!(r0.ok().unwrap(), "ftp:21|http:80|".to_string());
+        handlebars.register("t0", template);
+        handlebars.assert_render("t0", &json!({"ftp": 21, "http": 80}), "ftp:21|http:80|");
     }
 
     #[test]
@@ -377,26 +312,16 @@ mod test {
         let template = "{{#each this as |v k|}}\
                         {{#with v as |inner_v|}}{{k}}:{{inner_v}}{{/with}}|\
                         {{/each}}";
-
-        assert!(handlebars.register_template_string("t0", template).is_ok());
-
-        let m = json!({
-            "ftp": 21,
-            "http": 80
-        });
-        let r0 = handlebars.render("t0", &m);
-        assert_eq!(r0.ok().unwrap(), "ftp:21|http:80|".to_string());
+        handlebars.register("t0", template);
+        handlebars.assert_render("t0", &json!({"ftp": 21, "http": 80}), "ftp:21|http:80|");
     }
 
+    #[test]
     fn test_nested_each_with_path_ups() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#each a.b}}{{#each c}}{{../../d}}{{/each}}{{/each}}",
-                )
-                .is_ok()
+        handlebars.register(
+            "t0",
+            "{{#each a.b}}{{#each c}}{{../../d}}{{/each}}{{/each}}",
         );
 
         let data = json!({
@@ -406,8 +331,7 @@ mod test {
             "d": 1
         });
 
-        let r0 = handlebars.render("t0", &data);
-        assert_eq!(r0.ok().unwrap(), "1".to_string());
+        handlebars.assert_render("t0", &data, "1");
     }
 
     #[test]
@@ -416,23 +340,18 @@ mod test {
         let template = "{{#each variant}}{{#each ../typearg}}\
                         {{#if @first}}template<{{/if}}{{this}}{{#if @last}}>{{else}},{{/if}}\
                         {{/each}}{{/each}}";
-        assert!(handlebars.register_template_string("t0", template).is_ok());
+        handlebars.register("t0", template);
         let data = json!({
             "typearg": ["T"],
             "variant": ["1", "2"]
         });
-        let r0 = handlebars.render("t0", &data);
-        assert_eq!(r0.ok().unwrap(), "template<T>template<T>".to_string());
+        handlebars.assert_render("t0", &data, "template<T>template<T>");
     }
 
     #[test]
     fn test_key_iteration_with_unicode() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each this}}{{@key}}: {{this}}\n{{/each}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#each this}}{{@key}}: {{this}}\n{{/each}}");
         let data = json!({
             "normal": 1,
             "你好": 2,
@@ -440,7 +359,7 @@ mod test {
             "😂": 4,
             "me.dot.key": 5
         });
-        let r0 = handlebars.render("t0", &data).ok().unwrap();
+        let r0 = handlebars.render("t0", &data).unwrap();
         assert!(r0.contains("normal: 1"));
         assert!(r0.contains("你好: 2"));
         assert!(r0.contains("#special key: 3"));
@@ -451,37 +370,32 @@ mod test {
     #[test]
     fn test_base_path_after_each() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each a}}{{this}}{{/each}} {{b}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#each a}}{{this}}{{/each}} {{b}}");
         let data = json!({
             "a": [1, 2, 3, 4],
             "b": "good",
         });
-
-        let r0 = handlebars.render("t0", &data).ok().unwrap();
-
-        assert_eq!("1234 good", r0);
+        handlebars.assert_render("t0", &data, "1234 good");
     }
 
     #[test]
     fn test_else_context() {
         let reg = Registry::new();
-        let template = "{{#each list}}A{{else}}{{foo}}{{/each}}";
-        let input = json!({"list": [], "foo": "bar"});
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("bar", rendered);
+        reg.assert_render_template(
+            "{{#each list}}A{{else}}{{foo}}{{/each}}",
+            &json!({"list": [], "foo": "bar"}),
+            "bar",
+        );
     }
 
     #[test]
     fn test_block_context_leak() {
         let reg = Registry::new();
-        let template = "{{#each list}}{{#each inner}}{{this}}{{/each}}{{foo}}{{/each}}";
-        let input = json!({"list": [{"inner": [], "foo": 1}, {"inner": [], "foo": 2}]});
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("12", rendered);
+        reg.assert_render_template(
+            "{{#each list}}{{#each inner}}{{this}}{{/each}}{{foo}}{{/each}}",
+            &json!({"list": [{"inner": [], "foo": 1}, {"inner": [], "foo": 2}]}),
+            "12",
+        );
     }
 
     #[test]
@@ -489,10 +403,7 @@ mod test {
         handlebars_helper!(range: |x: u64| (0..x).collect::<Vec<u64>>());
         let mut reg = Registry::new();
         reg.register_helper("range", Box::new(range));
-        let template = "{{#each (range 3) as |i|}}{{i}}{{/each}}";
-        let input = json!(0);
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("012", rendered);
+        reg.assert_render_template("{{#each (range 3) as |i|}}{{i}}{{/each}}", &json!(0), "012");
     }
 
     #[test]
@@ -500,10 +411,11 @@ mod test {
         handlebars_helper!(point: |x: u64, y: u64| json!({"x":x, "y":y}));
         let mut reg = Registry::new();
         reg.register_helper("point", Box::new(point));
-        let template = "{{#each (point 0 1) as |i|}}{{i}}{{/each}}";
-        let input = json!(0);
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("01", rendered);
+        reg.assert_render_template(
+            "{{#each (point 0 1) as |i|}}{{i}}{{/each}}",
+            &json!(0),
+            "01",
+        );
     }
 
     #[test]
@@ -511,10 +423,7 @@ mod test {
         handlebars_helper!(range: |x: u64| (0..x).collect::<Vec<u64>>());
         let mut reg = Registry::new();
         reg.register_helper("range", Box::new(range));
-        let template = "{{#each (range 3)}}{{this}}{{/each}}";
-        let input = json!(0);
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("012", rendered);
+        reg.assert_render_template("{{#each (range 3)}}{{this}}{{/each}}", &json!(0), "012");
     }
 
     #[test]
@@ -522,46 +431,41 @@ mod test {
         handlebars_helper!(point: |x: u64, y: u64| json!({"x":x, "y":y}));
         let mut reg = Registry::new();
         reg.register_helper("point", Box::new(point));
-        let template = "{{#each (point 0 1)}}{{this}}{{/each}}";
-        let input = json!(0);
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("01", rendered);
+        reg.assert_render_template("{{#each (point 0 1)}}{{this}}{{/each}}", &json!(0), "01");
     }
 
     #[test]
     fn test_non_iterable() {
         let reg = Registry::new();
-        let template = "{{#each this}}each block{{else}}else block{{/each}}";
-        let input = json!("strings aren't iterable");
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("else block", rendered);
+        reg.assert_render_template(
+            "{{#each this}}each block{{else}}else block{{/each}}",
+            &json!("strings aren't iterable"),
+            "else block",
+        );
     }
 
     #[test]
     fn test_render_array_without_trailig_commas() {
         let reg = Registry::new();
-        let template = "Array: {{array}}";
-        let input = json!({"array": [1, 2, 3]});
-        let rendered = reg.render_template(template, &input);
-
-        assert_eq!("Array: [1, 2, 3]", rendered.unwrap());
+        reg.assert_render_template(
+            "Array: {{array}}",
+            &json!({"array": [1, 2, 3]}),
+            "Array: [1, 2, 3]",
+        );
     }
 
     #[test]
     fn test_recursion() {
         let mut reg = Registry::new();
-        assert!(
-            reg.register_template_string(
-                "walk",
-                "(\
+        reg.register(
+            "walk",
+            "(\
                     {{#each this}}\
                         {{#if @key}}{{@key}}{{else}}{{@index}}{{/if}}: \
                         {{this}} \
                         {{> walk this}}, \
                     {{/each}}\
                 )",
-            )
-            .is_ok()
         );
 
         let input = json!({
@@ -584,41 +488,22 @@ mod test {
             string: hi (), \
         )";
 
-        let rendered = reg.render("walk", &input).unwrap();
-        assert_eq!(expected_output, rendered);
+        reg.assert_render("walk", &input, expected_output);
     }
 
     #[test]
     fn test_strict_each() {
         let mut reg = Registry::new();
 
-        assert!(
-            reg.render_template("{{#each data}}{{/each}}", &json!({}))
-                .is_ok()
-        );
-        assert!(
-            reg.render_template("{{#each data}}{{/each}}", &json!({"data": 24}))
-                .is_ok()
-        );
+        reg.assert_render_template_ok("{{#each data}}{{/each}}", &json!({}));
+        reg.assert_render_template_ok("{{#each data}}{{/each}}", &json!({"data": 24}));
 
         reg.set_strict_mode(true);
 
-        assert!(
-            reg.render_template("{{#each data}}{{/each}}", &json!({}))
-                .is_err()
-        );
-        assert!(
-            reg.render_template("{{#each data}}{{/each}}", &json!({"data": 24}))
-                .is_err()
-        );
-        assert!(
-            reg.render_template("{{#each data}}{{else}}food{{/each}}", &json!({}))
-                .is_ok()
-        );
-        assert!(
-            reg.render_template("{{#each data}}{{else}}food{{/each}}", &json!({"data": 24}))
-                .is_ok()
-        );
+        reg.assert_render_template_err("{{#each data}}{{/each}}", &json!({}), None);
+        reg.assert_render_template_err("{{#each data}}{{/each}}", &json!({"data": 24}), None);
+        reg.assert_render_template_ok("{{#each data}}{{else}}food{{/each}}", &json!({}));
+        reg.assert_render_template_ok("{{#each data}}{{else}}food{{/each}}", &json!({"data": 24}));
     }
 
     #[test]
@@ -631,12 +516,13 @@ mod test {
     <li>{{this}}</li>
   {{/each}}
 </ul>";
-        assert_eq!(
+        reg.assert_render_template(
+            tpl,
+            &json!({"a": [0, 1]}),
             r"<ul>
     <li>0</li>
     <li>1</li>
 </ul>",
-            reg.render_template(tpl, &json!({"a": [0, 1]})).unwrap()
         );
     }
 }

--- a/src/helpers/helper_extras.rs
+++ b/src/helpers/helper_extras.rs
@@ -272,16 +272,15 @@ pub(crate) static OR_HELPER: ManyBoolHelper = ManyBoolHelper {
 
 #[cfg(test)]
 mod test_conditions {
+    use crate::testing::TestHandlebars;
+
     fn test_condition(condition: &str, expected: bool) {
         let handlebars = crate::Handlebars::new();
-
-        let result = handlebars
-            .render_template(
-                &format!("{{{{#if {condition}}}}}lorem{{{{else}}}}ipsum{{{{/if}}}}"),
-                &json!({}),
-            )
-            .unwrap();
-        assert_eq!(&result, if expected { "lorem" } else { "ipsum" });
+        handlebars.assert_render_template(
+            &format!("{{{{#if {condition}}}}}lorem{{{{else}}}}ipsum{{{{/if}}}}"),
+            &json!({}),
+            if expected { "lorem" } else { "ipsum" },
+        );
     }
 
     #[test]
@@ -334,44 +333,29 @@ mod test_conditions {
     #[test]
     fn nested_conditions() {
         let handlebars = crate::Handlebars::new();
-
-        let result = handlebars
-            .render_template("{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}", &json!({}))
-            .unwrap();
-        assert_eq!(&result, "lorem");
-
-        let result = handlebars
-            .render_template(
-                "{{#if (not (gt 5 3))}}lorem{{else}}ipsum{{/if}}",
-                &json!({}),
-            )
-            .unwrap();
-        assert_eq!(&result, "ipsum");
+        handlebars.assert_render_template(
+            "{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}",
+            &json!({}),
+            "lorem",
+        );
+        handlebars.assert_render_template(
+            "{{#if (not (gt 5 3))}}lorem{{else}}ipsum{{/if}}",
+            &json!({}),
+            "ipsum",
+        );
     }
 
     #[test]
     fn test_len() {
         let handlebars = crate::Handlebars::new();
-
-        let result = handlebars
-            .render_template("{{len value}}", &json!({"value": [1,2,3]}))
-            .unwrap();
-        assert_eq!(&result, "3");
-
-        let result = handlebars
-            .render_template("{{len value}}", &json!({"value": {"a" :1, "b": 2}}))
-            .unwrap();
-        assert_eq!(&result, "2");
-
-        let result = handlebars
-            .render_template("{{len value}}", &json!({"value": "tomcat"}))
-            .unwrap();
-        assert_eq!(&result, "6");
-
-        let result = handlebars
-            .render_template("{{len value}}", &json!({"value": 3}))
-            .unwrap();
-        assert_eq!(&result, "0");
+        handlebars.assert_render_template("{{len value}}", &json!({"value": [1,2,3]}), "3");
+        handlebars.assert_render_template(
+            "{{len value}}",
+            &json!({"value": {"a": 1, "b": 2}}),
+            "2",
+        );
+        handlebars.assert_render_template("{{len value}}", &json!({"value": "tomcat"}), "6");
+        handlebars.assert_render_template("{{len value}}", &json!({"value": 3}), "0");
     }
 
     #[test]
@@ -419,9 +403,7 @@ mod test_conditions {
 
     fn test_block(template: &str, expected: &str) {
         let handlebars = crate::Handlebars::new();
-
-        let result = handlebars.render_template(template, &json!({})).unwrap();
-        assert_eq!(&result, expected);
+        handlebars.assert_render_template(template, &json!({}), expected);
     }
 
     #[test]

--- a/src/helpers/helper_if.rs
+++ b/src/helpers/helper_if.rs
@@ -49,31 +49,19 @@ pub static UNLESS_HELPER: IfHelper = IfHelper { positive: false };
 mod test {
     use crate::helpers::WITH_HELPER;
     use crate::registry::Registry;
+    use crate::testing::TestHandlebars;
     use serde_json::value::Value as Json;
     use std::str::FromStr;
 
     #[test]
     fn test_if() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#if this}}hello{{/if}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t1", "{{#unless this}}hello{{else}}world{{/unless}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#if this}}hello{{/if}}");
+        handlebars.register("t1", "{{#unless this}}hello{{else}}world{{/unless}}");
 
-        let r0 = handlebars.render("t0", &true);
-        assert_eq!(r0.ok().unwrap(), "hello".to_string());
-
-        let r1 = handlebars.render("t1", &true);
-        assert_eq!(r1.ok().unwrap(), "world".to_string());
-
-        let r2 = handlebars.render("t0", &false);
-        assert_eq!(r2.ok().unwrap(), String::new());
+        handlebars.assert_render("t0", &true, "hello");
+        handlebars.assert_render("t1", &true, "world");
+        handlebars.assert_render("t0", &false, "");
     }
 
     #[test]
@@ -83,81 +71,53 @@ mod test {
 
         let mut handlebars = Registry::new();
         handlebars.register_helper("with", Box::new(WITH_HELPER));
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#if a.c.d}}hello {{a.b}}{{/if}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t1",
-                    "{{#with a}}{{#if c.d}}hello {{../a.b}}{{/if}}{{/with}}"
-                )
-                .is_ok()
+        handlebars.register("t0", "{{#if a.c.d}}hello {{a.b}}{{/if}}");
+        handlebars.register(
+            "t1",
+            "{{#with a}}{{#if c.d}}hello {{../a.b}}{{/if}}{{/with}}",
         );
 
-        let r0 = handlebars.render("t0", &data);
-        assert_eq!(r0.unwrap(), "hello 99".to_string());
-
-        let r1 = handlebars.render("t1", &data);
-        assert_eq!(r1.unwrap(), "hello 99".to_string());
+        handlebars.assert_render("t0", &data, "hello 99");
+        handlebars.assert_render("t1", &data, "hello 99");
     }
 
     #[test]
     fn test_if_else_chain() {
         let handlebars = Registry::new();
-
-        assert_eq!(
-            "0".to_owned(),
-            handlebars
-                .render_template("{{#if a}}1{{else if b}}2{{else}}0{{/if}}", &json!({"d": 1}))
-                .unwrap()
+        handlebars.assert_render_template(
+            "{{#if a}}1{{else if b}}2{{else}}0{{/if}}",
+            &json!({"d": 1}),
+            "0",
         );
     }
 
     #[test]
     fn test_if_else_chain2() {
         let handlebars = Registry::new();
-
-        assert_eq!(
-            "3".to_owned(),
-            handlebars
-                .render_template(
-                    "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{else}}0{{/if}}",
-                    &json!({"c": 1, "d":1})
-                )
-                .unwrap()
+        handlebars.assert_render_template(
+            "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{else}}0{{/if}}",
+            &json!({"c": 1, "d": 1}),
+            "3",
         );
     }
 
     #[test]
     fn test_if_else_chain3() {
         let handlebars = Registry::new();
-
-        assert_eq!(
-            "4".to_owned(),
-            handlebars
-                .render_template(
-                    "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{/if}}",
-                    &json!({"d":1})
-                )
-                .unwrap()
+        handlebars.assert_render_template(
+            "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{/if}}",
+            &json!({"d": 1}),
+            "4",
         );
     }
 
     #[test]
     fn test_if_else_chain4() {
         let handlebars = Registry::new();
-
-        assert_eq!(
-            "1".to_owned(),
-            handlebars
-                .render_template(
-                    "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{/if}}",
-                    &json!({"a":1})
-                )
-                .unwrap()
+        handlebars.assert_render_template(
+            "{{#if a}}1{{else if b}}2{{else if c}}3{{else if d}}4{{/if}}",
+            &json!({"a": 1}),
+            "1",
         );
     }
 
@@ -165,90 +125,57 @@ mod test {
     fn test_if_include_zero() {
         use std::f64;
         let handlebars = Registry::new();
-
-        assert_eq!(
-            "0".to_owned(),
-            handlebars
-                .render_template("{{#if a}}1{{else}}0{{/if}}", &json!({"a": 0}))
-                .unwrap()
+        handlebars.assert_render_template("{{#if a}}1{{else}}0{{/if}}", &json!({"a": 0}), "0");
+        handlebars.assert_render_template(
+            "{{#if a includeZero=true}}1{{else}}0{{/if}}",
+            &json!({"a": 0}),
+            "1",
         );
-        assert_eq!(
-            "1".to_owned(),
-            handlebars
-                .render_template(
-                    "{{#if a includeZero=true}}1{{else}}0{{/if}}",
-                    &json!({"a": 0})
-                )
-                .unwrap()
-        );
-        assert_eq!(
-            "0".to_owned(),
-            handlebars
-                .render_template(
-                    "{{#if a includeZero=true}}1{{else}}0{{/if}}",
-                    &json!({ "a": f64::NAN })
-                )
-                .unwrap()
+        handlebars.assert_render_template(
+            "{{#if a includeZero=true}}1{{else}}0{{/if}}",
+            &json!({"a": f64::NAN}),
+            "0",
         );
     }
 
     #[test]
     fn test_invisible_line_stripping() {
         let hbs = Registry::new();
-        assert_eq!(
-            "yes\n",
-            hbs.render_template("{{#if a}}\nyes\n{{/if}}\n", &json!({"a": true}))
-                .unwrap()
-        );
-
-        assert_eq!(
+        hbs.assert_render_template("{{#if a}}\nyes\n{{/if}}\n", &json!({"a": true}), "yes\n");
+        hbs.assert_render_template(
+            "{{#if a}}\r\nyes\r\n{{/if}}\r\n",
+            &json!({"a": true}),
             "yes\r\n",
-            hbs.render_template("{{#if a}}\r\nyes\r\n{{/if}}\r\n", &json!({"a": true}))
-                .unwrap()
         );
-
-        assert_eq!(
-            "x\ny",
-            hbs.render_template("{{#if a}}x{{/if}}\ny", &json!({"a": true}))
-                .unwrap()
-        );
-
-        assert_eq!(
+        hbs.assert_render_template("{{#if a}}x{{/if}}\ny", &json!({"a": true}), "x\ny");
+        hbs.assert_render_template(
+            "{{#if a}}\nx\n{{^}}\ny\n{{/if}}\nz",
+            &json!({"a": false}),
             "y\nz",
-            hbs.render_template("{{#if a}}\nx\n{{^}}\ny\n{{/if}}\nz", &json!({"a": false}))
-                .unwrap()
         );
-
-        assert_eq!(
+        hbs.assert_render_template(
             r"yes
-  foo
-  bar
-  baz",
-            hbs.render_template(
-                r"yes
   {{#if true}}
   foo
   bar
   {{/if}}
   baz",
-                &json!({})
-            )
-            .unwrap()
-        );
-
-        assert_eq!(
-            r"  foo
+            &json!({}),
+            r"yes
+  foo
   bar
   baz",
-            hbs.render_template(
-                r"  {{#if true}}
+        );
+        hbs.assert_render_template(
+            r"  {{#if true}}
   foo
   bar
   {{/if}}
   baz",
-                &json!({})
-            )
-            .unwrap()
+            &json!({}),
+            r"  foo
+  bar
+  baz",
         );
     }
 }

--- a/src/helpers/helper_lookup.rs
+++ b/src/helpers/helper_lookup.rs
@@ -44,76 +44,40 @@ pub static LOOKUP_HELPER: LookupHelper = LookupHelper;
 #[cfg(test)]
 mod test {
     use crate::registry::Registry;
+    use crate::testing::TestHandlebars;
 
     #[test]
     fn test_lookup() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#each v1}}{{lookup ../v2 @index}}{{/each}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t1", "{{#each v1}}{{lookup ../v2 1}}{{/each}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t2", "{{lookup kk \"a\"}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#each v1}}{{lookup ../v2 @index}}{{/each}}");
+        handlebars.register("t1", "{{#each v1}}{{lookup ../v2 1}}{{/each}}");
+        handlebars.register("t2", "{{lookup kk \"a\"}}");
 
         let m = json!({"v1": [1,2,3], "v2": [9,8,7]});
-
         let m2 = json!({
             "kk": {"a": "world"}
         });
 
-        let r0 = handlebars.render("t0", &m);
-        assert_eq!(r0.ok().unwrap(), "987".to_string());
+        handlebars.assert_render("t0", &m, "987");
+        handlebars.assert_render("t1", &m, "888");
+        handlebars.assert_render("t2", &m2, "world");
 
-        let r1 = handlebars.render("t1", &m);
-        assert_eq!(r1.ok().unwrap(), "888".to_string());
-
-        let r2 = handlebars.render("t2", &m2);
-        assert_eq!(r2.ok().unwrap(), "world".to_string());
-
-        assert!(handlebars.render_template("{{lookup}}", &m).is_err());
-        assert!(handlebars.render_template("{{lookup v1}}", &m).is_err());
-        assert_eq!(
-            handlebars.render_template("{{lookup null 1}}", &m).unwrap(),
-            ""
-        );
-        assert_eq!(
-            handlebars.render_template("{{lookup v1 3}}", &m).unwrap(),
-            ""
-        );
+        handlebars.assert_render_template_err("{{lookup}}", &m, None);
+        handlebars.assert_render_template_err("{{lookup v1}}", &m, None);
+        handlebars.assert_render_template("{{lookup null 1}}", &m, "");
+        handlebars.assert_render_template("{{lookup v1 3}}", &m, "");
     }
 
     #[test]
     fn test_strict_lookup() {
         let mut hbs = Registry::new();
 
-        assert_eq!(
-            hbs.render_template("{{lookup kk 1}}", &json!({"kk": []}))
-                .unwrap(),
-            ""
-        );
-        assert!(
-            hbs.render_template("{{lookup kk 0}}", &json!({ "kk": [null] }))
-                .is_ok()
-        );
+        hbs.assert_render_template("{{lookup kk 1}}", &json!({"kk": []}), "");
+        hbs.assert_render_template_ok("{{lookup kk 0}}", &json!({ "kk": [null] }));
 
         hbs.set_strict_mode(true);
 
-        assert!(
-            hbs.render_template("{{lookup kk 1}}", &json!({"kk": []}))
-                .is_err()
-        );
-        assert!(
-            hbs.render_template("{{lookup kk 0}}", &json!({ "kk": [null] }))
-                .is_ok()
-        );
+        hbs.assert_render_template_err("{{lookup kk 1}}", &json!({"kk": []}), None);
+        hbs.assert_render_template_ok("{{lookup kk 0}}", &json!({ "kk": [null] }));
     }
 }

--- a/src/helpers/helper_with.rs
+++ b/src/helpers/helper_with.rs
@@ -71,6 +71,7 @@ pub static WITH_HELPER: WithHelper = WithHelper;
 #[cfg(test)]
 mod test {
     use crate::registry::Registry;
+    use crate::testing::TestHandlebars;
 
     #[derive(Serialize)]
     struct Address {
@@ -88,151 +89,78 @@ mod test {
 
     #[test]
     fn test_with() {
-        let addr = Address {
-            city: "Beijing".to_string(),
-            country: "China".to_string(),
-        };
-
         let person = Person {
             name: "Ning Sun".to_string(),
             age: 27,
-            addr,
+            addr: Address {
+                city: "Beijing".to_string(),
+                country: "China".to_string(),
+            },
             titles: vec!["programmer".to_string(), "cartographier".to_string()],
         };
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#with addr}}{{city}}{{/with}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t1", "{{#with notfound}}hello{{else}}world{{/with}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t2", "{{#with addr/country}}{{this}}{{/with}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#with addr}}{{city}}{{/with}}");
+        handlebars.register("t1", "{{#with notfound}}hello{{else}}world{{/with}}");
+        handlebars.register("t2", "{{#with addr/country}}{{this}}{{/with}}");
 
-        let r0 = handlebars.render("t0", &person);
-        assert_eq!(r0.ok().unwrap(), "Beijing".to_string());
-
-        let r1 = handlebars.render("t1", &person);
-        assert_eq!(r1.ok().unwrap(), "world".to_string());
-
-        let r2 = handlebars.render("t2", &person);
-        assert_eq!(r2.ok().unwrap(), "China".to_string());
+        handlebars.assert_render("t0", &person, "Beijing");
+        handlebars.assert_render("t1", &person, "world");
+        handlebars.assert_render("t2", &person, "China");
     }
 
     #[test]
     fn test_with_block_param() {
-        let addr = Address {
-            city: "Beijing".to_string(),
-            country: "China".to_string(),
-        };
-
         let person = Person {
             name: "Ning Sun".to_string(),
             age: 27,
-            addr,
+            addr: Address {
+                city: "Beijing".to_string(),
+                country: "China".to_string(),
+            },
             titles: vec!["programmer".to_string(), "cartographier".to_string()],
         };
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{#with addr as |a|}}{{a.city}}{{/with}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t1",
-                    "{{#with notfound as |c|}}hello{{else}}world{{/with}}"
-                )
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t2", "{{#with addr/country as |t|}}{{t}}{{/with}}")
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#with addr as |a|}}{{a.city}}{{/with}}");
+        handlebars.register("t1", "{{#with notfound as |c|}}hello{{else}}world{{/with}}");
+        handlebars.register("t2", "{{#with addr/country as |t|}}{{t}}{{/with}}");
 
-        let r0 = handlebars.render("t0", &person);
-        assert_eq!(r0.ok().unwrap(), "Beijing".to_string());
-
-        let r1 = handlebars.render("t1", &person);
-        assert_eq!(r1.ok().unwrap(), "world".to_string());
-
-        let r2 = handlebars.render("t2", &person);
-        assert_eq!(r2.ok().unwrap(), "China".to_string());
+        handlebars.assert_render("t0", &person, "Beijing");
+        handlebars.assert_render("t1", &person, "world");
+        handlebars.assert_render("t2", &person, "China");
     }
 
     #[test]
     fn test_with_in_each() {
-        let addr = Address {
-            city: "Beijing".to_string(),
-            country: "China".to_string(),
-        };
-
-        let person = Person {
+        let person = |age: i16| Person {
             name: "Ning Sun".to_string(),
-            age: 27,
-            addr,
+            age,
+            addr: Address {
+                city: "Beijing".to_string(),
+                country: "China".to_string(),
+            },
             titles: vec!["programmer".to_string(), "cartographier".to_string()],
         };
-
-        let addr2 = Address {
-            city: "Beijing".to_string(),
-            country: "China".to_string(),
-        };
-
-        let person2 = Person {
-            name: "Ning Sun".to_string(),
-            age: 27,
-            addr: addr2,
-            titles: vec!["programmer".to_string(), "cartographier".to_string()],
-        };
-
-        let people = vec![person, person2];
+        let people = vec![person(27), person(27)];
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#each this}}{{#with addr}}{{city}}{{/with}}{{/each}}"
-                )
-                .is_ok()
+        handlebars.register(
+            "t0",
+            "{{#each this}}{{#with addr}}{{city}}{{/with}}{{/each}}",
         );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t1",
-                    "{{#each this}}{{#with addr}}{{../age}}{{/with}}{{/each}}"
-                )
-                .is_ok()
+        handlebars.register(
+            "t1",
+            "{{#each this}}{{#with addr}}{{../age}}{{/with}}{{/each}}",
         );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t2",
-                    "{{#each this}}{{#with addr}}{{@../index}}{{/with}}{{/each}}"
-                )
-                .is_ok()
+        handlebars.register(
+            "t2",
+            "{{#each this}}{{#with addr}}{{@../index}}{{/with}}{{/each}}",
         );
 
-        let r0 = handlebars.render("t0", &people);
-        assert_eq!(r0.ok().unwrap(), "BeijingBeijing".to_string());
-
-        let r1 = handlebars.render("t1", &people);
-        assert_eq!(r1.ok().unwrap(), "2727".to_string());
-
-        let r2 = handlebars.render("t2", &people);
-        assert_eq!(r2.ok().unwrap(), "01".to_string());
+        handlebars.assert_render("t0", &people, "BeijingBeijing");
+        handlebars.assert_render("t1", &people, "2727");
+        handlebars.assert_render("t2", &people, "01");
     }
 
     #[test]
@@ -241,99 +169,70 @@ mod test {
         // must remain accessible inside `{{#with}}`, matching Handlebars.js.
         let mut handlebars = Registry::new();
 
-        let template_obj = "{{#each this}}{{#with this}}{{@key}}={{this}}|{{/with}}{{/each}}";
-        handlebars
-            .register_template_string("obj", template_obj)
-            .unwrap();
-        let r_obj = handlebars.render(
+        handlebars.register(
             "obj",
-            &json!({
-                "ftp": 21,
-                "http": 80,
-            }),
+            "{{#each this}}{{#with this}}{{@key}}={{this}}|{{/with}}{{/each}}",
         );
-        assert_eq!(r_obj.unwrap(), "ftp=21|http=80|".to_string());
+        handlebars.assert_render("obj", &json!({"ftp": 21, "http": 80}), "ftp=21|http=80|");
 
-        let template_arr = "{{#each this}}{{#with this}}{{@index}}={{this}}|{{/with}}{{/each}}";
-        handlebars
-            .register_template_string("arr", template_arr)
-            .unwrap();
-        let r_arr = handlebars.render("arr", &json!([10, 20]));
-        assert_eq!(r_arr.unwrap(), "0=10|1=20|".to_string());
+        handlebars.register(
+            "arr",
+            "{{#each this}}{{#with this}}{{@index}}={{this}}|{{/with}}{{/each}}",
+        );
+        handlebars.assert_render("arr", &json!([10, 20]), "0=10|1=20|");
     }
 
     #[test]
     fn test_path_up() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t0",
-                    "{{#with a}}{{#with b}}{{../../d}}{{/with}}{{/with}}"
-                )
-                .is_ok()
-        );
+        handlebars.register("t0", "{{#with a}}{{#with b}}{{../../d}}{{/with}}{{/with}}");
         let data = json!({
             "a": {
                 "b": [{"c": [1]}]
             },
             "d": 1
         });
-
-        let r0 = handlebars.render("t0", &data);
-        assert_eq!(r0.ok().unwrap(), "1".to_string());
+        handlebars.assert_render("t0", &data, "1");
     }
 
     #[test]
     fn test_else_context() {
         let reg = Registry::new();
-        let template = "{{#with list}}A{{else}}{{foo}}{{/with}}";
-        let input = json!({"list": [], "foo": "bar"});
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("bar", rendered);
+        reg.assert_render_template(
+            "{{#with list}}A{{else}}{{foo}}{{/with}}",
+            &json!({"list": [], "foo": "bar"}),
+            "bar",
+        );
     }
 
     #[test]
     fn test_derived_value() {
         let hb = Registry::new();
-        let data = json!({"a": {"b": {"c": "d"}}});
-        let template = "{{#with (lookup a.b \"c\")}}{{this}}{{/with}}";
-        assert_eq!("d", hb.render_template(template, &data).unwrap());
+        hb.assert_render_template(
+            "{{#with (lookup a.b \"c\")}}{{this}}{{/with}}",
+            &json!({"a": {"b": {"c": "d"}}}),
+            "d",
+        );
     }
 
     #[test]
     fn test_nested_derived_value() {
         let hb = Registry::new();
-        let data = json!({"a": {"b": {"c": "d"}}});
-        let template = "{{#with (lookup a \"b\")}}{{#with this}}{{c}}{{/with}}{{/with}}";
-        assert_eq!("d", hb.render_template(template, &data).unwrap());
+        hb.assert_render_template(
+            "{{#with (lookup a \"b\")}}{{#with this}}{{c}}{{/with}}{{/with}}",
+            &json!({"a": {"b": {"c": "d"}}}),
+            "d",
+        );
     }
 
     #[test]
     fn test_strict_with() {
         let mut hb = Registry::new();
-
-        assert_eq!(
-            hb.render_template("{{#with name}}yes{{/with}}", &json!({}))
-                .unwrap(),
-            ""
-        );
-        assert_eq!(
-            hb.render_template("{{#with name}}yes{{else}}no{{/with}}", &json!({}))
-                .unwrap(),
-            "no"
-        );
+        hb.assert_render_template("{{#with name}}yes{{/with}}", &json!({}), "");
+        hb.assert_render_template("{{#with name}}yes{{else}}no{{/with}}", &json!({}), "no");
 
         hb.set_strict_mode(true);
-
-        assert!(
-            hb.render_template("{{#with name}}yes{{/with}}", &json!({}))
-                .is_err()
-        );
-        assert_eq!(
-            hb.render_template("{{#with name}}yes{{else}}no{{/with}}", &json!({}))
-                .unwrap(),
-            "no"
-        );
+        hb.assert_render_template_err("{{#with name}}yes{{/with}}", &json!({}), None);
+        hb.assert_render_template("{{#with name}}yes{{else}}no{{/with}}", &json!({}), "no");
     }
 }

--- a/src/helpers/string_helpers/mod.rs
+++ b/src/helpers/string_helpers/mod.rs
@@ -49,20 +49,21 @@ define_case_helper!(train_case, to_train_case);
 
 #[cfg(test)]
 mod tests {
+    use crate::testing::TestHandlebars;
+
     macro_rules! define_case_helpers_test_cases {
     ($template_fn_name:literal, $helper_tc_fn_name:ident, $(($tc_input:literal, $tc_expected:literal),)+) => {
 
         #[test]
         fn $helper_tc_fn_name() {
             let hbs = crate::registry::Registry::new();
-            let test_cases = vec![$(($tc_input, $tc_expected)),+];
-            for tc in test_cases {
-                let result =
-                    hbs.render_template(
-                        concat!("{{", $template_fn_name, " data}}"),
-                        &json!({"data": tc.0}));
-                assert!(result.is_ok(), "{}", result.err().unwrap());
-                assert_eq!(result.unwrap(), tc.1.to_string());
+            let test_cases = [$(($tc_input, $tc_expected)),+];
+            for (input, expected) in test_cases {
+                hbs.assert_render_template(
+                    concat!("{{", $template_fn_name, " data}}"),
+                    &json!({"data": input}),
+                    expected,
+                );
             }
         }
     }
@@ -121,9 +122,7 @@ mod tests {
         use crate::error::RenderErrorReason;
 
         let hbs = crate::registry::Registry::new();
-        let err = hbs
-            .render_template("{{snakeCase 1}}", &json!({}))
-            .unwrap_err();
+        let err = hbs.assert_render_template_err("{{snakeCase 1}}", &json!({}), None);
         assert!(matches!(
             err.reason(),
             RenderErrorReason::ParamTypeMismatchForName(_, _, _)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,3 +450,9 @@ mod sources;
 mod support;
 pub mod template;
 mod util;
+
+/// Test helpers shared by this crate's tests and, behind the `testing` cargo
+/// feature, by downstream users. See `src/testing.rs`.
+#[cfg(any(test, feature = "testing"))]
+#[doc(hidden)]
+pub mod testing;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -179,83 +179,36 @@ mod test {
     use crate::output::Output;
     use crate::registry::Registry;
     use crate::render::{Helper, RenderContext};
+    use crate::testing::TestHandlebars;
     use crate::{Decorator, RenderErrorReason};
 
     #[test]
     fn test() {
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("t0", "{{> t1}}")
-                .is_ok()
+        handlebars.register("t0", "{{> t1}}");
+        handlebars.register("t1", "{{this}}");
+        handlebars.register("t2", "{{#> t99}}not there{{/t99}}");
+        handlebars.register("t3", "{{#*inline \"t31\"}}{{this}}{{/inline}}{{> t31}}");
+        handlebars.register(
+            "t4",
+            "{{#> t5}}{{#*inline \"nav\"}}navbar{{/inline}}{{/t5}}",
         );
-        assert!(
-            handlebars
-                .register_template_string("t1", "{{this}}")
-                .is_ok()
+        handlebars.register("t5", "include {{> nav}}");
+        handlebars.register("t6", "{{> t1 a}}");
+        handlebars.register(
+            "t7",
+            "{{#*inline \"t71\"}}{{a}}{{/inline}}{{> t71 a=\"world\"}}",
         );
-        assert!(
-            handlebars
-                .register_template_string("t2", "{{#> t99}}not there{{/t99}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t3", "{{#*inline \"t31\"}}{{this}}{{/inline}}{{> t31}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t4",
-                    "{{#> t5}}{{#*inline \"nav\"}}navbar{{/inline}}{{/t5}}"
-                )
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t5", "include {{> nav}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("t6", "{{> t1 a}}")
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string(
-                    "t7",
-                    "{{#*inline \"t71\"}}{{a}}{{/inline}}{{> t71 a=\"world\"}}"
-                )
-                .is_ok()
-        );
-        assert!(handlebars.register_template_string("t8", "{{a}}").is_ok());
-        assert!(
-            handlebars
-                .register_template_string("t9", "{{> t8 a=2}}")
-                .is_ok()
-        );
+        handlebars.register("t8", "{{a}}");
+        handlebars.register("t9", "{{> t8 a=2}}");
 
-        assert_eq!(handlebars.render("t0", &1).ok().unwrap(), "1".to_string());
-        assert_eq!(
-            handlebars.render("t2", &1).ok().unwrap(),
-            "not there".to_string()
-        );
-        assert_eq!(handlebars.render("t3", &1).ok().unwrap(), "1".to_string());
-        assert_eq!(
-            handlebars.render("t4", &1).ok().unwrap(),
-            "include navbar".to_string()
-        );
-        assert_eq!(
-            handlebars.render("t6", &json!({"a": "2"})).ok().unwrap(),
-            "2".to_string()
-        );
-        assert_eq!(
-            handlebars.render("t7", &1).ok().unwrap(),
-            "world".to_string()
-        );
-        assert_eq!(handlebars.render("t9", &1).ok().unwrap(), "2".to_string());
+        handlebars.assert_render("t0", &1, "1");
+        handlebars.assert_render("t2", &1, "not there");
+        handlebars.assert_render("t3", &1, "1");
+        handlebars.assert_render("t4", &1, "include navbar");
+        handlebars.assert_render("t6", &json!({"a": "2"}), "2");
+        handlebars.assert_render("t7", &1, "world");
+        handlebars.assert_render("t9", &1, "2");
     }
 
     #[test]
@@ -264,11 +217,10 @@ mod test {
         let t1 = "{{#> t0}}inner {{this}}{{/t0}}";
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", t0).is_ok());
-        assert!(handlebars.register_template_string("t1", t1).is_ok());
+        handlebars.register("t0", t0);
+        handlebars.register("t1", t1);
 
-        let r0 = handlebars.render("t1", &true);
-        assert_eq!(r0.ok().unwrap(), "hello inner true".to_string());
+        handlebars.assert_render("t1", &true, "hello inner true");
     }
 
     #[test]
@@ -276,11 +228,10 @@ mod test {
         let t0 = "hello {{> t1}} {{> t0}}";
         let t1 = "some template";
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t0", t0).is_ok());
-        assert!(handlebars.register_template_string("t1", t1).is_ok());
+        handlebars.register("t0", t0);
+        handlebars.register("t1", t1);
 
-        let r0 = handlebars.render("t0", &true);
-        assert!(r0.is_err());
+        handlebars.assert_render_err("t0", &true, None);
     }
 
     #[test]
@@ -289,19 +240,10 @@ mod test {
         let two_partial = "--- two ---";
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("template", main_template)
-                .is_ok()
-        );
-        assert!(
-            handlebars
-                .register_template_string("two", two_partial)
-                .is_ok()
-        );
+        handlebars.register("template", main_template);
+        handlebars.register("two", two_partial);
 
-        let r0 = handlebars.render("template", &true);
-        assert_eq!(r0.ok().unwrap(), "one--- two ---three--- two ---");
+        handlebars.assert_render("template", &true, "one--- two ---three--- two ---");
     }
 
     #[test]
@@ -310,50 +252,37 @@ mod test {
         let p_partial = "{{a}}";
 
         let mut handlebars = Registry::new();
-        assert!(
-            handlebars
-                .register_template_string("template", main_template)
-                .is_ok()
-        );
-        assert!(handlebars.register_template_string("p", p_partial).is_ok());
+        handlebars.register("template", main_template);
+        handlebars.register("p", p_partial);
 
-        let r0 = handlebars.render("template", &true);
-        assert_eq!(r0.ok().unwrap(), "In: 2 Out: ");
+        handlebars.assert_render("template", &true, "In: 2 Out: ");
     }
 
     #[test]
     fn test_partial_context_hash() {
         let mut hbs = Registry::new();
-        hbs.register_template_string("one", "This is a test. {{> two name=\"fred\" }}")
-            .unwrap();
-        hbs.register_template_string("two", "Lets test {{name}}")
-            .unwrap();
-        assert_eq!(
-            "This is a test. Lets test fred",
-            hbs.render("one", &0).unwrap()
-        );
+        hbs.register("one", "This is a test. {{> two name=\"fred\" }}");
+        hbs.register("two", "Lets test {{name}}");
+        hbs.assert_render("one", &0, "This is a test. Lets test fred");
     }
 
     #[test]
-    fn teset_partial_context_with_both_hash_and_param() {
+    fn test_partial_context_with_both_hash_and_param() {
         let mut hbs = Registry::new();
-        hbs.register_template_string("one", "This is a test. {{> two this name=\"fred\" }}")
-            .unwrap();
-        hbs.register_template_string("two", "Lets test {{name}} and {{root_name}}")
-            .unwrap();
-        assert_eq!(
+        hbs.register("one", "This is a test. {{> two this name=\"fred\" }}");
+        hbs.register("two", "Lets test {{name}} and {{root_name}}");
+        hbs.assert_render(
+            "one",
+            &json!({"root_name": "tom"}),
             "This is a test. Lets test fred and tom",
-            hbs.render("one", &json!({"root_name": "tom"})).unwrap()
         );
     }
 
     #[test]
     fn test_partial_subexpression_context_hash() {
         let mut hbs = Registry::new();
-        hbs.register_template_string("one", "This is a test. {{> (x @root) name=\"fred\" }}")
-            .unwrap();
-        hbs.register_template_string("two", "Lets test {{name}}")
-            .unwrap();
+        hbs.register("one", "This is a test. {{> (x @root) name=\"fred\" }}");
+        hbs.register("two", "Lets test {{name}}");
 
         hbs.register_helper(
             "x",
@@ -369,10 +298,7 @@ mod test {
                 },
             ),
         );
-        assert_eq!(
-            "This is a test. Lets test fred",
-            hbs.render("one", &0).unwrap()
-        );
+        hbs.assert_render("one", &0, "This is a test. Lets test fred");
     }
 
     #[test]
@@ -381,9 +307,8 @@ mod test {
         let data = json!({"c": [{"b": true}, {"b": false}]});
 
         let mut handlebars = Registry::new();
-        assert!(handlebars.register_template_string("t", t).is_ok());
-        let r0 = handlebars.render("t", &data);
-        assert_eq!(r0.ok().unwrap(), "2 true2 false");
+        handlebars.register("t", t);
+        handlebars.assert_render("t", &data, "2 true2 false");
     }
 
     #[test]
@@ -393,15 +318,14 @@ mod test {
         let template2 = "{{#> t1 }}<inner>{{> @partial-block }}</inner>{{/ t1 }}";
         let template3 = "{{#> t2 }}Hello{{/ t2 }}";
 
-        handlebars
-            .register_template_string("t1", template1)
-            .unwrap();
-        handlebars
-            .register_template_string("t2", template2)
-            .unwrap();
+        handlebars.register("t1", template1);
+        handlebars.register("t2", template2);
 
-        let page = handlebars.render_template(template3, &json!({})).unwrap();
-        assert_eq!("<outer><inner>Hello</inner></outer>", page);
+        handlebars.assert_render_template(
+            template3,
+            &json!({}),
+            "<outer><inner>Hello</inner></outer>",
+        );
     }
 
     #[test]
@@ -439,15 +363,14 @@ mod test {
                 },
             ),
         );
-        handlebars
-            .register_template_string("t1", template1)
-            .unwrap();
-        handlebars
-            .register_template_string("t2", template2)
-            .unwrap();
+        handlebars.register("t1", template1);
+        handlebars.register("t2", template2);
 
-        let page = handlebars.render_template(template3, &json!({})).unwrap();
-        assert_eq!("<outer><inner>Hello</inner></outer> World", page);
+        handlebars.assert_render_template(
+            template3,
+            &json!({}),
+            "<outer><inner>Hello</inner></outer> World",
+        );
     }
 
     #[test]
@@ -458,13 +381,10 @@ mod test {
         let data = json!({ "fruits": ["carrot", "tomato"] });
 
         let mut handlebars = Registry::new();
-        handlebars.register_template_string("outer", outer).unwrap();
-        handlebars.register_template_string("inner", inner).unwrap();
+        handlebars.register("outer", outer);
+        handlebars.register("inner", inner);
 
-        assert_eq!(
-            handlebars.render("outer", &data).unwrap(),
-            "fruit: carrot,fruit: tomato,"
-        );
+        handlebars.assert_render("outer", &data, "fruit: carrot,fruit: tomato,");
     }
 
     #[test]
@@ -480,17 +400,19 @@ mod test {
 {{> foo}}"#;
 
         let hbs = Registry::new();
-        assert_eq!(
+        hbs.assert_render_template(
+            tpl0,
+            &json!({}),
             r"foo
 foo
 foo
 ",
-            hbs.render_template(tpl0, &json!({})).unwrap()
         );
-        assert_eq!(
+        hbs.assert_render_template(
+            tpl1,
+            &json!({}),
             r"
 foofoofoo",
-            hbs.render_template(tpl1, &json!({})).unwrap()
         );
     }
 
@@ -510,25 +432,18 @@ foofoofoo",
 ";
 
         let mut hbs = Registry::new();
+        hbs.register("inner", inner);
+        hbs.register("outer", outer);
 
-        hbs.register_template_string("inner", inner).unwrap();
-        hbs.register_template_string("outer", outer).unwrap();
-
-        let result = hbs
-            .render(
-                "outer",
-                &json!({
-                    "inner_solo": {"name": "inner_solo"},
-                    "inners": [
-                        {"name": "hello"},
-                        {"name": "there"}
-                    ]
-                }),
-            )
-            .unwrap();
-
-        assert_eq!(
-            result,
+        hbs.assert_render(
+            "outer",
+            &json!({
+                "inner_solo": {"name": "inner_solo"},
+                "inners": [
+                    {"name": "hello"},
+                    {"name": "there"}
+                ]
+            }),
             r"                name: inner_solo
 
                 name: hello
@@ -536,7 +451,7 @@ foofoofoo",
 
         name: hello
         name: there
-"
+",
         );
     }
     // Rule::partial_expression should not trim leading indent  by default
@@ -558,25 +473,18 @@ foofoofoo",
 
         let mut hbs = Registry::new();
         hbs.set_prevent_indent(true);
+        hbs.register("inner", inner);
+        hbs.register("outer", outer);
 
-        hbs.register_template_string("inner", inner).unwrap();
-        hbs.register_template_string("outer", outer).unwrap();
-
-        let result = hbs
-            .render(
-                "outer",
-                &json!({
-                    "inner_solo": {"name": "inner_solo"},
-                    "inners": [
-                        {"name": "hello"},
-                        {"name": "there"}
-                    ]
-                }),
-            )
-            .unwrap();
-
-        assert_eq!(
-            result,
+        hbs.assert_render(
+            "outer",
+            &json!({
+                "inner_solo": {"name": "inner_solo"},
+                "inners": [
+                    {"name": "hello"},
+                    {"name": "there"}
+                ]
+            }),
             r"                name: inner_solo
 
                 name: hello
@@ -584,16 +492,15 @@ foofoofoo",
 
         name: hello
         name: there
-"
+",
         );
     }
 
     #[test]
     fn test_nested_partials() {
         let mut hb = Registry::new();
-        hb.register_template_string("partial", "{{> @partial-block}}")
-            .unwrap();
-        hb.register_template_string(
+        hb.register("partial", "{{> @partial-block}}");
+        hb.register(
             "index",
             r"{{#>partial}}
     Yo
@@ -601,34 +508,31 @@ foofoofoo",
     Yo 2
     {{/partial}}
 {{/partial}}",
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb.assert_render(
+            "index",
+            &(),
             r"    Yo
     Yo 2
 ",
-            hb.render("index", &()).unwrap()
         );
 
-        hb.register_template_string("partial2", "{{> @partial-block}}")
-            .unwrap();
-        let r2 = hb
-            .render_template(
-                r"{{#> partial}}
+        hb.register("partial2", "{{> @partial-block}}");
+        hb.assert_render_template(
+            r"{{#> partial}}
 {{#> partial2}}
 :(
 {{/partial2}}
 {{/partial}}",
-                &(),
-            )
-            .unwrap();
-        assert_eq!(":(\n", r2);
+            &(),
+            ":(\n",
+        );
     }
 
     #[test]
     fn test_partial_context_issue_495() {
         let mut hb = Registry::new();
-        hb.register_template_string(
+        hb.register(
             "t1",
             r#"{{~#*inline "displayName"~}}
 Template:{{name}}
@@ -637,10 +541,8 @@ Template:{{name}}
 Name:{{name}}
 {{>displayName name="aaaa"}}
 {{/each}}"#,
-        )
-        .unwrap();
-
-        hb.register_template_string(
+        );
+        hb.register(
             "t2",
             r#"{{~#*inline "displayName"~}}
 Template:{{this}}
@@ -649,28 +551,29 @@ Template:{{this}}
 Name:{{name}}
 {{>displayName}}
 {{/each}}"#,
-        )
-        .unwrap();
+        );
 
         let data = json!({
             "data": ["hudel", "test"]
         });
 
-        assert_eq!(
+        hb.assert_render(
+            "t1",
+            &data,
             r"Name:hudel
 Template:aaaa
 Name:test
 Template:aaaa
 ",
-            hb.render("t1", &data).unwrap()
         );
-        assert_eq!(
+        hb.assert_render(
+            "t2",
+            &data,
             r"Name:hudel
 Template:hudel
 Name:test
 Template:test
 ",
-            hb.render("t2", &data).unwrap()
         );
     }
 
@@ -678,7 +581,7 @@ Template:test
     fn test_multiline_partial_indent() {
         let mut hb = Registry::new();
 
-        hb.register_template_string(
+        hb.register(
             "t1",
             r#"{{#*inline "thepartial"}}
   inner first line
@@ -686,47 +589,46 @@ Template:test
 {{/inline}}
   {{> thepartial}}
 outer third line"#,
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb.assert_render(
+            "t1",
+            &(),
             r"    inner first line
     inner second line
 outer third line",
-            hb.render("t1", &()).unwrap()
         );
 
-        hb.register_template_string(
+        hb.register(
             "t2",
             r#"{{#*inline "thepartial"}}inner first line
 inner second line
 {{/inline}}
   {{> thepartial}}
 outer third line"#,
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb.assert_render(
+            "t2",
+            &(),
             r"  inner first line
   inner second line
 outer third line",
-            hb.render("t2", &()).unwrap()
         );
 
-        hb.register_template_string(
+        hb.register(
             "t3",
             r#"{{#*inline "thepartial"}}{{a}}{{/inline}}
   {{> thepartial}}
 outer third line"#,
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb.assert_render(
+            "t3",
+            &json!({"a": "inner first line\ninner second line"}),
             r"
   inner first line
   inner second lineouter third line",
-            hb.render("t3", &json!({"a": "inner first line\ninner second line"}))
-                .unwrap()
         );
 
-        hb.register_template_string(
+        hb.register(
             "t4",
             r#"{{#*inline "thepartial"}}
   inner first line
@@ -734,19 +636,18 @@ outer third line"#,
 {{/inline}}
   {{~> thepartial}}
 outer third line"#,
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb.assert_render(
+            "t4",
+            &(),
             r"  inner first line
   inner second line
 outer third line",
-            hb.render("t4", &()).unwrap()
         );
 
         let mut hb2 = Registry::new();
         hb2.set_prevent_indent(true);
-
-        hb2.register_template_string(
+        hb2.register(
             "t1",
             r#"{{#*inline "thepartial"}}
   inner first line
@@ -754,13 +655,13 @@ outer third line",
 {{/inline}}
   {{> thepartial}}
 outer third line"#,
-        )
-        .unwrap();
-        assert_eq!(
+        );
+        hb2.assert_render(
+            "t1",
+            &(),
             r"    inner first line
   inner second line
 outer third line",
-            hb2.render("t1", &()).unwrap()
         );
     }
 
@@ -794,16 +695,11 @@ outer third line",
 ";
 
         let mut hb = Registry::new();
-        hb.register_template_string("nested_partial", nested_partial.trim_start())
-            .unwrap();
-        hb.register_template_string("partial", partial.trim_start())
-            .unwrap();
-        hb.register_template_string("partial_indented", partial_indented.trim_start())
-            .unwrap();
+        hb.register("nested_partial", nested_partial.trim_start());
+        hb.register("partial", partial.trim_start());
+        hb.register("partial_indented", partial_indented.trim_start());
 
-        let s = hb.render("partial_indented", &()).unwrap();
-
-        assert_eq!(&s, result.trim_start());
+        hb.assert_render("partial_indented", &(), result.trim_start());
     }
 
     #[test]
@@ -819,145 +715,112 @@ outer third line",
         });
 
         let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
+        hbs.register("t1", t1);
+        hbs.register("t2", t2);
 
-        assert_eq!("foobar", hbs.render("t2", &data).unwrap());
+        hbs.assert_render("t2", &data, "foobar");
     }
 
     #[test]
     fn test_partial_not_found() {
-        let t1 = "{{> bar}}";
         let hbs = Registry::new();
-        assert!(hbs.render_template(t1, &()).is_err());
+        hbs.assert_render_template_err("{{> bar}}", &(), None);
     }
 
     #[test]
     fn test_issue_643_this_context() {
-        let t1 = "{{this}}";
-        let t2 = "{{> t1 \"hello world\"}}";
+        let mut hbs = Registry::new();
+        hbs.register("t1", "{{this}}");
+        hbs.register("t2", "{{> t1 \"hello world\"}}");
+        hbs.assert_render("t2", &(), "hello world");
 
         let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
-
-        assert_eq!("hello world", hbs.render("t2", &()).unwrap());
-
-        let t1 = "{{a}} {{[0]}} {{[1]}}";
-        let t2 = "{{> t1 \"hello world\" a=1}}";
+        hbs.register("t1", "{{a}} {{[0]}} {{[1]}}");
+        hbs.register("t2", "{{> t1 \"hello world\" a=1}}");
+        hbs.assert_render("t2", &(), "1 h e");
 
         let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
-
-        assert_eq!("1 h e", hbs.render("t2", &()).unwrap());
-
-        let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
-        let t2 = "{{> t1 a=1}}";
+        hbs.register("t1", "{{#each this}}{{@key}}:{{this}},{{/each}}");
+        hbs.register("t2", "{{> t1 a=1}}");
+        hbs.assert_render("t2", &(), "a:1,");
 
         let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
-
-        assert_eq!("a:1,", hbs.render("t2", &()).unwrap());
-
-        let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
-        let t2 = "{{> t1 a=1}}";
+        hbs.register("t1", "{{#each this}}{{@key}}:{{this}},{{/each}}");
+        hbs.register("t2", "{{> t1 a=1}}");
+        hbs.assert_render("t2", &json!({"b": 2}), "b:2,a:1,");
 
         let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
-
-        assert_eq!("b:2,a:1,", hbs.render("t2", &json!({"b": 2})).unwrap());
-
-        let t1 = "{{#each this}}{{@key}}:{{this}},{{/each}}";
-        let t2 = "{{> t1 b a=1}}";
-
-        let mut hbs = Registry::new();
-        hbs.register_template_string("t1", t1).unwrap();
-        hbs.register_template_string("t2", t2).unwrap();
-
-        assert_eq!("a:1,", hbs.render("t2", &json!({"b": 2})).unwrap());
+        hbs.register("t1", "{{#each this}}{{@key}}:{{this}},{{/each}}");
+        hbs.register("t2", "{{> t1 b a=1}}");
+        hbs.assert_render("t2", &json!({"b": 2}), "a:1,");
     }
 
     #[test]
     fn test_nested_partial_block_scope_issue() {
         let mut hs = Registry::new();
-        hs.register_template_string("primary", "{{> @partial-block }}")
-            .unwrap();
-        hs.register_template_string("secondary", "{{#*inline \"inl\"}}Bug{{/inline}}{{#>primary}}{{> @partial-block }}{{>inl}}{{/primary}}").unwrap();
-        hs.register_template_string("current", "{{>secondary}}")
-            .unwrap();
+        hs.register("primary", "{{> @partial-block }}");
+        hs.register("secondary", "{{#*inline \"inl\"}}Bug{{/inline}}{{#>primary}}{{> @partial-block }}{{>inl}}{{/primary}}");
+        hs.register("current", "{{>secondary}}");
 
+        let err = hs.assert_render_err("current", &(), None);
         assert!(matches!(
-            hs.render("current", &()).unwrap_err().reason(),
+            err.reason(),
             RenderErrorReason::PartialBlockNotFound
         ));
 
         let mut hs = Registry::new();
-        hs.register_template_string("primary", "{{> @partial-block }}")
-            .unwrap();
-        hs.register_template_string("secondary", "{{#*inline \"inl\"}}Bug{{/inline}}{{#>primary}}{{> @partial-block }}{{>inl}}{{/primary}}").unwrap();
-        hs.register_template_string("current", "{{#>secondary}}Not a {{/secondary}}")
-            .unwrap();
+        hs.register("primary", "{{> @partial-block }}");
+        hs.register("secondary", "{{#*inline \"inl\"}}Bug{{/inline}}{{#>primary}}{{> @partial-block }}{{>inl}}{{/primary}}");
+        hs.register("current", "{{#>secondary}}Not a {{/secondary}}");
 
-        assert_eq!(hs.render("current", &()).unwrap(), "Not a Bug");
+        hs.assert_render("current", &(), "Not a Bug");
     }
 
     #[test]
     fn test_partial_block_syntax_for_at_partial_block() {
         let mut hb = Registry::new();
-        hb.register_template_string(
+        hb.register(
             "some_partial",
             "before {{#> @partial-block}}DEFAULT{{/@partial-block}} after",
-        )
-        .unwrap();
+        );
 
-        let r1 = hb
-            .render_template("{{> some_partial}}", &json!({}))
-            .unwrap();
-        assert_eq!(r1, "before DEFAULT after");
-
-        let r2 = hb
-            .render_template("{{#> some_partial}}CONTENT{{/some_partial}}", &json!({}))
-            .unwrap();
-        assert_eq!(r2, "before CONTENT after");
+        hb.assert_render_template("{{> some_partial}}", &json!({}), "before DEFAULT after");
+        hb.assert_render_template(
+            "{{#> some_partial}}CONTENT{{/some_partial}}",
+            &json!({}),
+            "before CONTENT after",
+        );
     }
 
     #[test]
     fn test_partial_block_fallback_restores_state() {
         let mut hb = Registry::new();
-        hb.register_template_string(
+        hb.register(
             "wrapper",
             "[{{#> @partial-block}}DEFAULT{{/@partial-block}}] {{> inner}}",
-        )
-        .unwrap();
-        hb.register_template_string("inner", "ok").unwrap();
+        );
+        hb.register("inner", "ok");
 
-        let r1 = hb.render_template("{{> wrapper}}", &json!({})).unwrap();
-        assert_eq!(r1, "[DEFAULT] ok");
-
-        let r2 = hb
-            .render_template("{{#> wrapper}}CUSTOM{{/wrapper}}", &json!({}))
-            .unwrap();
-        assert_eq!(r2, "[CUSTOM] ok");
+        hb.assert_render_template("{{> wrapper}}", &json!({}), "[DEFAULT] ok");
+        hb.assert_render_template(
+            "{{#> wrapper}}CUSTOM{{/wrapper}}",
+            &json!({}),
+            "[CUSTOM] ok",
+        );
     }
 
     #[test]
     fn test_partial_block_fallback_restores_template_name() {
         let mut hb = Registry::new();
-        hb.register_template_string(
+        hb.register(
             "self_ref",
             "{{#> @partial-block}}DEFAULT{{/@partial-block}}{{> self_ref}}",
-        )
-        .unwrap();
+        );
 
-        let result = hb.render_template("{{> self_ref}}", &json!({}));
-        assert!(result.is_err());
-        let msg = format!("{}", result.unwrap_err());
-        assert!(
-            msg.contains("include current template"),
-            "expected self-inclusion error, got: {msg}"
+        hb.assert_render_template_err(
+            "{{> self_ref}}",
+            &json!({}),
+            Some("include current template"),
         );
     }
 
@@ -995,25 +858,18 @@ outer third line",
 
         handlebars_helper!(lower: |s: str| s.to_lowercase());
         handlebars.register_helper("lower", Box::new(lower));
-        handlebars
-            .register_template_string(
-                "an-included-file",
-                "This file is included.\n\nSee {{lower somevalue}}\n",
-            )
-            .unwrap();
+        handlebars.register(
+            "an-included-file",
+            "This file is included.\n\nSee {{lower somevalue}}\n",
+        );
 
-        let data = serde_json::json!({});
-        assert_eq!(
-            handlebars
-                .render_template(
-                    r#"
+        handlebars.assert_render_template(
+            r#"
 {{~*set somevalue="Example"}}
 {{> an-included-file }}
 "#,
-                    &data
-                )
-                .unwrap(),
-            "This file is included.\n\nSee example\n"
+            &serde_json::json!({}),
+            "This file is included.\n\nSee example\n",
         );
     }
 
@@ -1022,8 +878,6 @@ outer third line",
         let mut reg = Registry::new();
         reg.register_partial("p", "{{#each this}}\n{{n}}\n{{/each}}")
             .unwrap();
-
-        let template = "{{#each nums}}{{> p par=42}}{{/each}}";
 
         let input = json!({
             "nums": [
@@ -1042,14 +896,17 @@ outer third line",
                 ]
             ]
         });
-        let rendered = reg.render_template(template, &input).unwrap();
         // Matches Handlebars.js: the array context is converted to an object
         // (indexed by stringified indices) and merged with the hash parameter,
         // so `{{#each this}}` iterates the 11 array elements *and* the `par`
         // entry (whose `{{n}}` renders empty), yielding the trailing extra
         // newline. The array indices are iterated in numeric order, not the
         // lexicographic order that would otherwise reorder "10" before "2".
-        assert_eq!("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n\n", rendered);
+        reg.assert_render_template(
+            "{{#each nums}}{{> p par=42}}{{/each}}",
+            &input,
+            "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n\n",
+        );
     }
 
     #[test]
@@ -1062,9 +919,7 @@ outer third line",
         reg.register_partial("p", "{{#each this}}[{{this}}]{{/each}}")
             .unwrap();
 
-        let template = "{{> p items par=\"ok\"}}";
         let input = json!({ "items": [1, 2, 3] });
-        let rendered = reg.render_template(template, &input).unwrap();
-        assert_eq!("[1][2][3][ok]", rendered);
+        reg.assert_render_template("{{> p items par=\"ok\"}}", &input, "[1][2][3][ok]");
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -925,6 +925,7 @@ mod test {
     use crate::render::{Helper, RenderContext, Renderable};
     use crate::support::str::StringWriter;
     use crate::template::Template;
+    use crate::testing::TestHandlebars;
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
@@ -1216,18 +1217,17 @@ mod test {
 
         let input = String::from("\"<>&");
 
-        r.register_template_string("test", String::from("{{this}}"))
-            .unwrap();
+        r.register("test", "{{this}}");
 
-        assert_eq!("&quot;&lt;&gt;&amp;", r.render("test", &input).unwrap());
+        r.assert_render("test", &input, "&quot;&lt;&gt;&amp;");
 
         r.register_escape_fn(|s| s.into());
 
-        assert_eq!("\"<>&", r.render("test", &input).unwrap());
+        r.assert_render("test", &input, "\"<>&");
 
         r.unregister_escape_fn();
 
-        assert_eq!("&quot;&lt;&gt;&amp;", r.render("test", &input).unwrap());
+        r.assert_render("test", &input, "&quot;&lt;&gt;&amp;");
     }
 
     #[test]
@@ -1235,17 +1235,9 @@ mod test {
         let r = Registry::new();
         let data = json!({"hello": "world"});
 
-        assert_eq!(
-            "{{hello}}",
-            r.render_template(r"\{{hello}}", &data).unwrap()
-        );
-
-        assert_eq!(
-            " {{hello}}",
-            r.render_template(r" \{{hello}}", &data).unwrap()
-        );
-
-        assert_eq!(r"\world", r.render_template(r"\\{{hello}}", &data).unwrap());
+        r.assert_render_template(r"\{{hello}}", &data, "{{hello}}");
+        r.assert_render_template(r" \{{hello}}", &data, " {{hello}}");
+        r.assert_render_template(r"\\{{hello}}", &data, r"\world");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -979,6 +979,7 @@ mod test {
     use crate::registry::Registry;
     use crate::template::TemplateElement::*;
     use crate::template::{HelperTemplate, Template, TemplateElement};
+    use crate::testing::TestHandlebars;
 
     #[test]
     fn test_raw_string() {
@@ -1152,46 +1153,29 @@ mod test {
     fn test_partial_failback_render() {
         let mut r = Registry::new();
 
-        assert!(
-            r.register_template_string("parent", "<html>{{> layout}}</html>")
-                .is_ok()
+        r.register("parent", "<html>{{> layout}}</html>");
+        r.register(
+            "child",
+            "{{#*inline \"layout\"}}content{{/inline}}{{#> parent}}{{> seg}}{{/parent}}",
         );
-        assert!(
-            r.register_template_string(
-                "child",
-                "{{#*inline \"layout\"}}content{{/inline}}{{#> parent}}{{> seg}}{{/parent}}",
-            )
-            .is_ok()
-        );
-        assert!(r.register_template_string("seg", "1234").is_ok());
+        r.register("seg", "1234");
 
-        let r = r.render("child", &true).expect("should work");
-        assert_eq!(r, "<html>content</html>");
+        r.assert_render("child", &true, "<html>content</html>");
     }
 
     #[test]
     fn test_key_with_slash() {
         let mut r = Registry::new();
 
-        assert!(
-            r.register_template_string("t", "{{#each this}}{{@key}}: {{this}}\n{{/each}}")
-                .is_ok()
-        );
+        r.register("t", "{{#each this}}{{@key}}: {{this}}\n{{/each}}");
 
-        let r = r.render("t", &json!({"/foo": "bar"})).unwrap();
-
-        assert_eq!(r, "/foo: bar\n");
+        r.assert_render("t", &json!({"/foo": "bar"}), "/foo: bar\n");
     }
 
     #[test]
     fn test_comment() {
         let r = Registry::new();
-
-        assert_eq!(
-            r.render_template("Hello {{this}} {{! test me }}", &0)
-                .unwrap(),
-            "Hello 0 "
-        );
+        r.assert_render_template("Hello {{this}} {{! test me }}", &0, "Hello 0 ");
     }
 
     #[test]
@@ -1309,12 +1293,10 @@ mod test {
           "outer": "outer"
         });
 
-        let r1 = r.render_template(TEMPLATE, &data).unwrap();
-        assert_eq!(r1, "outer= inner=inner");
+        r.assert_render_template(TEMPLATE, &data, "outer= inner=inner");
 
         r.set_recursive_lookup(true);
 
-        let r2 = r.render_template(TEMPLATE, &data).unwrap();
-        assert_eq!(r2, "outer=outer inner=inner");
+        r.assert_render_template(TEMPLATE, &data, "outer=outer inner=inner");
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,168 @@
+//! Ergonomic test helpers for handlebars.
+//!
+//! Available to this crate's own `#[cfg(test)]` modules unconditionally, and
+//! to downstream users (for testing their own helpers/templates) when the
+//! `testing` cargo feature is enabled.
+//!
+//! The helpers collapse the repetitive `Registry::new()` / `render_template` /
+//! `.unwrap()` / `assert_eq!` boilerplate and, more importantly, produce
+//! self-describing failure messages that include the template and the data.
+//!
+//! ```ignore
+//! use handlebars::Handlebars;
+//! use handlebars::testing::TestHandlebars;
+//! use serde_json::json;
+//!
+//! // inline string template
+//! let hbs = Handlebars::new();
+//! hbs.assert_render_template("hello {{name}}", &json!({"name": "world"}), "hello world");
+//!
+//! // registered template, rendered by name
+//! let mut hbs = Handlebars::new();
+//! hbs.register("p", "{{this}}!");
+//! hbs.assert_render("p", &json!("hi"), "hi!");
+//! ```
+
+use crate::error::RenderError;
+use crate::registry::Registry;
+use serde::Serialize;
+
+/// Extension trait that adds render-test assertions to a [`Registry`].
+///
+/// On failure these methods panic with the template and the data so the cause
+/// is obvious without re-running under a debugger.
+pub trait TestHandlebars {
+    /// Register a template string, panicking with a descriptive message on a
+    /// compile error.
+    ///
+    /// Replaces the common `assert!(hbs.register_template_string(..).is_ok())`
+    /// idiom, which hides compile errors.
+    fn register(&mut self, name: &str, template: &str);
+
+    /// Render an inline string template against `data` and assert the output
+    /// equals `expected`.
+    fn assert_render_template<T: Serialize>(&self, template: &str, data: &T, expected: &str);
+
+    /// Render a previously-registered template by `name` and assert the output
+    /// equals `expected`.
+    fn assert_render<T: Serialize>(&self, name: &str, data: &T, expected: &str);
+
+    /// Assert that rendering an inline template succeeds (the output is
+    /// discarded). Useful for suites that toggle registry options such as
+    /// strict mode between cases.
+    fn assert_render_template_ok<T: Serialize>(&self, template: &str, data: &T);
+
+    /// Assert that rendering an inline template fails. If `msg` is `Some(_)`,
+    /// additionally require the rendered error string to contain it.
+    ///
+    /// The error is returned so the caller can inspect it further
+    /// (e.g. `reason()`, `line_no`).
+    fn assert_render_template_err<T: Serialize>(
+        &self,
+        template: &str,
+        data: &T,
+        msg: Option<&str>,
+    ) -> RenderError;
+
+    /// Assert that rendering a registered template by `name` fails. If `msg` is
+    /// `Some(_)`, additionally require the error string to contain it. Returns
+    /// the error for further inspection.
+    fn assert_render_err<T: Serialize>(
+        &self,
+        name: &str,
+        data: &T,
+        msg: Option<&str>,
+    ) -> RenderError;
+}
+
+impl<'reg> TestHandlebars for Registry<'reg> {
+    fn register(&mut self, name: &str, template: &str) {
+        if let Err(e) = self.register_template_string(name, template) {
+            panic!("failed to register template {name:?} ({template:?}):\n{e}");
+        }
+    }
+
+    fn assert_render_template<T: Serialize>(&self, template: &str, data: &T, expected: &str) {
+        let actual = self.render_template(template, data).unwrap_or_else(|e| {
+            panic!("render_template failed:\n  template: {template:?}\n  error: {e}")
+        });
+        assert_eq!(
+            actual,
+            expected,
+            "\nrender_template mismatch\n  template: {template:?}\n  data: {}\n",
+            data_to_string(data)
+        );
+    }
+
+    fn assert_render<T: Serialize>(&self, name: &str, data: &T, expected: &str) {
+        let actual = self
+            .render(name, data)
+            .unwrap_or_else(|e| panic!("render({name:?}) failed:\n  error: {e}"));
+        assert_eq!(
+            actual,
+            expected,
+            "\nrender({name:?}) mismatch\n  data: {}\n",
+            data_to_string(data)
+        );
+    }
+
+    fn assert_render_template_ok<T: Serialize>(&self, template: &str, data: &T) {
+        if let Err(e) = self.render_template(template, data) {
+            panic!(
+                "expected render_template to succeed, but it errored:\n  template: {template:?}\n  error: {e}"
+            );
+        }
+    }
+
+    fn assert_render_template_err<T: Serialize>(
+        &self,
+        template: &str,
+        data: &T,
+        msg: Option<&str>,
+    ) -> RenderError {
+        match self.render_template(template, data) {
+            Ok(actual) => panic!(
+                "expected render_template to fail, but it produced:\n  template: {template:?}\n  output: {actual:?}"
+            ),
+            Err(e) => {
+                if let Some(needle) = msg {
+                    let s = e.to_string();
+                    assert!(
+                        s.contains(needle),
+                        "render_template failed as expected, but the error did not contain \
+                         {needle:?}:\n  {s}"
+                    );
+                }
+                e
+            }
+        }
+    }
+
+    fn assert_render_err<T: Serialize>(
+        &self,
+        name: &str,
+        data: &T,
+        msg: Option<&str>,
+    ) -> RenderError {
+        match self.render(name, data) {
+            Ok(actual) => {
+                panic!("expected render({name:?}) to fail, but it produced:\n  output: {actual:?}")
+            }
+            Err(e) => {
+                if let Some(needle) = msg {
+                    let s = e.to_string();
+                    assert!(
+                        s.contains(needle),
+                        "render({name:?}) failed as expected, but the error did not contain \
+                         {needle:?}:\n  {s}"
+                    );
+                }
+                e
+            }
+        }
+    }
+}
+
+fn data_to_string<T: Serialize>(data: &T) -> String {
+    serde_json::to_string(data).unwrap_or_else(|_| "<non-serializable>".to_owned())
+}

--- a/tests/block_context.rs
+++ b/tests/block_context.rs
@@ -1,4 +1,5 @@
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 use serde_json::json;
 
 #[test]
@@ -13,7 +14,7 @@ fn test_partial_with_blocks() {
     });
 
     let template = "{{#*inline \"test\"}}{{b}};{{/inline}}{{#each a as |z|}}{{> test z}}{{/each}}";
-    assert_eq!(hbs.render_template(template, &data).unwrap(), "1;2;");
+    hbs.assert_render_template(template, &data, "1;2;");
 }
 
 #[test]
@@ -30,7 +31,7 @@ fn test_root_with_blocks() {
 
     let template =
         "{{#*inline \"test\"}}{{b}}:{{@root.b}};{{/inline}}{{#each a}}{{> test}}{{/each}}";
-    assert_eq!(hbs.render_template(template, &data).unwrap(), "1:3;2:3;");
+    hbs.assert_render_template(template, &data, "1:3;2:3;");
 }
 
 #[test]
@@ -43,10 +44,7 @@ fn test_singular_and_pair_block_params() {
     ]);
 
     let template = "{{#each this as |b index|}}{{b.value}}{{#each this as |value key|}}:{{key}},{{/each}}{{/each}}";
-    assert_eq!(
-        hbs.render_template(template, &data).unwrap(),
-        "11:value,22:value,"
-    );
+    hbs.assert_render_template(template, &data, "11:value,22:value,");
 }
 
 #[test]
@@ -71,7 +69,7 @@ fn test_nested_each() {
     });
 
     let template = "{{#each classes as |class|}}{{#each class.methods as |method|}}{{method.id}};{{/each}}{{/each}}";
-    assert_eq!(hbs.render_template(template, &data).unwrap(), "1;2;3;4;");
+    hbs.assert_render_template(template, &data, "1;2;3;4;");
 }
 
 #[test]
@@ -98,10 +96,7 @@ fn test_referencing_block_param_from_upper_scope() {
     });
 
     let template = "{{#each classes as |class|}}{{#each class.methods as |method|}}{{class.private}}|{{method.id}};{{/each}}{{/each}}";
-    assert_eq!(
-        hbs.render_template(template, &data).unwrap(),
-        "false|1;false|2;true|3;true|4;"
-    );
+    hbs.assert_render_template(template, &data, "false|1;false|2;true|3;true|4;");
 }
 
 #[test]
@@ -120,9 +115,5 @@ fn nested_path_lookup() {
 ";
     let hbs = Handlebars::new();
 
-    assert_eq!(
-        hbs.render_template(input, &json!({"foo": [42], "bar": [1,2,3]}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"foo": [42], "bar": [1,2,3]}), output);
 }

--- a/tests/data_helper.rs
+++ b/tests/data_helper.rs
@@ -1,3 +1,4 @@
+use handlebars::testing::TestHandlebars;
 use handlebars::*;
 use serde_json::json;
 
@@ -24,6 +25,5 @@ fn test_helper_with_ref_data() {
     let mut r = Handlebars::new();
     r.register_helper("hello", Box::new(the_helper));
 
-    let s = r.render_template("Output: {{hello}}", &json!({})).unwrap();
-    assert_eq!(s, "Output: hello helper".to_owned());
+    r.assert_render_template("Output: {{hello}}", &json!({}), "Output: hello helper");
 }

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -1,8 +1,8 @@
 extern crate handlebars;
-
 #[macro_use]
 extern crate serde_json;
 
+use handlebars::testing::TestHandlebars;
 use handlebars::{Handlebars, handlebars_helper, no_escape};
 
 #[test]
@@ -14,9 +14,10 @@ fn test_escape_216() {
         "BAR": "bar"
     });
 
-    assert_eq!(
-        hbs.render_template(r"\\\\ {{FOO}} {{BAR}} {{FOO}}{{BAR}} {{FOO}}#{{BAR}} {{FOO}}//{{BAR}} {{FOO}}\\{{FOO}} {{FOO}}\\\\{{FOO}}\\\{{FOO}} \\\{{FOO}} \{{FOO}} \{{FOO}}", &data).unwrap(),
-        r"\\\\ foo bar foobar foo#bar foo//bar foo\foo foo\\\foo\\foo \\foo {{FOO}} {{FOO}}"
+    hbs.assert_render_template(
+        r"\\\\ {{FOO}} {{BAR}} {{FOO}}{{BAR}} {{FOO}}#{{BAR}} {{FOO}}//{{BAR}} {{FOO}}\\{{FOO}} {{FOO}}\\\\{{FOO}}\\\{{FOO}} \\\{{FOO}} \{{FOO}} \{{FOO}}",
+        &data,
+        r"\\\\ foo bar foobar foo#bar foo//bar foo\foo foo\\\foo\\foo \\foo {{FOO}} {{FOO}}",
     );
 }
 
@@ -33,37 +34,19 @@ fn test_string_no_escape_422() {
     hbs.register_helper("replace", Box::new(replace));
     hbs.register_helper("echo", Box::new(echo));
 
-    assert_eq!(
-        r"some\ path",
-        hbs.render_template(r#"{{replace "some/path" "/" "\\ " }}"#, &())
-            .unwrap()
-    );
-    assert_eq!(
-        r"some\ path",
-        hbs.render_template(r"{{replace 'some/path' '/' '\\ ' }}", &())
-            .unwrap()
-    );
-
-    assert_eq!(
-        r"some\path",
-        hbs.render_template(r#"{{replace "some/path" "/" "\\" }}"#, &())
-            .unwrap()
-    );
-    assert_eq!(
-        r"some\path",
-        hbs.render_template(r"{{replace 'some/path' '/' '\\' }}", &())
-            .unwrap()
-    );
-
-    assert_eq!(
+    hbs.assert_render_template(r#"{{replace "some/path" "/" "\\ " }}"#, &(), r"some\ path");
+    hbs.assert_render_template(r"{{replace 'some/path' '/' '\\ ' }}", &(), r"some\ path");
+    hbs.assert_render_template(r#"{{replace "some/path" "/" "\\" }}"#, &(), r"some\path");
+    hbs.assert_render_template(r"{{replace 'some/path' '/' '\\' }}", &(), r"some\path");
+    hbs.assert_render_template(
+        r#"{{echo "double-quoted \\ 'with' \"nesting\""}}"#,
+        &(),
         r"double-quoted \ &#x27;with&#x27; &quot;nesting&quot;",
-        hbs.render_template(r#"{{echo "double-quoted \\ 'with' \"nesting\""}}"#, &())
-            .unwrap()
     );
-    assert_eq!(
+    hbs.assert_render_template(
+        r#"{{echo 'single-quoted \\ \'with\' "nesting"'}}"#,
+        &(),
         r"single-quoted \ &#x27;with&#x27; &quot;nesting&quot;",
-        hbs.render_template(r#"{{echo 'single-quoted \\ \'with\' "nesting"'}}"#, &())
-            .unwrap()
     );
 }
 
@@ -76,13 +59,13 @@ fn test_string_whitespace_467() {
 
     let mut hbs = Handlebars::new();
     hbs.register_escape_fn(no_escape);
-    hbs.register_template_string("perl", TEMPLATE_UNQUOTED)
-        .unwrap();
+    hbs.register("perl", TEMPLATE_UNQUOTED);
 
-    let r = hbs
-        .render("perl", &json!({"synonyms": [{"name": "lt", "sym": "<"}]}))
-        .unwrap();
-    assert_eq!("    lt => '<',\n", r);
+    hbs.assert_render(
+        "perl",
+        &json!({"synonyms": [{"name": "lt", "sym": "<"}]}),
+        "    lt => '<',\n",
+    );
 }
 
 #[test]
@@ -94,29 +77,27 @@ fn test_triple_bracket_expression_471() {
     });
     hbs.register_helper("replace", Box::new(replace));
 
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{replace h}}",
+        &json!({"h": "some\npath"}),
         "some&lt;br/&gt;path",
-        hbs.render_template("{{replace h}}", &json!({"h": "some\npath"}))
-            .unwrap()
     );
-
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{{replace h}}}",
+        &json!({"h": "some\npath"}),
         "some<br/>path",
-        hbs.render_template("{{{replace h}}}", &json!({"h": "some\npath"}))
-            .unwrap()
     );
 }
 
 #[test]
 fn test_trimmed_nonescaped_variable() {
-    let mut handlebars = Handlebars::new();
-    handlebars
-        .register_partial("system", "system: {{~{system}~}}")
+    let mut hbs = Handlebars::new();
+    hbs.register_partial("system", "system: {{~{system}~}}")
         .unwrap();
 
-    let output = handlebars
-        .render_template("{{>system system=\"hello\" prompt=\" world\"}}", &())
-        .unwrap();
-
-    assert_eq!(output, "system:hello");
+    hbs.assert_render_template(
+        r#"{{>system system="hello" prompt=" world"}}"#,
+        &(),
+        "system:hello",
+    );
 }

--- a/tests/helper_function_lifetime.rs
+++ b/tests/helper_function_lifetime.rs
@@ -1,3 +1,4 @@
+use handlebars::testing::TestHandlebars;
 use handlebars::*;
 
 fn ifcond<'reg, 'rc>(
@@ -26,10 +27,5 @@ fn test_helper() {
 
     // make data and render it
     let data = true;
-    assert_eq!(
-        "yes",
-        handlebars
-            .render_template("{{#ifcond this}}yes{{/ifcond}}", &data)
-            .unwrap()
-    );
+    handlebars.assert_render_template("{{#ifcond this}}yes{{/ifcond}}", &data, "yes");
 }

--- a/tests/helper_macro.rs
+++ b/tests/helper_macro.rs
@@ -4,6 +4,8 @@ extern crate handlebars;
 extern crate serde_json;
 
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
+use serde_json::Value;
 use time::OffsetDateTime;
 use time::format_description::{parse_borrowed, well_known::Rfc2822};
 
@@ -26,84 +28,43 @@ fn test_macro_helper() {
     hbs.register_helper("upper", Box::new(upper));
     hbs.register_helper("hex", Box::new(hex));
     hbs.register_helper("money", Box::new(money));
+    hbs.register_helper("all_hash", Box::new(all_hash));
     hbs.register_helper("nargs", Box::new(nargs));
     hbs.register_helper("has_a", Box::new(has_a));
     hbs.register_helper("tag", Box::new(tag));
     hbs.register_helper("date", Box::new(date));
 
-    let data = json!("Teixeira");
-
-    assert_eq!(
-        hbs.render_template("{{lower this}}", &data).unwrap(),
-        "teixeira"
-    );
-    assert_eq!(
-        hbs.render_template("{{upper this}}", &data).unwrap(),
-        "TEIXEIRA"
-    );
-    assert_eq!(hbs.render_template("{{hex 16}}", &()).unwrap(), "0x10");
-
-    assert_eq!(
-        hbs.render_template("{{money 5000}}", &()).unwrap(),
-        "$5000.00"
-    );
-    assert_eq!(
-        hbs.render_template("{{money 5000 cur=\"£\"}}", &())
-            .unwrap(),
-        "£5000.00"
-    );
-    assert_eq!(
-        hbs.render_template("{{nargs 1 1 1 1 1}}", &()).unwrap(),
-        "5"
-    );
-    assert_eq!(hbs.render_template("{{nargs}}", &()).unwrap(), "0");
-
-    assert_eq!(
-        hbs.render_template("{{has_a a=1 b=2}}", &()).unwrap(),
-        "1, true"
-    );
-
-    assert_eq!(
-        hbs.render_template("{{has_a x=1 b=2}}", &()).unwrap(),
-        "99, false"
-    );
-
-    assert_eq!(
-        hbs.render_template("{{tag \"html\"}}", &()).unwrap(),
-        "&lt;html&gt;"
-    );
-
-    assert_eq!(
-        hbs.render_template("{{{tag \"html\"}}}", &()).unwrap(),
-        "<html>"
-    );
-
-    assert_eq!(
-        hbs.render_template(
-            "{{date this}}",
-            &OffsetDateTime::parse("Wed, 18 Feb 2015 23:16:09 GMT", &Rfc2822).unwrap()
-        )
-        .unwrap(),
-        "2015-02-18"
-    );
-
-    assert_eq!(
-        hbs.render_template("{{eq image.link null}}", &json!({"image": {"link": null}}))
-            .unwrap(),
-        "true"
-    );
-
-    assert_eq!(
-        hbs.render_template(
+    // (template, data, expected). Cases that ignore the data use `null`,
+    // which renders identically to `()` for these templates.
+    let cases: &[(&str, Value, &str)] = &[
+        ("{{lower this}}", json!("Teixeira"), "teixeira"),
+        ("{{upper this}}", json!("Teixeira"), "TEIXEIRA"),
+        ("{{hex 16}}", json!(null), "0x10"),
+        ("{{money 5000}}", json!(null), "$5000.00"),
+        (r#"{{money 5000 cur="£"}}"#, json!(null), "£5000.00"),
+        ("{{nargs 1 1 1 1 1}}", json!(null), "5"),
+        ("{{nargs}}", json!(null), "0"),
+        ("{{has_a a=1 b=2}}", json!(null), "1, true"),
+        ("{{has_a x=1 b=2}}", json!(null), "99, false"),
+        (r#"{{tag "html"}}"#, json!(null), "&lt;html&gt;"),
+        (r#"{{{tag "html"}}}"#, json!(null), "<html>"),
+        (
             "{{eq image.link null}}",
-            &json!({"image": {"link": "https://url"}})
-        )
-        .unwrap(),
-        "false"
-    );
+            json!({"image": {"link": null}}),
+            "true",
+        ),
+        (
+            "{{eq image.link null}}",
+            json!({"image": {"link": "https://url"}}),
+            "false",
+        ),
+        (r"{{tag 'html'}}", json!(null), "&lt;html&gt;"),
+    ];
+    for (template, data, expected) in cases {
+        hbs.assert_render_template(template, data, expected);
+    }
 
-    assert_eq!(
-        hbs.render_template("{{tag 'html'}}", &()).unwrap(),
-        "&lt;html&gt;"
-    );
+    // `date` takes an `OffsetDateTime`, so it is exercised separately.
+    let dt = OffsetDateTime::parse("Wed, 18 Feb 2015 23:16:09 GMT", &Rfc2822).unwrap();
+    hbs.assert_render_template("{{date this}}", &dt, "2015-02-18");
 }

--- a/tests/helper_with_space.rs
+++ b/tests/helper_with_space.rs
@@ -1,3 +1,4 @@
+use handlebars::testing::TestHandlebars;
 use handlebars::*;
 use serde_json::json;
 
@@ -26,20 +27,18 @@ fn test_helper_with_space_param() {
     let mut r = Handlebars::new();
     r.register_helper("echo", Box::new(dump));
 
-    let s = r
-        .render_template(
-            "Output: {{echo \"Mozilla Firefox\" \"Google Chrome\"}}",
-            &json!({}),
-        )
-        .unwrap();
-    assert_eq!(s, "Output: Mozilla Firefox, Google Chrome".to_owned());
+    r.assert_render_template(
+        "Output: {{echo \"Mozilla Firefox\" \"Google Chrome\"}}",
+        &json!({}),
+        "Output: Mozilla Firefox, Google Chrome",
+    );
 }
 
 #[test]
 fn test_empty_lines_472() {
     let mut r = Handlebars::new();
 
-    r.register_template_string(
+    r.register(
         "t1",
         r"{{#each routes}}
 import { default as {{this.handler}} } from '{{this.file_path}}'
@@ -48,10 +47,9 @@ import { default as {{this.handler}} } from '{{this.file_path}}'
 addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
 })",
-    )
-    .unwrap();
+    );
 
-    r.register_template_string(
+    r.register(
         "t2",
         r"addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
@@ -61,8 +59,7 @@ addEventListener('fetch', (event) => {
 import { default as {{this.handler}} } from '{{this.file_path}}'
 {{/each}}
 ",
-    )
-    .unwrap();
+    );
 
     let data = json!({"routes": [{"handler": "__hello_handler", "file_path": "./hello.js"},
                                  {"handler": "__world_index_handler", "file_path": "./world/index.js"},
@@ -85,6 +82,6 @@ import { default as __world_index_handler } from './world/index.js'
 import { default as __index_handler } from './index.js'
 ";
 
-    assert_eq!(r.render("t1", &data).unwrap(), exp1);
-    assert_eq!(r.render("t2", &data).unwrap(), exp2);
+    r.assert_render("t1", &data, exp1);
+    r.assert_render("t2", &data, exp2);
 }

--- a/tests/issue_756.rs
+++ b/tests/issue_756.rs
@@ -1,4 +1,5 @@
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 use serde_json::json;
 
 // Regression test for https://github.com/sunng87/handlebars-rust/issues/756
@@ -9,34 +10,29 @@ use serde_json::json;
 #[test]
 fn test_key_in_partial_in_each() {
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "{{@key}}: {{this}}\n")
-        .unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
-        .unwrap();
-    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
-    assert_eq!("foo: bar\n", r);
+    hbs.register("p", "{{@key}}: {{this}}\n");
+    hbs.register("t", "{{#each this}}{{> p}}{{/each}}");
+    hbs.assert_render("t", &json!({"foo": "bar"}), "foo: bar\n");
 }
 
 #[test]
 fn test_index_in_partial_in_each() {
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "{{@index}}: {{this}}\n")
-        .unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
-        .unwrap();
-    let r = hbs.render("t", &json!(["bar"])).unwrap();
-    assert_eq!("0: bar\n", r);
+    hbs.register("p", "{{@index}}: {{this}}\n");
+    hbs.register("t", "{{#each this}}{{> p}}{{/each}}");
+    hbs.assert_render("t", &json!(["bar"]), "0: bar\n");
 }
 
 #[test]
 fn test_first_last_index_in_partial_in_each() {
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "[{{@first}}/{{@last}}/{{@index}}]")
-        .unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
-        .unwrap();
-    let r = hbs.render("t", &json!(["a", "b", "c"])).unwrap();
-    assert_eq!("[true/false/0][false/false/1][false/true/2]", r);
+    hbs.register("p", "[{{@first}}/{{@last}}/{{@index}}]");
+    hbs.register("t", "{{#each this}}{{> p}}{{/each}}");
+    hbs.assert_render(
+        "t",
+        &json!(["a", "b", "c"]),
+        "[true/false/0][false/false/1][false/true/2]",
+    );
 }
 
 #[test]
@@ -46,11 +42,9 @@ fn test_key_in_partial_still_inherited_with_hash() {
     // merges into the partial context, but should not wipe the implicit
     // data variables.)
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "{{@key}}").unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p myvar=\"x\"}}{{/each}}")
-        .unwrap();
-    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
-    assert_eq!("foo", r);
+    hbs.register("p", "{{@key}}");
+    hbs.register("t", "{{#each this}}{{> p myvar=\"x\"}}{{/each}}");
+    hbs.assert_render("t", &json!({"foo": "bar"}), "foo");
 }
 
 #[test]
@@ -58,26 +52,23 @@ fn test_each_inside_partial_resets_key() {
     // Inheriting locals must not leak: a nested `{{#each}}` inside the
     // partial should set its own `@key`/`@index`, not the outer ones.
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "{{#each this}}{{@key}}={{this}};{{/each}}")
-        .unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p}}{{/each}}")
-        .unwrap();
-    let r = hbs
-        .render("t", &json!({"outer": {"inner_a": 1, "inner_b": 2}}))
-        .unwrap();
-    assert_eq!("inner_a=1;inner_b=2;", r);
+    hbs.register("p", "{{#each this}}{{@key}}={{this}};{{/each}}");
+    hbs.register("t", "{{#each this}}{{> p}}{{/each}}");
+    hbs.assert_render(
+        "t",
+        &json!({"outer": {"inner_a": 1, "inner_b": 2}}),
+        "inner_a=1;inner_b=2;",
+    );
 }
 
 #[test]
 fn test_key_in_nested_partial() {
     // Local inheritance should chain across multiple partial boundaries.
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p2", "{{@key}}").unwrap();
-    hbs.register_template_string("p1", "{{> p2}}").unwrap();
-    hbs.register_template_string("t", "{{#each this}}{{> p1}}{{/each}}")
-        .unwrap();
-    let r = hbs.render("t", &json!({"foo": "bar"})).unwrap();
-    assert_eq!("foo", r);
+    hbs.register("p2", "{{@key}}");
+    hbs.register("p1", "{{> p2}}");
+    hbs.register("t", "{{#each this}}{{> p1}}{{/each}}");
+    hbs.assert_render("t", &json!({"foo": "bar"}), "foo");
 }
 
 #[test]
@@ -85,9 +76,7 @@ fn test_key_in_partial_not_inside_each_is_empty() {
     // Outside of any each/with, `@key` should remain empty (no leak of a
     // phantom value), as the root block has no local vars.
     let mut hbs = Handlebars::new();
-    hbs.register_template_string("p", "{{@key}}:{{this}}")
-        .unwrap();
-    hbs.register_template_string("t", "{{> p}}").unwrap();
-    let r = hbs.render("t", &json!("hello")).unwrap();
-    assert_eq!(":hello", r);
+    hbs.register("p", "{{@key}}:{{this}}");
+    hbs.register("t", "{{> p}}");
+    hbs.assert_render("t", &json!("hello"), ":hello");
 }

--- a/tests/root_var.rs
+++ b/tests/root_var.rs
@@ -3,6 +3,7 @@ extern crate handlebars;
 extern crate serde_json;
 
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 
 #[test]
 fn test_root_var() {
@@ -13,9 +14,9 @@ fn test_root_var() {
         "b": "top"
     });
 
-    assert_eq!(
-        hbs.render_template("{{#each a}}{{@root/b}}: {{this}};{{/each}}", &data)
-            .unwrap(),
-        "top: 1;top: 2;top: 3;top: 4;"
+    hbs.assert_render_template(
+        "{{#each a}}{{@root/b}}: {{this}};{{/each}}",
+        &data,
+        "top: 1;top: 2;top: 3;top: 4;",
     );
 }

--- a/tests/scoped_inline.rs
+++ b/tests/scoped_inline.rs
@@ -1,4 +1,5 @@
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 
 #[test]
 fn test_inline_scope() {
@@ -8,18 +9,15 @@ fn test_inline_scope() {
         r#"{{#>nested_partial}}Inner Content{{/nested_partial}}"#,
     )
     .unwrap();
-    let output = hbs
-        .render_template(
-            r#"{{>test_partial}}
+    hbs.assert_render_template(
+        r#"{{>test_partial}}
 
 {{#>test_partial}}
 {{#*inline "nested_partial"}}Overwrite{{/inline}}
 {{/test_partial}}
 
 {{>test_partial}}"#,
-            &(),
-        )
-        .unwrap();
-
-    assert_eq!("Inner Content\nOverwrite\nInner Content", output);
+        &(),
+        "Inner Content\nOverwrite\nInner Content",
+    );
 }

--- a/tests/subexpression.rs
+++ b/tests/subexpression.rs
@@ -5,6 +5,7 @@ extern crate serde_json;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
 
+use handlebars::testing::TestHandlebars;
 use handlebars::{
     Context, Handlebars, Helper, HelperDef, RenderContext, RenderError, RenderErrorReason,
     ScopedJson,
@@ -16,46 +17,40 @@ fn test_subexpression() {
 
     let data = json!({"a": 1, "b": 0, "c": 2});
 
-    assert_eq!(
-        hbs.render_template("{{#if (gt a b)}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Success"
+    hbs.assert_render_template(
+        "{{#if (gt a b)}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Success",
     );
-
-    assert_eq!(
-        hbs.render_template("{{#if (gt a c)}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Failed"
+    hbs.assert_render_template(
+        "{{#if (gt a c)}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Failed",
     );
-
-    assert_eq!(
-        hbs.render_template("{{#if (not (gt a c))}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Success"
+    hbs.assert_render_template(
+        "{{#if (not (gt a c))}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Success",
     );
-
-    assert_eq!(
-        hbs.render_template("{{#if (not (gt a b))}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Failed"
+    hbs.assert_render_template(
+        "{{#if (not (gt a b))}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Failed",
     );
 
     // no argument provided for not
-    assert!(
-        hbs.render_template("{{#if (not)}}Success{{else}}Failed{{/if}}", &data)
-            .is_err()
-    );
+    hbs.assert_render_template_err("{{#if (not)}}Success{{else}}Failed{{/if}}", &data, None);
 
     // json literal
-    assert_eq!(
-        hbs.render_template("{{#if (not true)}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Failed"
+    hbs.assert_render_template(
+        "{{#if (not true)}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Failed",
     );
-    assert_eq!(
-        hbs.render_template("{{#if (not false)}}Success{{else}}Failed{{/if}}", &data)
-            .unwrap(),
-        "Success"
+    hbs.assert_render_template(
+        "{{#if (not false)}}Success{{else}}Failed{{/if}}",
+        &data,
+        "Success",
     );
 }
 
@@ -66,14 +61,8 @@ fn test_strict_mode() {
 
     let data = json!({"a": 1});
 
-    assert!(
-        hbs.render_template("{{#if (eq a 1)}}Success{{else}}Failed{{/if}}", &data)
-            .is_ok()
-    );
-    assert!(
-        hbs.render_template("{{#if (eq z 1)}}Success{{else}}Failed{{/if}}", &data)
-            .is_err()
-    );
+    hbs.assert_render_template_ok("{{#if (eq a 1)}}Success{{else}}Failed{{/if}}", &data);
+    hbs.assert_render_template_err("{{#if (eq z 1)}}Success{{else}}Failed{{/if}}", &data, None);
 }
 
 #[test]
@@ -83,7 +72,7 @@ fn invalid_json_path() {
 
     let hbs = Handlebars::new();
 
-    let error = hbs.render_template("{{x[]@this}}", &data).unwrap_err();
+    let error = hbs.assert_render_template_err("{{x[]@this}}", data, None);
     let cause = error.reason();
 
     assert!(matches!(cause, RenderErrorReason::HelperNotFound(_)));
@@ -110,13 +99,9 @@ impl HelperDef for MyHelper {
 fn test_lookup_with_subexpression() {
     let mut registry = Handlebars::new();
     registry.register_helper("myhelper", Box::new(MyHelper {}));
-    registry
-        .register_template_string("t", "{{ lookup (myhelper) \"a\" }}")
-        .unwrap();
+    registry.register("t", r#"{{ lookup (myhelper) "a" }}"#);
 
-    let result = registry.render("t", &json!({})).unwrap();
-
-    assert_eq!("1", result);
+    registry.assert_render("t", &json!({}), "1");
 }
 
 struct CallCounterHelper {

--- a/tests/template_names.rs
+++ b/tests/template_names.rs
@@ -3,6 +3,7 @@ extern crate handlebars;
 extern crate serde_json;
 
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 
 #[test]
 fn test_walk_dir_template_name() {
@@ -13,9 +14,8 @@ fn test_walk_dir_template_name() {
         "b": "top"
     });
 
-    hbs.register_template_string("foo/bar", "{{@root/b}}")
-        .unwrap();
-    assert_eq!(hbs.render_template("{{> foo/bar }}", &data).unwrap(), "top");
+    hbs.register("foo/bar", "{{@root/b}}");
+    hbs.assert_render_template("{{> foo/bar }}", &data, "top");
 }
 
 #[test]
@@ -27,9 +27,6 @@ fn test_walk_dir_template_name_with_args() {
         "b": "top"
     });
 
-    hbs.register_template_string("foo/bar", "{{this}}").unwrap();
-    assert_eq!(
-        hbs.render_template("{{> foo/bar b }}", &data).unwrap(),
-        "top"
-    );
+    hbs.register("foo/bar", "{{this}}");
+    hbs.assert_render_template("{{> foo/bar b }}", &data, "top");
 }

--- a/tests/whitespace.rs
+++ b/tests/whitespace.rs
@@ -1,26 +1,13 @@
 use handlebars::Handlebars;
+use handlebars::testing::TestHandlebars;
 use serde_json::json;
 
 #[test]
 fn test_whitespaces_elision() {
     let hbs = Handlebars::new();
-    assert_eq!(
-        "bar",
-        hbs.render_template("  {{~ foo ~}}  ", &json!({"foo": "bar"}))
-            .unwrap()
-    );
-
-    assert_eq!(
-        "<bar/>",
-        hbs.render_template("  {{{~ foo ~}}}  ", &json!({"foo": "<bar/>"}))
-            .unwrap()
-    );
-
-    assert_eq!(
-        "<bar/>",
-        hbs.render_template("  {{~ {foo} ~}}  ", &json!({"foo": "<bar/>"}))
-            .unwrap()
-    );
+    hbs.assert_render_template("  {{~ foo ~}}  ", &json!({"foo": "bar"}), "bar");
+    hbs.assert_render_template("  {{{~ foo ~}}}  ", &json!({"foo": "<bar/>"}), "<bar/>");
+    hbs.assert_render_template("  {{~ {foo} ~}}  ", &json!({"foo": "<bar/>"}), "<bar/>");
 }
 
 #[test]
@@ -45,11 +32,7 @@ fn test_indent_after_if() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"foo": true})).unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"foo": true}), output);
 }
 
 #[test]
@@ -81,11 +64,7 @@ fn test_partial_inside_if() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"foo": true})).unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"foo": true}), output);
 }
 
 #[test]
@@ -119,11 +98,7 @@ fn test_partial_inside_double_if() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"foo": true})).unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"foo": true}), output);
 }
 
 #[test]
@@ -140,8 +115,7 @@ fn test_empty_partial() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(hbs.render_template(input, &()).unwrap(), output);
+    hbs.assert_render_template(input, &(), output);
 }
 
 #[test]
@@ -158,11 +132,7 @@ fn test_partial_pasting_empty_dynamic_content() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"input": ""})).unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"input": ""}), output);
 }
 
 #[test]
@@ -181,12 +151,7 @@ fn test_partial_pasting_dynamic_content_with_newlines() {
     baz</div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"input": "foo\nbar\nbaz"}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"input": "foo\nbar\nbaz"}), output);
 }
 
 #[test]
@@ -205,11 +170,10 @@ fn test_indent_on_consecutive_dynamic_contents() {
 </div>
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"a": "foo\n", "b": "bar", "c": "baz\n"}))
-            .unwrap(),
-        output
+    hbs.assert_render_template(
+        input,
+        &json!({"a": "foo\n", "b": "bar", "c": "baz\n"}),
+        output,
     );
 }
 
@@ -235,12 +199,7 @@ foo
     foofoo
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"content": "foo"}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"content": "foo"}), output);
 }
 
 #[test]
@@ -263,12 +222,7 @@ foo
     foofoo
 ";
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"content": "foo"}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"content": "foo"}), output);
 }
 
 #[test]
@@ -283,8 +237,7 @@ fn test_empty_inline_partials_and_helpers_retain_indent_directive() {
 "#;
     let output = "    foo\n";
     let hbs = Handlebars::new();
-
-    assert_eq!(hbs.render_template(input, &()).unwrap(), output);
+    hbs.assert_render_template(input, &(), output);
 }
 
 #[test]
@@ -297,13 +250,14 @@ fn test_indent_directive_propagated_but_not_restored_if_content_was_written() {
 "#;
     let output = "    foofoo\n";
     let hbs = Handlebars::new();
-
-    assert_eq!(hbs.render_template(input, &()).unwrap(), output);
+    hbs.assert_render_template(input, &(), output);
 }
 
 //regression test for #611
 #[test]
 fn tag_before_eof_becomes_standalone_in_full_template() {
+    let hbs = Handlebars::new();
+
     let input = r#"<ul>
   {{#each a}}
     {{!-- comment --}}
@@ -314,13 +268,7 @@ fn tag_before_eof_becomes_standalone_in_full_template() {
     <li>2</li>
     <li>3</li>
 "#;
-    let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"a": [1, 2, 3]}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"a": [1, 2, 3]}), output);
 
     let input = r#"<ul>
   {{#each a}}
@@ -332,13 +280,7 @@ fn tag_before_eof_becomes_standalone_in_full_template() {
       <li>2</li>
       <li>3</li>
   abc"#;
-    let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"a": [1, 2, 3]}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"a": [1, 2, 3]}), output);
 }
 
 #[test]
@@ -357,12 +299,7 @@ fn tag_before_eof_does_not_become_standalone_in_partial() {
       <li>3</li>
   "#;
     let hbs = Handlebars::new();
-
-    assert_eq!(
-        hbs.render_template(input, &json!({"a": [1, 2, 3]}))
-            .unwrap(),
-        output
-    );
+    hbs.assert_render_template(input, &json!({"a": [1, 2, 3]}), output);
 }
 
 // Regression test for https://github.com/sunng87/handlebars-rust/issues/766
@@ -373,34 +310,30 @@ fn test_else_if_with_whitespace_omission() {
 
     // Leading tilde on `else if` should strip preceding whitespace, mirroring
     // the behaviour of `{{~else}}`.
-    let leading = "{{#if x}}\nA\n   {{~else if y}}\nB\n{{/if}}";
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{#if x}}\nA\n   {{~else if y}}\nB\n{{/if}}",
+        &json!({"x": false, "y": true}),
         "B\n",
-        hbs.render_template(leading, &json!({"x": false, "y": true}))
-            .unwrap()
     );
 
     // Trailing tilde on `else if` should strip following whitespace.
-    let trailing = "{{#if x}}\nA\n{{else if y ~}}   \nB\n{{/if}}";
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{#if x}}\nA\n{{else if y ~}}   \nB\n{{/if}}",
+        &json!({"x": false, "y": true}),
         "B\n",
-        hbs.render_template(trailing, &json!({"x": false, "y": true}))
-            .unwrap()
     );
 
     // Both tildes.
-    let both = "{{#if x}}\nA\n   {{~else if y~}}   \nB\n{{/if}}";
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{#if x}}\nA\n   {{~else if y~}}   \nB\n{{/if}}",
+        &json!({"x": false, "y": true}),
         "B\n",
-        hbs.render_template(both, &json!({"x": false, "y": true}))
-            .unwrap()
     );
 
     // And the falsy fallback when no chain matches.
-    let fallback = "{{#if x}}\nA\n   {{~else if y}}\nB\n{{else}}\nC\n{{/if}}";
-    assert_eq!(
+    hbs.assert_render_template(
+        "{{#if x}}\nA\n   {{~else if y}}\nB\n{{else}}\nC\n{{/if}}",
+        &json!({"x": false, "y": false}),
         "C\n",
-        hbs.render_template(fallback, &json!({"x": false, "y": false}))
-            .unwrap()
     );
 }


### PR DESCRIPTION
## Why

Most render tests repeated the same `Handlebars::new()` / `register_template_string(..).is_ok()` / `render(..).unwrap()` / `assert_eq!` dance, with `.unwrap()` hiding the cause of failures and `assert_eq!` of two long strings giving no hint of *which template/data* produced the mismatch. This adds a small shared helper and adopts it across the render-assert test suite.

## The helper

A new off-by-default `testing` cargo feature exposes a `#[doc(hidden)] pub mod testing` containing a `TestHandlebars` extension trait over `Registry`:

| method | maps to |
| --- | --- |
| `register(name, template)` | `register_template_string` (panics with context on compile error) |
| `assert_render_template(t, data, expected)` | `render_template` |
| `assert_render(name, data, expected)` | `render` |
| `assert_render_template_ok(t, data)` | assert `render_template` is `Ok` |
| `assert_render_template_err(t, data, msg?)` | assert `render_template` errors (+ optional substring) |
| `assert_render_err(name, data, msg?)` | assert `render` errors |

Method names mirror the underlying `Registry` calls 1:1, so there's no second vocabulary. On failure, assertions print the **template and the data**, so the cause is obvious without a debugger.

The module is compiled for this crate's own tests via a self `dev-dependency` (`handlebars = { path = ".", features = ["testing"] }`), and — behind the off-by-default feature — is also available to **downstream users** testing their own helpers/templates.

## Scope

**Converted:** all 12 `tests/*.rs` integration files, and the unit-test modules in `helpers/{helper_each,helper_if,helper_with,helper_lookup,helper_extras,string_helpers}`, `partial`, plus the clean render-assert tests in `registry` and `render`. `helper_macro` is now table-driven.

**Intentionally left untouched** (a render helper doesn't help and forcing it would hurt): template AST tests, the grammar pest-parser tests, context navigation tests, render-of-element tests, `decorators/inline`, and the detailed error-inspection/mechanics tests in `registry`/`render` (e.g. those asserting on `column_no` / `reason()`).

## Pre-existing issues fixed along the way
- `helper_each::test_nested_each_with_path_ups` was **missing its `#[test]` attribute** (dead code). It now runs and **passes**.
- `partial::teset_partial_context_with_both_hash_and_param` typo → renamed to `test_…`.

## Verification
- `cargo test` and `cargo test --all-features` — all green (lib unit tests went **up** by 1 thanks to the revived dead test, confirming nothing was dropped).
- `cargo clippy --tests [--all-features]` — zero warnings.
- `cargo build --features testing --no-default-features` — the public path compiles for downstream users.

## Notes
- Net **−~750 lines** of test boilerplate (886 insertions, 1390 deletions across 24 files + new `src/testing.rs`).
- This commit is **unsigned** (no GPG key available in the working environment). Please re-sign/amend if the repo requires it.